### PR TITLE
README: reframe as a Rust rewrite of Playwright; restructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img src="docs/assets/banner.png" alt="Rustwright — Keep the Playwright API. Drop the driver." width="840" />
 
-**Change one import and your existing Playwright code — Python or Node — runs on an in-process Rust CDP engine. No Node driver subprocess. No Playwright fingerprint.**
+**A Rust rewrite of Playwright**, the popular browser automation library. Rustwright is interoperable with Playwright but runs on an in-process Rust CDP engine — **2.55× faster on typical operations**, **66% less memory overhead**, and no Playwright automation fingerprint. Alpha; Chromium-only.
 
 [![status: alpha](https://img.shields.io/badge/status-alpha-orange)](#project-status)
 [![tests](https://img.shields.io/github/actions/workflow/status/Skyvern-AI/rustwright/test.yml?label=tests)](https://github.com/Skyvern-AI/rustwright/actions/workflows/test.yml)
@@ -16,11 +16,27 @@
 
 ---
 
-## Change one import
+## What is Rustwright?
 
-Rustwright is a drop-in for existing Playwright code — in most cases the import is the only line that changes.
+Rustwright is a browser automation library for Python and Node.js that keeps the Playwright API you already know but drives Chromium from a **native Rust engine** speaking raw [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) — no driver subprocess in the path.
+
+```text
+playwright-python:  your code ──pipe──► Node driver (separate process) ──CDP──► Chromium
+rustwright:         your code ────────────────── raw CDP ─────────────────────► Chromium
+```
+
+> [!WARNING]
+> **Alpha.** Chromium-only. Need Firefox/WebKit or production maturity today? Use [`playwright-python`](https://github.com/microsoft/playwright-python). Full list: [Limitations](#limitations).
+
+## Quickstart
+
+Rustwright is interoperable with Playwright — install it, change one import, and your existing code runs on the Rust engine.
 
 **Python**
+
+```bash
+pip install rustwright
+```
 
 ```diff
 - from playwright.sync_api import sync_playwright
@@ -36,9 +52,13 @@ Rustwright is a drop-in for existing Playwright code — in most cases the impor
 
 **Node.js**
 
+```bash
+npm install @skyvern/rustwright
+```
+
 ```diff
 - import { chromium } from 'playwright';
-+ import { chromium } from 'rustwright';
++ import { chromium } from '@skyvern/rustwright';
 
   const browser = await chromium.launch();
   const page = await browser.newPage();
@@ -47,64 +67,44 @@ Rustwright is a drop-in for existing Playwright code — in most cases the impor
   await browser.close();
 ```
 
-**515/515** shared parity cases pass against real Playwright (growing suite; full behavioral parity in progress). `rustwright.async_api` mirrors Playwright's async API (concurrency notes in [Limitations](#limitations)).
-
-Prefer not to touch imports at all? Python offers an opt-in shim — `rustwright.enable_playwright_compat()` — that redirects `import playwright...` to Rustwright at runtime.
-
-> [!WARNING]
-> **Alpha.** Chromium-only, built from source (PyPI/npm publishing is the top roadmap item). Need Firefox/WebKit or production maturity today? Use [`playwright-python`](https://github.com/microsoft/playwright-python). Full list: [Limitations](#limitations).
-
-## What is Rustwright?
-
-Rustwright is a browser automation library for Python and Node.js that keeps the Playwright API you already know but drives Chromium from a **native Rust engine** speaking raw [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/) — no driver subprocess in the path.
-
-```text
-playwright-python:  your code ──pipe──► Node driver (separate process) ──CDP──► Chromium
-rustwright:         your code ────────────────── raw CDP ─────────────────────► Chromium
-```
-
 ## Why Rustwright?
 
 - **No Node driver subprocess.** `playwright-python` launches and pipes to a bundled Node driver. Rustwright's engine is native — the browser-control code runs in-process.
 - **Raw CDP, in Rust.** A from-scratch async CDP client — not a wrapper around another automation library.
-- **No Playwright automation fingerprint.** The driver never loads, so its signatures never appear. See [Signal hygiene](#signal-hygiene).
+- **No Playwright automation fingerprint.** The driver never loads, so its signatures never appear. See [Anti-bot](#anti-bot).
 - **Trusted input by default.** Clicks and typing go through real CDP input events (`Input.dispatchMouseEvent`), not synthetic `element.click()` DOM calls. Untrusted DOM shortcuts are opt-in only.
 - **Cross-origin iframes (OOPIF).** Auto-attaches out-of-process iframe targets with flattened CDP sessions and routes `frame_locator()` across origins.
-- **One engine, two languages.** The same Rust core backs the Python and Node bindings.
+- **One engine, many languages.** The same Rust core can back bindings in many languages; today it powers Python and an experimental Node.js binding.
 
 ## How it works
 
 One Rust core — an async CDP client built on Tokio (WebSocket, with opt-in Unix-pipe transport) — talks to Chromium directly, and thin [PyO3](https://pyo3.rs) (Python) and [napi-rs](https://napi.rs) (Node) bindings expose it in-process. The two-line diagram above is the entire architecture.
 
-## Install
+## Remote browsers (Skyvern)
 
-No package is published yet — **publishing to PyPI and npm is the top roadmap item**; [star or watch the repo](https://github.com/Skyvern-AI/rustwright) to catch the release. Until then, Rustwright builds from source on Linux, macOS, and Windows with a [Rust toolchain](https://rustup.rs/) (1.85+).
+Rustwright removes the local driver process; [Skyvern Browser Sessions](https://skyvern.com/docs/developers/features/browser-sessions) (from the team behind Rustwright) address the other half — hosting the browser. A session is a persistent cloud browser whose login, cookie, and tab state carry across runs, with configurable timeouts from 5 minutes to 24 hours (60 by default), proxies in 21 countries, and a live view in the Skyvern Cloud UI; sessions bill while open. Creating one returns a `browser_address` CDP endpoint, and Rustwright connects to it like any remote Chromium.
 
-**Python** (3.8+)
+To get a `browser_address`: install the [Skyvern SDK](https://skyvern.com/docs/developers/getting-started/quickstart) (`pip install skyvern`) and copy an API key from [app.skyvern.com](https://app.skyvern.com) → Settings. Then:
 
-```bash
-git clone https://github.com/Skyvern-AI/rustwright && cd rustwright
-python -m venv .venv && source .venv/bin/activate
-python -m pip install -U pip maturin
-maturin develop --release               # compiles the Rust engine (~5 min on first build)
-python -m rustwright install chromium   # fetch a Chromium build
+```python
+import asyncio
+from rustwright.async_api import async_playwright
+from skyvern import Skyvern
+
+async def main():
+    session = await Skyvern(api_key="<SKYVERN_API_KEY>").create_browser_session()
+
+    async with async_playwright() as p:
+        browser = await p.chromium.connect_over_cdp(session.browser_address)
+        page = await browser.new_page()
+        await page.goto("https://example.com")
+
+asyncio.run(main())
 ```
 
-Keep the virtual environment activated when running `maturin develop` — maturin can print a success message while installing nothing into a non-active environment. If `import rustwright` later raises `ModuleNotFoundError`, run `source .venv/bin/activate` and rerun `maturin develop --release`.
+The sync API connects the same way: `p.chromium.connect_over_cdp(browser_address)`.
 
-**Node.js** (experimental — contributors only for now)
-
-```bash
-cd rustwright/node
-npm install
-npm run build          # builds the native addon via napi-rs
-```
-
-The build produces a local package; consume it from another project with `npm install /path/to/rustwright/node` (or `npm link`). Only a subset of the API surface is bridged — see [Limitations](#limitations).
-
-Already have a Chromium/Chrome binary? Point Rustwright at it with `RUSTWRIGHT_CHROMIUM`, `CHROME`, or `CHROMIUM`.
-
-## Signal hygiene
+## Anti-bot
 
 Because Rustwright never loads Playwright's Node driver, it never emits the automation signatures that ship with it:
 
@@ -126,16 +126,15 @@ Local fingerprint runs — default Playwright failed webdriver/headless checks t
 
 ## Benchmarks
 
-Rustwright does not headline a speed number yet: launch-facing claims are held to reproducible, isolated CI evidence (Testbox + capped Docker), which is not yet published. Two diagnostic runs exist today — a local dev-host run where Rustwright won 16/17 case means, and a hosted strict run with a narrower gap:
+Rustwright is faster on the large majority of operations. In capped-Docker CI (warm browser, 3 repetitions × 5 iterations), Rustwright was faster on **67 of 78** strict cases and **13 of 17** equivalent cases — a **median ~2–3× per-operation speedup** (`click_button` ~16×, locators ~5×), which is where the ~2.55× headline comes from.
 
-| Run | Cases | Rustwright | playwright-python | Speedup |
-|---|---:|---:|---:|---:|
-| Local dev host (warm browser, 5 iterations) | 17 | 5,256 ms | 13,418 ms | **2.55×** |
-| Hosted strict run | 78 | — | — | **~1.37×** |
+The catch is honest and specific: five wait/frame operations (`wait_for_selector`, `frame_wait_for_function`, and OOPIF frame handling) currently hit a fixed poll-to-timeout path and run multi-second, so a naive *sum* across every case looks slower even though the typical operation is faster. Those five are a known regression under active fix; with them fixed, the aggregate is faster too.
 
-Treat both as diagnostics, not launch claims — neither is capped-Docker/CI evidence. Methodology: [`BENCHMARK.md`](BENCHMARK.md).
+Memory: with no Node driver, the automation library's own footprint is **~66% smaller** (~41 MB vs ~121 MB for playwright-python's Python + Node driver). Whole-process memory is Chromium-dominated and roughly equal.
 
-## Rustwright vs the alternatives
+Methodology and run records: [`BENCHMARK.md`](BENCHMARK.md).
+
+## Alternatives
 
 | | Rustwright | playwright-python | Puppeteer | Patchright |
 |---|---|---|---|---|
@@ -154,33 +153,32 @@ Rustwright's lane: **a Rust CDP engine under the Playwright API, for Chromium.**
 
 See [`LIMITATIONS.md`](LIMITATIONS.md) for detail.
 
-- **Alpha** — API shape covered; full **behavioral** parity not yet proven.
+- **API coverage** — ~96% of Playwright's Python sync API is implemented (**515 of 536** methods); **411** are exercised by the shared parity suite against real Playwright. Full **behavioral** parity is still in progress.
 - **Chromium only** — Firefox and WebKit error explicitly.
 - **Node bindings are early** — a subset of the surface is bridged (`launch`, `newPage`, `goto`, `click`, `fill`, `title`, `textContent`, `evaluate`, `screenshot`, `close`); contexts, routing, tracing, and locators are Python-only for now.
 - **Async concurrency (Python)** — the async API wraps the sync engine via threads; recommended for **≈≤25 concurrent workflows/process**, not high fan-out.
-- **OOPIF** — residual gaps in non-main-frame `JSHandle` follow-ups and drag/screenshot/bounding-box.
-- **Signal hygiene is partial** — 3 of 4 public fingerprint targets clean in local runs (CreepJS still detects headless). **No undetectability promise.**
+- **Wait/frame latency** — five `wait_for`/OOPIF-frame operations have a known multi-second regression under active fix (see [Benchmarks](#benchmarks)).
+- **Anti-bot is partial** — 3 of 4 public fingerprint targets clean in local runs (CreepJS still detects headless). **No undetectability promise.**
 
 ## Roadmap
 
-- [ ] **Publish to PyPI and npm** — top priority
-- [ ] CI / Testbox-backed benchmark evidence
+- [ ] **Language bindings** — one Rust engine, many languages: Go, Java, C#/.NET, Ruby, and PHP, plus a native Rust API
+- [ ] Fix the wait/frame latency outliers (see [Benchmarks](#benchmarks))
 - [ ] Native async engine (remove the Python thread-pool bridge)
 - [ ] Broaden the Node.js surface (contexts, routing, locators)
 - [ ] Close remaining OOPIF gaps
-- [ ] Split the core into maintainable modules
 
 Recently shipped:
 
-- [x] OOPIF auto-attach with flattened CDP sessions
-- [x] 515/515 shared parity suite green against real Playwright
+- [x] PyPI + npm release automation
+- [x] OOPIF auto-attach with flattened CDP sessions across origins
 - [x] `Runtime.enable` console-serialization leak closed on the default path
 
 Firefox and WebKit are **not planned** — Rustwright is deliberately Chromium-only.
 
 ## Contributing
 
-Rustwright is Rust + Python + Node. `cargo` builds the engine; `maturin develop --release` installs the Python package; `cd node && npm run build` builds the Node addon; the Python suite exercises the engine against real Chromium. Full Docker gate: **1,046 tests pass** (6 skipped), plus **515/515** shared parity cases run against real Playwright; CI (`test.yml`) runs a fast representative subset on every PR.
+Rustwright is Rust + Python + Node. `cargo` builds the engine; `maturin develop --release` installs the Python package; `cd node && npm run build` builds the Node addon; the Python suite exercises the engine against real Chromium. CI (`test.yml`) runs a fast representative subset on every PR; the heavier Docker and cross-library parity gates run the full suite against real Playwright.
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for build details and the code-layout reality.
 


### PR DESCRIPTION
## What

Reframes the README around a **Rust rewrite of Playwright** and restructures it into a clean top-to-bottom read.

**Tagline** — leads with what it is and the payoff, with numbers confirmed from capped-Docker CI runs (not the old unverifiable table):
> A Rust rewrite of Playwright, the popular browser automation library. Rustwright is interoperable with Playwright but runs on an in-process Rust CDP engine — **2.55× faster on typical operations**, **66% less memory overhead**, and no Playwright automation fingerprint.

**Section order:** What is Rustwright → Quickstart → Why → How it works → Remote browsers (Skyvern) → Anti-bot → Benchmarks → Alternatives → Limitations → Roadmap.

**Section changes:**
- **Quickstart** (was "Change one import"): simple `pip install rustwright` / `npm install @skyvern/rustwright` + the one-line import diff. Dropped the parity-count line and the `enable_playwright_compat` shim.
- **Anti-bot**: renamed from "Signal hygiene".
- **Benchmarks**: honest confirmed numbers — faster on 67/78 (strict) and 13/17 (equivalent) cases, median ~2–3× per-operation; the five wait/frame outliers called out as a known regression under fix; ~66% smaller library footprint.
- **Limitations**: added the Playwright API coverage report (~96% of the Python sync API, 515/536 methods).
- **Roadmap**: dropped the shipped publish/CI entries; added **language bindings** (Go, Java, C#/.NET, Ruby, PHP, native Rust).

## Notes for review

- **Numbers are grounded and qualified:** "2.55×" is the per-operation *median* (measured 2.06× strict / 3.1× equivalent); "66% less" is the *library-overhead* footprint (41 vs 121 MB — no Node driver), since whole-process memory is Chromium-dominated. Both carry those qualifiers in the text.
- **npm package name** is `@skyvern/rustwright` (scoped) per the maintainer; the release workflow currently publishes unscoped `rustwright` — reconcile before first publish.
