### PR TITLE
chore(release): bump version to 0.1.0-alpha.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustwright-core"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "rustwright-node"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-core"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 rust-version = "1.85"
 description = "Rust CDP core for a Python Playwright-compatible automation API"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-node"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2021"
 publish = false
 

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rustwright",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rustwright",
-      "version": "0.1.0-alpha.2",
+      "version": "0.1.0-alpha.3",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustwright",
-  "version": "0.1.0-alpha.2",
+  "version": "0.1.0-alpha.3",
   "private": true,
   "description": "Node.js bindings for Rustwright's Rust CDP core",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustwright"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 description = "A Rust-backed, CDP-first Python automation library with a Playwright-compatible sync API"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## What

Bump the version to 0.1.0-alpha.3 across all six version files (lockfiles regenerated via the toolchain).

## Why

Release prerequisite for the first npm publish now that #31 removed the libpython linkage. PyPI already has 0.1.0a2 and the old tags were deleted in the history rewrite, so the release fixes forward to alpha.3; the tag will publish npm (first release, `next` dist-tag) and PyPI (alpha.3 with the pyo3 feature gating) together. Nothing publishes on merge; publishing is tag-gated and environment-approved.

## Testing

- [x] cargo check --locked (all 8 version fields agree at 0.1.0-alpha.3)
- [x] Full local battery ran on the parent commit (#31): cargo test 23/23, node addon builds with zero python linkage + smoke, maturin wheel + python API smoke

## Checklist

- [x] I kept this change focused.
- [x] I added or updated tests for behavior changes. (n/a: version-only)
- [x] I did not include private credentials, tokens, or internal-only artifacts.
