### PR TITLE
fix(release): npm publish tarball path needs ./ prefix; bump to 0.1.0-alpha.4

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -276,6 +276,6 @@ jobs:
           esac
 
       - name: Publish experimental package with provenance
-        run: npm publish npm-dist/*.tgz --provenance --access public --tag next
+        run: npm publish ./npm-dist/*.tgz --provenance --access public --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustwright-core"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "rustwright-node"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-core"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2021"
 rust-version = "1.85"
 description = "Rust CDP core for a Python Playwright-compatible automation API"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-node"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2021"
 publish = false
 

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rustwright",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rustwright",
-      "version": "0.1.0-alpha.3",
+      "version": "0.1.0-alpha.4",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustwright",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "private": true,
   "description": "Node.js bindings for Rustwright's Rust CDP core",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustwright"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 description = "A Rust-backed, CDP-first Python automation library with a Playwright-compatible sync API"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## What

Prefix the npm publish tarball path with ./ and bump to 0.1.0-alpha.4 (all six version files, lockfiles regenerated).

## Why

The v0.1.0-alpha.3 npm publish failed: npm parsed `npm-dist/rustwright-0.1.0-alpha.3.tgz` (slash, no ./ prefix) as a GitHub owner/repo shorthand and ran `git ls-remote ssh://git@github.com/npm-dist/...` instead of publishing the local tarball. `./npm-dist/*.tgz` forces file-path parsing. The publish job only runs on tags and a tag's workflow snapshot is immutable, so this fixes forward to alpha.4; the tag will publish npm (first release) and PyPI alpha.4. PyPI 0.1.0a3 published fine and stays.

## Testing

- [x] cargo check --locked; all 8 version fields agree at 0.1.0-alpha.4
- [x] Everything else on this path validated on the alpha.3 tag run: all 5 npm prebuilds green (aarch64 zig fix), assembled package built, addons verified libpython-free; failure was isolated to the publish command's argument parsing

## Checklist

- [x] I kept this change focused.
- [x] I added or updated tests for behavior changes. (n/a: CI command + version bump)
- [x] I did not include private credentials, tokens, or internal-only artifacts.
