### PR TITLE
Fix CDP WebSocket 400 for query-only endpoint URLs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,8 @@ use tempfile::{NamedTempFile, TempDir};
 use thiserror::Error;
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
-use tokio_tungstenite::tungstenite::http::{HeaderName, HeaderValue};
+use tokio_tungstenite::tungstenite::http::uri::PathAndQuery;
+use tokio_tungstenite::tungstenite::http::{HeaderName, HeaderValue, Uri};
 use tokio_tungstenite::tungstenite::{Error as WsError, Message};
 use tokio_tungstenite::{connect_async, MaybeTlsStream};
 
@@ -153,6 +154,41 @@ fn map_chromium_permissions(permissions: &Value, fallback: bool) -> RwResult<Val
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+    fn request_target(endpoint: &str) -> String {
+        let mut request = endpoint.into_client_request().unwrap();
+        ensure_ws_request_path(&mut request);
+        request
+            .uri()
+            .path_and_query()
+            .map(|paq| paq.as_str().to_string())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn empty_path_ws_endpoint_gets_origin_form_target() {
+        // Anchor Browser's CDP URL shape: empty path, query-only.
+        assert_eq!(
+            request_target("wss://connect.example.io?apiKey=secret&sessionId=abc"),
+            "/?apiKey=secret&sessionId=abc"
+        );
+        // No query, empty path -> bare "/".
+        assert_eq!(request_target("wss://connect.example.io"), "/");
+    }
+
+    #[test]
+    fn non_empty_path_ws_endpoint_is_unchanged() {
+        assert_eq!(
+            request_target("ws://127.0.0.1:9222/devtools/browser/abc?token=xyz"),
+            "/devtools/browser/abc?token=xyz"
+        );
+        assert_eq!(
+            request_target("ws://127.0.0.1:9222/devtools/browser/abc"),
+            "/devtools/browser/abc"
+        );
+    }
 
     #[test]
     fn chromium_permissions_match_playwright_protocol_names() {
@@ -599,6 +635,35 @@ fn close_pending_cdp_commands(pending: CdpPendingMap) {
     }
 }
 
+/// Ensure the WebSocket handshake request-target is in origin-form (starts with `/`).
+///
+/// tungstenite builds the request line directly from `uri.path_and_query()`. For CDP
+/// endpoints whose URL has an empty path but a query string — e.g. Anchor Browser's
+/// `wss://host?apiKey=...&sessionId=...` — `http::Uri` yields `?apiKey=...` with no
+/// leading slash, producing a malformed request line `GET ?apiKey=... HTTP/1.1`.
+/// Strict front-ends (nginx) reject that with `400 Bad Request`. Playwright's client
+/// always sends origin-form `GET /?...`, so normalize the target to match.
+fn ensure_ws_request_path(
+    request: &mut tokio_tungstenite::tungstenite::handshake::client::Request,
+) {
+    let uri = request.uri().clone();
+    // tungstenite writes `uri.path_and_query()` verbatim as the request target, so
+    // inspect that exact string rather than `uri.path()` (which normalizes "" to "/").
+    let current = uri.path_and_query().map(PathAndQuery::as_str).unwrap_or("");
+    if current.starts_with('/') {
+        return;
+    }
+    let normalized = format!("/{current}");
+    let Ok(path_and_query) = normalized.parse::<PathAndQuery>() else {
+        return;
+    };
+    let mut parts = uri.into_parts();
+    parts.path_and_query = Some(path_and_query);
+    if let Ok(new_uri) = Uri::from_parts(parts) {
+        *request.uri_mut() = new_uri;
+    }
+}
+
 impl CdpClient {
     async fn connect(ws_endpoint: &str) -> RwResult<Arc<Self>> {
         Self::connect_with_headers(ws_endpoint, &[]).await
@@ -609,6 +674,7 @@ impl CdpClient {
         headers: &[(String, String)],
     ) -> RwResult<Arc<Self>> {
         let mut request = ws_endpoint.into_client_request()?;
+        ensure_ws_request_path(&mut request);
         for (name, value) in headers {
             let header_name = HeaderName::from_bytes(name.as_bytes()).map_err(|error| {
                 RwError::Message(format!("invalid CDP header name {name:?}: {error}"))


### PR DESCRIPTION
## Summary

`connect_over_cdp` failed with `400 Bad Request` against remote CDP providers (e.g. Anchor Browser) whose endpoint URL has an **empty path but a non-empty query** — shaped `wss://host?apiKey=...&sessionId=...`.

Root cause is a rustwright-level bug composed from upstream behavior:
- `http`'s `PathAndQuery::as_str()` returns the stored data verbatim (`?apiKey=...`, no leading `/`) for query-only URLs.
- `tungstenite` writes that string directly into the handshake request line, producing `GET ?apiKey=... HTTP/1.1`.

That request-target is not origin-form (RFC 9112 §3.2.1 requires a leading `/`), so strict front-ends like nginx reject it at the parser with a stock 400 — before routing or auth. Playwright's client sends origin-form `GET /?... HTTP/1.1` and passes.

Fix: new helper `ensure_ws_request_path`, called once in `connect_with_headers` (the single choke point all CDP connects funnel through). It rebuilds the URI's `PathAndQuery` to origin-form when needed:
- query-only → `/?...`
- bare host → `/`
- normal `/path?q` → unchanged (no-op)

Scope is deliberately minimal: only the malformed request-target is corrected; no other header mimicry was added.

## Test Plan

- `cargo test --lib` → 12 passed, 0 failed (includes 2 new regression tests):
  - `empty_path_ws_endpoint_gets_origin_form_target` — query-only and bare-host URLs normalize to `/?...` and `/`.
  - `non_empty_path_ws_endpoint_is_unchanged` — normal `/devtools/...?token=...` targets pass through untouched.
- Verified end-to-end against a real remote CDP provider: `connect_over_cdp` and a subsequent `goto` both succeed post-patch (were `400 Bad Request` before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)