### PR TITLE
Scope evaluate() string scripts via indirect eval to prevent redeclaration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -372,6 +372,51 @@ mod tests {
             json!({ "angle": 0, "type": "landscapePrimary" })
         );
     }
+
+    #[test]
+    fn plain_string_script_is_wrapped_in_indirect_eval() {
+        // A plain statement script (not a function, no arg) must not be handed
+        // to Runtime.evaluate verbatim: top-level `let`/`const` would leak into
+        // the global lexical environment and break repeated evaluation. It is
+        // instead wrapped in an indirect `eval` that scopes those declarations
+        // to the call while preserving the script's completion value.
+        let script = "let browserNameForWorkarounds = 'chromium';\nhelper();";
+        let wrapped = make_evaluate_expression(script, None);
+        assert_eq!(
+            wrapped,
+            r#"(0, eval)("let browserNameForWorkarounds = 'chromium';\nhelper();")"#
+        );
+    }
+
+    #[test]
+    fn plain_expression_is_wrapped_in_indirect_eval() {
+        assert_eq!(
+            make_evaluate_expression("1 + 2", None),
+            r#"(0, eval)("1 + 2")"#
+        );
+        assert_eq!(
+            make_evaluate_expression("document.title", None),
+            r#"(0, eval)("document.title")"#
+        );
+    }
+
+    #[test]
+    fn indirect_eval_wrapper_escapes_embedded_quotes_and_newlines() {
+        // The source is embedded as a JS string literal, so any quotes,
+        // backslashes, or newlines in the script must be escaped safely.
+        let script = "const s = \"a\\tb\";\ns;";
+        let wrapped = make_evaluate_expression(script, None);
+        assert_eq!(wrapped, r#"(0, eval)("const s = \"a\\tb\";\ns;")"#);
+    }
+
+    #[test]
+    fn function_and_arg_scripts_are_not_double_wrapped_in_eval() {
+        // Functions and arg-bearing calls keep their IIFE wrapping, which
+        // already scopes their internals; they should not be routed through
+        // the indirect-eval branch.
+        assert!(!make_evaluate_expression("() => 1", None).contains("(0, eval)"));
+        assert!(!make_evaluate_expression("(x) => x + 1", Some("2")).contains("(0, eval)"));
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -10453,7 +10498,18 @@ fn make_evaluate_expression(expression: &str, arg_json: Option<&str>) -> String 
     } else if looks_like_function(trimmed) {
         format!("(async () => {{ const __rw_fn = ({trimmed}); return await __rw_fn(); }})()")
     } else {
-        trimmed.to_string()
+        // Plain expression/statement string. Run it through an indirect `eval`
+        // so that top-level `let`/`const`/`class` declarations are scoped to
+        // this single evaluation instead of leaking into the global lexical
+        // environment. Passing the raw source to `Runtime.evaluate` executes it
+        // at the REPL-style global top level, where those declarations persist
+        // across calls and make repeated evaluation of the same script fail
+        // with "Identifier '...' has already been declared". Playwright avoids
+        // this by running non-function expressions via indirect `eval` in its
+        // utility script; this mirrors that, including preserving the script's
+        // completion value and the standard `var`/`function` global hoisting.
+        let literal = serde_json::to_string(trimmed).unwrap_or_else(|_| "\"\"".to_string());
+        format!("(0, eval)({literal})")
     }
 }
 

--- a/tests/test_rustwright_sync_api.py
+++ b/tests/test_rustwright_sync_api.py
@@ -1632,6 +1632,31 @@ def test_launch_goto_title_and_url(browser):
     page.close()
 
 
+def test_repeated_evaluate_of_top_level_let_const_does_not_redeclare(page):
+    # Skyvern (and Playwright) re-evaluate the same string script — e.g.
+    # domUtils.js — many times on a page. Such scripts declare top-level
+    # `let`/`const` identifiers. Matching Playwright, repeated evaluation must
+    # not leak those declarations into the global lexical environment, which
+    # would otherwise raise "Identifier '...' has already been declared".
+    page.goto(data_url("<title>redeclare</title>"))
+    script = (
+        "let browserNameForWorkarounds = 'chromium';\n"
+        "const marker = 7;\n"
+        "class Helper { value() { return browserNameForWorkarounds.length + marker; } }\n"
+        "new Helper().value();"
+    )
+    for _ in range(3):
+        assert page.evaluate(script) == len("chromium") + 7
+
+
+def test_evaluate_plain_expression_still_returns_completion_value(page):
+    # The indirect-eval wrapping must preserve the completion value of a plain
+    # expression string.
+    page.goto(data_url("<title>expr</title>"))
+    assert page.evaluate("1 + 2") == 3
+    assert page.evaluate("document.title") == "expr"
+
+
 def test_chromium_connect_uses_direct_cdp_endpoint(playwright):
     launched = playwright.chromium.launch(headless=True)
     connected = None


### PR DESCRIPTION
## Problem

`page.evaluate()` / `frame.evaluate()` with a **plain string script** (not a function, no argument) passed the raw source straight to `Runtime.evaluate`, which runs at the REPL-style global top level. Top-level `let` / `const` / `class` declarations there persist across calls, so re-evaluating the same script many times (a common pattern for injected DOM-utility scripts) fails with:

```
SyntaxError: Identifier '...' has already been declared
```

## Fix

Wrap plain expression/statement strings in an indirect `eval` (`(0, eval)(<source>)`) so those lexical declarations are scoped to the single evaluation, matching how Playwright runs non-function scripts in its utility script. This preserves:

- the script's **completion value**, and
- the standard `var` / `function` global hoisting.

Functions and argument-bearing calls keep their existing IIFE wrapping and are unaffected.

## Tests

- **Rust unit tests** for the wrapper output: plain statement, plain expression, quote/newline escaping, and that function/arg scripts are not routed through the eval branch.
- **Python integration tests**: repeated `evaluate()` of a top-level `let`/`const`/`class` script no longer redeclares, and a plain-expression completion value is still returned.

Verification:

```
cargo test --locked          # 16 passed
pytest tests/test_rustwright_sync_api.py -k "evaluate"   # evaluate subset passed
```
