### PR TITLE
Fix CI: create a virtualenv before maturin develop

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,11 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Python build and test dependencies
-        run: python -m pip install -U pip maturin pytest pytest-benchmark
+        run: |
+          python -m venv .venv
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+          echo "VIRTUAL_ENV=$PWD/.venv" >> "$GITHUB_ENV"
+          .venv/bin/python -m pip install -U pip maturin pytest pytest-benchmark
 
       - name: Cargo check
         run: cargo check --locked


### PR DESCRIPTION
CI has failed on every commit: `test.yml` ran `maturin develop --release` with no virtualenv. Creates a `.venv`, exports it via GITHUB_PATH/VIRTUAL_ENV, installs deps into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)