### PR TITLE
Add PyPI and npm release workflows

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,281 @@
+name: Release Node.js package
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build and upload artifacts without publishing"
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-npm-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  metadata:
+    name: validate package versions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Validate release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+          import tomllib
+
+          root = pathlib.Path(".")
+          cargo_lock = tomllib.loads((root / "Cargo.lock").read_text())
+          cargo_versions = {
+              package["name"]: package["version"]
+              for package in cargo_lock["package"]
+              if package["name"] in {"rustwright-core", "rustwright-node"}
+          }
+          node_lock = json.loads((root / "node/package-lock.json").read_text())
+          versions = {
+              "pyproject.toml": tomllib.loads((root / "pyproject.toml").read_text())["project"]["version"],
+              "Cargo.toml": tomllib.loads((root / "Cargo.toml").read_text())["package"]["version"],
+              "node/Cargo.toml": tomllib.loads((root / "node/Cargo.toml").read_text())["package"]["version"],
+              "node/package.json": json.loads((root / "node/package.json").read_text())["version"],
+              "Cargo.lock rustwright-core": cargo_versions["rustwright-core"],
+              "Cargo.lock rustwright-node": cargo_versions["rustwright-node"],
+              "node/package-lock.json": node_lock["version"],
+              'node/package-lock.json packages[""]': node_lock["packages"][""]["version"],
+          }
+
+          expected = next(iter(versions.values()))
+          if any(version != expected for version in versions.values()):
+              raise SystemExit(f"Package versions do not match: {versions}")
+
+          if os.environ["GITHUB_REF_TYPE"] == "tag":
+              tag_version = os.environ["GITHUB_REF_NAME"].removeprefix("v")
+              if tag_version != expected:
+                  raise SystemExit(
+                      f"Tag version {tag_version!r} does not match package version {expected!r}"
+                  )
+          print(f"Validated package version {expected}")
+          PY
+
+  native:
+    name: native addon - ${{ matrix.platform.target }}
+    needs: metadata
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - runner: macos-latest
+            target: aarch64-apple-darwin
+            zig: false
+            extra_args: ""
+          - runner: macos-latest
+            target: x86_64-apple-darwin
+            zig: false
+            extra_args: ""
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            zig: true
+            extra_args: --zig --zig-abi-suffix 2.17
+          - runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            zig: true
+            extra_args: --zig --zig-abi-suffix 2.17
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            zig: false
+            extra_args: ""
+
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "10.13"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: node/package-lock.json
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.platform.target }}
+
+      - name: Set up Zig
+        if: ${{ matrix.platform.zig }}
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.14.1
+
+      - name: Install cargo-zigbuild
+        if: ${{ matrix.platform.zig }}
+        uses: taiki-e/install-action@2ca9b94c269419b7b0c711c09d0b21c4e1d51145 # v2.83.1
+        with:
+          tool: cargo-zigbuild
+
+      - name: Install Node.js build dependencies
+        working-directory: node
+        run: npm ci --ignore-scripts
+
+      - name: Build native addon
+        working-directory: node
+        shell: bash
+        run: >-
+          npm exec -- napi build
+          --platform
+          --release
+          -p rustwright-node
+          --dts native.d.ts
+          --js false
+          --target ${{ matrix.platform.target }}
+          ${{ matrix.platform.extra_args }}
+
+      - name: Upload native addon
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-native-${{ matrix.platform.target }}
+          path: node/*.node
+          if-no-files-found: error
+
+  package:
+    name: assemble npm package
+    needs: native
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: node/package-lock.json
+
+      - name: Install Node.js build dependencies
+        working-directory: node
+        run: npm ci --ignore-scripts
+
+      - name: Download native addons
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: npm-native-*
+          path: node/prebuilds
+          merge-multiple: true
+
+      - name: Assemble publishable package
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -d '' addons < <(find node/prebuilds -type f -name '*.node' -print0)
+          if [ "${#addons[@]}" -ne 5 ]; then
+            echo "Expected 5 native addons, found ${#addons[@]}" >&2
+            exit 1
+          fi
+          cp "${addons[@]}" node/
+          rm -rf node/prebuilds
+          node - <<'JS'
+          const fs = require('node:fs');
+          const path = 'node/package.json';
+          const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+          delete pkg.private;
+          fs.writeFileSync(path, `${JSON.stringify(pkg, null, 2)}\n`);
+          JS
+          (cd node && node scripts/generate-types.mjs)
+          mkdir -p npm-dist
+          (cd node && npm pack --pack-destination "$GITHUB_WORKSPACE/npm-dist")
+
+      - name: Smoke-test packed addon
+        shell: bash
+        run: |
+          set -euo pipefail
+          tarball="$(find npm-dist -type f -name '*.tgz' -print -quit)"
+          test -n "$tarball"
+          test_project="$(mktemp -d)"
+          cd "$test_project"
+          npm init --yes >/dev/null
+          npm install --ignore-scripts "$GITHUB_WORKSPACE/$tarball"
+          node -e "require('rustwright')"
+
+      - name: Upload npm package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-package
+          path: npm-dist/*.tgz
+          if-no-files-found: error
+
+  publish:
+    name: publish to npm
+    needs: package
+    if: >-
+      ${{
+        github.repository == 'Skyvern-AI/rustwright' &&
+        github.ref_type == 'tag' &&
+        (
+          github.event_name == 'push' ||
+          (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+        )
+      }}
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/rustwright
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Download npm package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-package
+          path: npm-dist
+
+      - name: Require a prerelease version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          case "$version" in
+            *-*) ;;
+            *)
+              echo "The experimental npm package requires a prerelease version such as 0.2.0-alpha.1" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Publish experimental package with provenance
+        run: npm publish npm-dist/*.tgz --provenance --access public --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -1,0 +1,193 @@
+name: Release Python package
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build and upload artifacts without publishing"
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-pypi-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  metadata:
+    name: validate package versions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Validate release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import pathlib
+          import tomllib
+
+          root = pathlib.Path(".")
+          cargo_lock = tomllib.loads((root / "Cargo.lock").read_text())
+          cargo_versions = {
+              package["name"]: package["version"]
+              for package in cargo_lock["package"]
+              if package["name"] in {"rustwright-core", "rustwright-node"}
+          }
+          node_lock = json.loads((root / "node/package-lock.json").read_text())
+          versions = {
+              "pyproject.toml": tomllib.loads((root / "pyproject.toml").read_text())["project"]["version"],
+              "Cargo.toml": tomllib.loads((root / "Cargo.toml").read_text())["package"]["version"],
+              "node/Cargo.toml": tomllib.loads((root / "node/Cargo.toml").read_text())["package"]["version"],
+              "node/package.json": json.loads((root / "node/package.json").read_text())["version"],
+              "Cargo.lock rustwright-core": cargo_versions["rustwright-core"],
+              "Cargo.lock rustwright-node": cargo_versions["rustwright-node"],
+              "node/package-lock.json": node_lock["version"],
+              'node/package-lock.json packages[""]': node_lock["packages"][""]["version"],
+          }
+
+          expected = next(iter(versions.values()))
+          if any(version != expected for version in versions.values()):
+              raise SystemExit(f"Package versions do not match: {versions}")
+
+          # Match the npm workflow, which rejects stable versions: a single tag
+          # must publish to both registries or neither. This alpha project ships
+          # prereleases only (e.g. 0.2.0-alpha.1), so reject a stable version here
+          # too rather than let PyPI publish something npm would refuse.
+          if "-" not in expected:
+              raise SystemExit(
+                  f"Refusing to publish stable version {expected!r}: this project "
+                  f"publishes prereleases only (e.g. 0.2.0-alpha.1), matching release-npm.yml."
+              )
+
+          if os.environ["GITHUB_REF_TYPE"] == "tag":
+              tag_version = os.environ["GITHUB_REF_NAME"].removeprefix("v")
+              if tag_version != expected:
+                  raise SystemExit(
+                      f"Tag version {tag_version!r} does not match package version {expected!r}"
+                  )
+          print(f"Validated package version {expected}")
+          PY
+
+  wheels:
+    name: wheel - ${{ matrix.platform.target }}
+    needs: metadata
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - runner: macos-latest
+            target: aarch64-apple-darwin
+            manylinux: auto
+          - runner: macos-latest
+            target: x86_64-apple-darwin
+            manylinux: auto
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            manylinux: "2_17"
+          - runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            manylinux: "2_17"
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
+            manylinux: auto
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Build abi3 wheel
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          command: build
+          maturin-version: v1.11.5
+          target: ${{ matrix.platform.target }}
+          manylinux: ${{ matrix.platform.manylinux }}
+          rust-toolchain: stable
+          args: --release --locked --compatibility pypi --out dist
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pypi-wheel-${{ matrix.platform.target }}
+          path: dist/*.whl
+          if-no-files-found: error
+
+  sdist:
+    name: source distribution
+    needs: metadata
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Build source distribution
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          command: sdist
+          maturin-version: v1.11.5
+          rust-toolchain: stable
+          args: --out dist
+
+      - name: Upload source distribution
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pypi-sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: publish to PyPI
+    needs:
+      - wheels
+      - sdist
+    if: >-
+      ${{
+        github.repository == 'Skyvern-AI/rustwright' &&
+        github.ref_type == 'tag' &&
+        (
+          github.event_name == 'push' ||
+          (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+        )
+      }}
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/rustwright/
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: pypi-*
+          path: dist
+          merge-multiple: true
+
+      - name: Publish with PyPI Trusted Publishing
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,93 @@
+# Releasing Rustwright
+
+This guide is for the release owner.
+
+## One-time setup
+
+- [ ] Confirm the `rustwright` name is still available on both PyPI and npm. A name is not reserved until the first successful publish.
+- [ ] In GitHub, open **Settings → Environments → New environment**, create `pypi`, and add a required reviewer.
+- [ ] In PyPI, open **Account settings → Publishing → Add a new pending publisher** and enter exactly:
+  - PyPI project name: `rustwright`
+  - Owner: `Skyvern-AI`
+  - Repository: `rustwright`
+  - Workflow: `release-pypi.yml`
+  - Environment: `pypi`
+- [ ] Do not create a PyPI API token. `.github/workflows/release-pypi.yml` uses the `pypi` GitHub environment and OIDC Trusted Publishing.
+- [ ] In GitHub, create an `npm` environment, add a required reviewer, and add an environment secret named `NPM_TOKEN`.
+- [ ] Supply `NPM_TOKEN`: create an npm granular access token with **Packages and scopes: Read and write**, **All Packages** for the first unscoped publish, and **Bypass 2FA** for non-interactive publishing. Set an expiration and calendar a rotation. After the first release, replace it with a token restricted to `rustwright` if npm permits that scope.
+- [ ] Confirm the npm account behind `NPM_TOKEN` may create the unscoped public package `rustwright`. Unscoped packages are owned by npm user accounts, not organizations.
+- [ ] `examples/quickstart.py` is the public smoke test used by the registry-verification step below; confirm it still runs cleanly before tagging.
+
+No crates.io settings or token are currently required. Do not publish `rustwright-core` yet: it is tightly coupled to PyO3, has only a small Rust-facing API, and would commit the team to Rust API compatibility, documentation, security advisories, and an additional release channel. Reconsider after the core is cleanly separated and there are committed Rust users; then add a dedicated crates.io workflow and a narrowly scoped `CARGO_REGISTRY_TOKEN`.
+
+## Prepare a release
+
+- [ ] Choose one version in prerelease SemVer form, for example `0.2.0-alpha.1`. The npm workflow deliberately publishes under the `next` dist-tag and rejects a stable version.
+- [ ] Set that exact string in these source-of-truth fields:
+  - `pyproject.toml` → `[project].version`
+  - `Cargo.toml` → `[package].version` for `rustwright-core`
+  - `node/Cargo.toml` → `[package].version` for `rustwright-node`
+  - `node/package.json` → `version`
+- [ ] Regenerate the lockfiles; do not edit generated entries by hand:
+
+  ```bash
+  cargo check
+  (cd node && npm install --package-lock-only --ignore-scripts)
+  ```
+
+- [ ] Confirm `Cargo.lock` now has the same version for `rustwright-core` and `rustwright-node`, and `node/package-lock.json` has it in both top-level version fields.
+- [ ] Confirm all six files are staged: `pyproject.toml`, `Cargo.toml`, `node/Cargo.toml`, `node/package.json`, `Cargo.lock`, and `node/package-lock.json`.
+- [ ] Run local release checks:
+
+  ```bash
+  cargo check --locked
+  cargo test --locked
+  (cd node && npm ci --ignore-scripts && npm run build && npm run smoke)
+  ```
+
+The four source manifests and both lockfiles are all `0.1.0` today; there is no current version mismatch. The source `node/package.json` intentionally remains `"private": true`; the npm workflow removes that field only in its temporary assembled package.
+
+## Dry run
+
+- [ ] Merge the version bump and release setup before tagging.
+- [ ] In **Actions → Release Python package → Run workflow**, select the release commit, leave `dry_run` checked, and run it.
+- [ ] In **Actions → Release Node.js package → Run workflow**, select the same commit, leave `dry_run` checked, and run it.
+- [ ] Download and inspect `pypi-wheel-*`, `pypi-sdist`, and `npm-package`. A dispatch with `dry_run: true` never reaches either publish job.
+
+## Publish
+
+- [ ] From an up-to-date, clean checkout of the release commit, use the same version as every manifest:
+
+  ```bash
+  VERSION=0.2.0-alpha.1
+  git tag -a "v${VERSION}" -m "Rustwright ${VERSION}"
+  git push origin "v${VERSION}"
+  ```
+
+- [ ] Approve the `pypi` and `npm` GitHub environment deployments. The tag starts both workflows; publishing is also guarded to `Skyvern-AI/rustwright`.
+- [ ] If a publish job alone must be retried, dispatch that workflow from the existing tag and clear `dry_run`. A branch dispatch cannot publish.
+- [ ] Never move or reuse a published version tag. Fix forward with a new prerelease version.
+
+## Verify the registries
+
+- [ ] In a clean Python environment, install the exact release and Chromium, then run the quickstart:
+
+  ```bash
+  VERSION=0.2.0-alpha.1
+  python -m venv /tmp/rustwright-pypi-verify
+  /tmp/rustwright-pypi-verify/bin/python -m pip install --upgrade pip
+  /tmp/rustwright-pypi-verify/bin/python -m pip install --pre "rustwright==${VERSION}"
+  /tmp/rustwright-pypi-verify/bin/python -m rustwright install chromium
+  /tmp/rustwright-pypi-verify/bin/python examples/quickstart.py
+  ```
+
+- [ ] In a clean Node.js project, install from the experimental dist-tag and load the addon:
+
+  ```bash
+  test_dir="$(mktemp -d)"
+  (cd "$test_dir" && npm init --yes && npm install rustwright@next && node -e "require('rustwright')")
+  ```
+
+- [ ] Confirm PyPI shows five `cp38-abi3` wheels plus the sdist: macOS arm64/x86_64, manylinux x86_64/aarch64, and Windows x86_64.
+- [ ] Confirm npm shows version `${VERSION}` under the `next` dist-tag and displays provenance.
+- [ ] Record both registry URLs and workflow run URLs on the release tracking issue.

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,0 +1,13 @@
+"""Minimal, network-independent Rustwright smoke example."""
+
+from rustwright.sync_api import sync_playwright
+
+
+with sync_playwright() as playwright:
+    browser = playwright.chromium.launch(headless=True)
+    try:
+        page = browser.new_page()
+        page.goto("data:text/html,%3Ctitle%3ERustwright%20works%3C/title%3E")
+        print(page.title())
+    finally:
+        browser.close()


### PR DESCRIPTION
## What

Turnkey release automation so publishing to PyPI and npm is a tag-and-approve flow, plus the missing `examples/quickstart.py` that the README and release-verify step depend on.

- **`.github/workflows/release-pypi.yml`** — builds `cp38-abi3` wheels (PyO3 already sets `abi3-py38`) across macOS arm64/x86_64, manylinux x86_64/aarch64, and Windows, plus an sdist; publishes on a `v*` tag via **PyPI Trusted Publishing (OIDC — no API token)**. A `dry_run` dispatch builds artifacts without publishing. A metadata job fails the release if any of the 8 version fields across manifests/lockfiles disagree.
- **`.github/workflows/release-npm.yml`** — builds the napi-rs prebuilds for the same platforms and publishes under the `next` dist-tag with provenance and `NPM_TOKEN`.
- **`docs/RELEASING.md`** — maintainer handoff: one-time registry/secret setup, version-bump file list, dry-run, tag, and clean-env verification.
- **`examples/quickstart.py`** — was untracked and absent from `main`; the README quickstart tells users to run it, so cloning + following the quickstart currently fails. Now committed.

## Validation

`actionlint` clean on both workflows. The generator agent also ran cargo check/test (13 tests), npm build + smoke, npm tarball install/load, and a maturin wheel + sdist build confirming `cp38-abi3`. Version-consistency gate verified: all 8 locations currently agree at `0.1.0`. crates.io is intentionally deferred (rationale in RELEASING.md). Publish jobs are tag-gated and repository-guarded, so merging this does not publish anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
