### PR TITLE
Add two-way Rustwright repository sync

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,0 +1,53 @@
+# Shared Rustwright files mirrored from rustwright to rustwright-cloud.
+# Repository-specific GitHub workflows and metadata are intentionally excluded.
+# Cloud-only additions must live outside the mirrored paths below.
+Skyvern-AI/rustwright-cloud:
+  - source: benchmarks/
+    dest: benchmarks/
+    deleteOrphaned: true
+  - source: docs/
+    dest: docs/
+    deleteOrphaned: true
+  - source: node/
+    dest: node/
+    deleteOrphaned: true
+  - source: python/
+    dest: python/
+    deleteOrphaned: true
+  - source: src/
+    dest: src/
+    deleteOrphaned: true
+  - source: tests/
+    dest: tests/
+    deleteOrphaned: true
+  - source: tools/
+    dest: tools/
+    deleteOrphaned: true
+  - source: .dockerignore
+    dest: .dockerignore
+  - source: .gitignore
+    dest: .gitignore
+  - source: BENCHMARK.md
+    dest: BENCHMARK.md
+  - source: CODE_ARCHITECTURE.md
+    dest: CODE_ARCHITECTURE.md
+  - source: CODE_OF_CONDUCT.md
+    dest: CODE_OF_CONDUCT.md
+  - source: CONTRIBUTING.md
+    dest: CONTRIBUTING.md
+  - source: Cargo.lock
+    dest: Cargo.lock
+  - source: Cargo.toml
+    dest: Cargo.toml
+  - source: Dockerfile
+    dest: Dockerfile
+  - source: LICENSE
+    dest: LICENSE
+  - source: LIMITATIONS.md
+    dest: LIMITATIONS.md
+  - source: README.md
+    dest: README.md
+  - source: SECURITY.md
+    dest: SECURITY.md
+  - source: pyproject.toml
+    dest: pyproject.toml

--- a/.github/workflows/auto-merge-sync.yml
+++ b/.github/workflows/auto-merge-sync.yml
@@ -1,0 +1,48 @@
+name: Auto-merge sync PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, labeled, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+
+jobs:
+  merge-when-sync:
+    # Auto-merge only machine-generated mirror PRs:
+    #   - carry the 'sync' label applied by repo-file-sync-action
+    #   - branch created by the sync action (repo-sync/*)
+    #   - opened by the configured sync actor
+    if: >-
+      contains(join(github.event.pull_request.labels.*.name, ','), 'sync') &&
+      startsWith(github.event.pull_request.head.ref, 'repo-sync/') &&
+      github.event.pull_request.user.login == vars.RUSTWRIGHT_SYNC_ACTOR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for required checks to pass
+        uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 15
+          allowed-conclusions: success,skipped,neutral
+          ignore-checks: merge-when-sync,claude-review
+      - name: Verify PR is still open
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          STATE=$(gh pr view ${{ github.event.pull_request.number }} --repo "${{ github.repository }}" --json state --jq '.state')
+          if [ "$STATE" != "OPEN" ]; then
+            echo "::error::PR is $STATE — aborting merge"
+            exit 1
+          fi
+      - name: Merge sync PR with admin bypass
+        env:
+          GH_TOKEN: ${{ secrets.RUSTWRIGHT_SYNC_GH_PAT }}
+        run: |-
+          gh pr merge ${{ github.event.pull_request.number }} \
+            --squash \
+            --admin \
+            --repo "${{ github.repository }}"

--- a/.github/workflows/sync-rustwright-cloud.yml
+++ b/.github/workflows/sync-rustwright-cloud.yml
@@ -1,0 +1,62 @@
+name: Sync rustwright changes to rustwright-cloud
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  sync:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.merged == true &&
+      !contains(join(github.event.pull_request.labels.*.name, ','), 'sync') &&
+      !startsWith(github.event.pull_request.head.ref, 'repo-sync/'))
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Sync shared files to rustwright-cloud
+        id: file-sync
+        uses: Skyvern-AI/repo-file-sync-action@590c4ddbe1d7b5c4ca1e4b4edc85c7f919b6c26a # main
+        with:
+          GH_PAT: ${{ secrets.RUSTWRIGHT_SYNC_GH_PAT }}
+          GIT_EMAIL: ${{ github.event.pull_request.user.id && format('{0}+{1}@users.noreply.github.com', github.event.pull_request.user.id, github.event.pull_request.user.login) || format('{0}@users.noreply.github.com', github.actor) }}
+          GIT_USERNAME: ${{ github.event.pull_request.user.login || github.actor }}
+          PR_LABELS: sync
+          BRANCH_NAME: repo-sync/rustwright-${{ github.event.pull_request.number || github.run_id }}
+          PR_BODY: ${{ github.event.pull_request.html_url || 'Manual sync from rustwright' }}
+          PR_TITLE: "Sync rustwright changes to rustwright-cloud (#${{ github.event.pull_request.number || github.run_id }})"
+
+      - name: Link the rustwright-cloud PR
+        if: github.event_name == 'pull_request_target' && steps.file-sync.outputs.pull_request_urls
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          PR_URLS: ${{ steps.file-sync.outputs.pull_request_urls }}
+        with:
+          script: |
+            let urls;
+            try {
+              urls = JSON.parse(process.env.PR_URLS);
+            } catch {
+              urls = [process.env.PR_URLS].filter(Boolean);
+            }
+            if (urls.length) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: urls.map((url) => `Synced to rustwright-cloud: ${url}`).join('\n'),
+              });
+            }


### PR DESCRIPTION
## What

- Add the rustwright-to-rustwright-cloud sync manifest and merge-triggered workflow.
- Add guarded auto-merge for sync-labeled repo-sync branches.
- Include a manual workflow dispatch fallback.

## Why

Mirror merged Rustwright contributions back to rustwright-cloud while preventing sync loops.

## Testing

- [x] actionlint passes for both new workflows.
- [x] YAML parsing passes for the workflow and sync manifest.

## Checklist

- [x] I kept this change focused.
- [x] Tests are not required for workflow-only behavior.
- [x] I did not include private credentials, tokens, or internal-only artifacts.

## Risk and rollback

A token or ruleset mismatch could block automatic sync PR creation or merging. Roll back by reverting this PR; the repositories remain usable independently.