### PR TITLE
Add Claude auto code-review workflow

### DIFF
--- a/.github/prompts/code-review.md
+++ b/.github/prompts/code-review.md
@@ -1,0 +1,56 @@
+Please review this pull request for the **Rustwright** repository and give concise, actionable feedback.
+
+Rustwright is a Rust engine (PyO3 for Python, napi-rs for Node) that speaks raw Chrome DevTools Protocol and exposes a **Playwright-compatible** API. It is alpha, Chromium-only, MIT-licensed. The Rust core lives in `src/lib.rs`; the Python API in `python/rustwright/`; the Node bindings in `node/`.
+
+Review for:
+
+- **Correctness & bugs** — logic errors, unhandled edge cases, error handling. Pay special attention to:
+  - the FFI boundaries — PyO3 `Bound<'py, T>` usage and GIL handling (`py.detach` around blocking work), and napi async/threadsafe-function usage;
+  - the CDP layer — session/frame routing (OOPIF), the tokio-tungstenite WebSocket transport, and message dispatch/correlation.
+- **Memory & concurrency safety** — any new `unsafe`; `unwrap()`/`expect()`/`panic!` on fallible paths that could crash a user's process across the FFI boundary; races or deadlocks in the async CDP client; holding the GIL across I/O.
+- **Security** (this is browser-automation software) — untrusted-input handling, JS/CDP injection, and anything that silently changes the **trusted-input-by-default** behavior. Rustwright must **not overclaim on anti-detection**: flag any change that adds "undetectable" / "bypass Cloudflare" / "stealth" style claims, or that weakens the honest signal-hygiene framing (it currently passes 3/4 public fingerprint targets and says so plainly).
+- **API compatibility** — the Python/Node surface mirrors Playwright. Flag divergence from Playwright's shape/behavior that isn't justified, and missing parity coverage.
+- **Performance** — avoidable allocations/copies on the per-CDP-message hot path; blocking calls inside async paths.
+- **Tests** — is the change covered by the pytest suite (`tests/`)? Does it warrant a parity test against real Playwright?
+- **Honesty of claims** — if the PR touches README/docs/benchmarks, verify the claims match what the code and tests actually support (no inflated numbers, no unverified platform/behavior claims, MSRV kept accurate).
+
+Use `CONTRIBUTING.md` (and `CLAUDE.md` if present) for conventions. Be constructive.
+
+Keep the review **concise and scannable**:
+- Start with a 1–2 sentence overall assessment.
+- Group feedback by severity using GitHub `<details>`/`<summary>` collapsible sections.
+- Expand 🔴 Critical by default; keep 🟡 Suggestions and 📝 Minor collapsed.
+- If there are no issues, post a brief LGTM (with the marker).
+
+Format:
+
+```
+<!-- claude-code-review -->
+## Summary
+Brief overall assessment.
+
+<details open>
+<summary>🔴 Critical Issues (X)</summary>
+
+- ...
+
+</details>
+
+<details>
+<summary>🟡 Suggestions (X)</summary>
+
+- ...
+
+</details>
+
+<details>
+<summary>📝 Minor / Style (X)</summary>
+
+- ...
+
+</details>
+```
+
+IMPORTANT: Start your comment with the exact marker `<!-- claude-code-review -->` on the first line — this lets a later commit replace the previous review instead of stacking comments.
+
+Use `gh pr comment` (via your Bash tool) to post the review as a single comment on the PR.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,70 @@
+name: Claude Code Review
+
+# Automated PR review by Claude, on every opened/updated pull request.
+# Requires a repository secret CLAUDE_CODE_OAUTH_TOKEN (create with `claude setup-token`).
+# The review prompt is loaded from the BASE branch so untrusted PRs cannot alter
+# review behavior by editing the prompt file in the same PR.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    # Skip PRs opened by Claude itself or by GitHub Actions to avoid review loops.
+    if: |
+      !contains(fromJSON('["claude","claude[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 1
+
+      - name: Delete previous Claude review comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Remove any prior review comment (identified by the marker) so each
+          # push replaces the review instead of stacking comments.
+          gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq '.[] | select(.body | contains("<!-- claude-code-review -->")) | .id' \
+          | while read -r id; do
+              if [ -n "$id" ]; then
+                echo "Deleting previous Claude review comment: $id"
+                gh api "repos/${{ github.repository }}/issues/comments/$id" -X DELETE
+              fi
+            done
+
+      - name: Load review prompt from base branch
+        id: prompt
+        run: |
+          # Load the prompt from the PR's BASE commit (trusted), not the PR head.
+          git fetch --no-tags --depth=1 origin "${{ github.event.pull_request.base.sha }}"
+          BASE="${{ github.event.pull_request.base.sha }}"
+          DELIM="PROMPT_EOF_$(openssl rand -hex 16)"
+          {
+            printf 'content<<%s\n' "$DELIM"
+            git show "${BASE}:.github/prompts/code-review.md"
+            printf '%s\n' "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@ff9acae5886d41a99ed4ec14b7dc147d55834722 # v1.0.77
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "dependabot[bot],github-actions[bot],renovate[bot]"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            ${{ steps.prompt.outputs.content }}
+          # Read-only review: Claude may inspect the repo and the PR, and post one comment.
+          claude_args: >-
+            --max-turns 30
+            --allowed-tools "Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*)"


### PR DESCRIPTION
Adds an automated Claude PR reviewer (`anthropics/claude-code-action`), modeled on Skyvern Cloud's setup but self-contained (ubuntu-latest, no internal deps). Runs on every opened/updated PR, posts one collapsible review comment (replaced each push), and loads its prompt from the base branch so PRs can't alter review behavior.

**Requires** a `CLAUDE_CODE_OAUTH_TOKEN` repo secret to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)