### PR TITLE
fix(release): drop git-URL dep from compare extra; bump to 0.1.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustwright-core"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "rustwright-node"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-core"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2021"
 rust-version = "1.85"
 description = "Rust CDP core for a Python Playwright-compatible automation API"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-node"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2021"
 publish = false
 

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rustwright",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rustwright",
-      "version": "0.1.0-alpha.1",
+      "version": "0.1.0-alpha.2",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustwright",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "private": true,
   "description": "Node.js bindings for Rustwright's Rust CDP core",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustwright"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 description = "A Rust-backed, CDP-first Python automation library with a Playwright-compatible sync API"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -28,9 +28,11 @@ dev = [
   "pytest>=8",
   "pytest-benchmark>=4",
 ]
+# PyPI rejects direct URL dependencies, so browser-harness (used by the
+# comparison benchmarks) cannot live here; install it from git manually:
+# pip install "browser-harness @ git+https://github.com/browser-use/browser-harness.git"
 compare = [
   "playwright>=1.50",
-  "browser-harness @ git+https://github.com/browser-use/browser-harness.git",
 ]
 
 [tool.maturin]


### PR DESCRIPTION
## What

Remove the git-URL dependency (browser-harness) from the `compare` extra in package metadata, and fix forward to `0.1.0-alpha.2` across all six version files (lockfiles regenerated via toolchain).

## Why

PyPI rejected the `v0.1.0-alpha.1` publish with 400: direct URL dependencies are not allowed in published metadata. Nothing was uploaded. The comparison benchmarks can install browser-harness from git manually (comment added in pyproject). Fixing forward to alpha.2 per RELEASING.md rather than reusing the pushed tag.

## Testing

- [x] cargo check (lockfile regenerated, all 8 version fields agree at 0.1.0-alpha.2)
- [x] twine check PASSED on a locally built maturin sdist; Requires-Dist no longer contains any URL dependency
- [x] Wheels/sdist build path unchanged and already proven green on the v0.1.0-alpha.1 tag run (publish was the only failing job)

## Checklist

- [x] I kept this change focused.
- [x] I added or updated tests for behavior changes. (n/a: metadata + version bump)
- [x] I did not include private credentials, tokens, or internal-only artifacts.
