### PR TITLE
fix(release): build aarch64 linux wheel with zig

### DIFF
--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -96,18 +96,25 @@ jobs:
           - runner: macos-latest
             target: aarch64-apple-darwin
             manylinux: auto
+            extra_args: ""
           - runner: macos-latest
             target: x86_64-apple-darwin
             manylinux: auto
+            extra_args: ""
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             manylinux: "2_17"
+            extra_args: ""
           - runner: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             manylinux: "2_17"
+            # ring's pregenerated aarch64 assembly fails under the manylinux
+            # cross-gcc ("ARM assembler must define __ARM_ARCH"); build with zig.
+            extra_args: "--zig"
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             manylinux: auto
+            extra_args: ""
 
     steps:
       - name: Check out repository
@@ -126,7 +133,7 @@ jobs:
           target: ${{ matrix.platform.target }}
           manylinux: ${{ matrix.platform.manylinux }}
           rust-toolchain: stable
-          args: --release --locked --compatibility pypi --out dist
+          args: --release --locked --compatibility pypi --out dist ${{ matrix.platform.extra_args }}
 
       - name: Upload wheel
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## What

Build the `aarch64-unknown-linux-gnu` PyPI wheel with zig in `release-pypi.yml`. Adds a per-matrix `extra_args` field; only the aarch64 Linux leg gets `--zig`, every other leg is unchanged (empty).

## Why

The `v0.1.0-alpha.1` dry run failed on the aarch64 Linux wheel only: cross-compiling `ring` with the manylinux `aarch64-unknown-linux-gnu-gcc` trips `ring`'s pregenerated ARM assembly with `#error ... __ARM_ARCH`. Native x86_64 Linux is fine; aarch64 is a cross-compile, which is where it breaks. `release-npm.yml` already cross-builds its Linux targets with zig, so this brings `release-pypi.yml` in line. Left unfixed it blocks the real tag: the `publish` job needs the `wheels` job, and one failed matrix leg fails the whole job.

## Testing

- [x] YAML validates; matrix confirmed (only aarch64-linux carries `--zig`)
- [ ] Dry run against this branch (all 5 wheels + sdist green, publish auto-skipped): https://github.com/Skyvern-AI/rustwright/actions/runs/29176747078

## Checklist

- [x] I kept this change focused.
- [x] I added or updated tests for behavior changes. (n/a: CI workflow fix)
- [x] I did not include private credentials, tokens, or internal-only artifacts.
