### PR TITLE
chore(release): bump version to 0.1.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustwright-core"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "rustwright-node"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-core"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Rust CDP core for a Python Playwright-compatible automation API"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-node"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 publish = false
 

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rustwright",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rustwright",
-      "version": "0.1.0",
+      "version": "0.1.0-alpha.1",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustwright",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha.1",
   "private": true,
   "description": "Node.js bindings for Rustwright's Rust CDP core",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustwright"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 description = "A Rust-backed, CDP-first Python automation library with a Playwright-compatible sync API"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## What

Bump the version to 0.1.0-alpha.1 (first prerelease) across all six version-bearing files, ahead of the initial PyPI/npm publish tracked in SKY-12273.

- pyproject.toml -> 0.1.0-alpha.1
- Cargo.toml (rustwright-core) -> 0.1.0-alpha.1
- node/Cargo.toml (rustwright-node) -> 0.1.0-alpha.1
- node/package.json -> 0.1.0-alpha.1
- Cargo.lock and node/package-lock.json regenerated via the toolchain, not hand-edited

## Why

This is the version-bump prerequisite for the first release. It must merge (alongside the release-automation PR #21) before tagging v0.1.0-alpha.1. A prerelease string is required because the npm release workflow publishes under the next dist-tag and rejects a stable version; PyPI stays aligned on the same string. The version-consistency gate in release-pypi.yml requires all eight fields to agree; they now do at 0.1.0-alpha.1. Nothing publishes on merge -- publishing is tag-gated and environment-approved.

## Testing

- [x] cargo check --locked
- [x] cargo test --locked (17 tests pass)
- [x] npm ci --ignore-scripts and npm run build and npm run smoke (build reports rustwright@0.1.0-alpha.1; smoke drove a browser and captured a screenshot)

## Checklist

- [x] I kept this change focused.
- [x] I added or updated tests for behavior changes. (n/a -- version-only bump, no behavior change)
- [x] I did not include private credentials, tokens, or internal-only artifacts.
