### PR TITLE
feat(deps): restore browser-harness in compare extra as a PyPI dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,11 @@ dev = [
   "pytest>=8",
   "pytest-benchmark>=4",
 ]
-# PyPI rejects direct URL dependencies, so browser-harness (used by the
-# comparison benchmarks) cannot live here; install it from git manually:
-# pip install "browser-harness @ git+https://github.com/browser-use/browser-harness.git"
 compare = [
   "playwright>=1.50",
+  # browser-harness needs Python 3.11+; the marker keeps this extra
+  # installable on rustwright's older supported Pythons.
+  "browser-harness>=0.1.5 ; python_version >= '3.11'",
 ]
 
 [tool.maturin]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,6 @@ dev = [
 ]
 compare = [
   "playwright>=1.50",
-  # browser-harness needs Python 3.11+; the marker keeps this extra
-  # installable on rustwright's older supported Pythons.
   "browser-harness>=0.1.5 ; python_version >= '3.11'",
 ]
 


### PR DESCRIPTION
## What

Restore browser-harness in the `compare` extra as a normal PyPI requirement (`browser-harness>=0.1.5 ; python_version >= '3.11'`), replacing the git-URL form removed in #25.

## Why

The git-URL dependency was removed in #25 because PyPI rejects direct URL dependencies. browser-harness is published on PyPI (https://pypi.org/project/browser-harness/), so the extra can depend on it normally. It requires Python 3.11+ while rustwright supports 3.8+, so the environment marker keeps `pip install rustwright[compare]` working on older Pythons (the dep is simply skipped there). No version bump; this rides the next release tag.

## Testing

- [x] twine check PASSED on a locally built maturin sdist
- [x] Rendered metadata: `Requires-Dist: browser-harness>=0.1.5 ; python_full_version >= '3.11' and extra == 'compare'` (no URL deps)

## Checklist

- [x] I kept this change focused.
- [x] I added or updated tests for behavior changes. (n/a: metadata-only)
- [x] I did not include private credentials, tokens, or internal-only artifacts.
