### PR TITLE
Fix Locator.fill for React-controlled inputs; align Chromium launch flags with Playwright defaults

### DIFF
--- a/python/rustwright/sync_api.py
+++ b/python/rustwright/sync_api.py
@@ -11781,6 +11781,10 @@ class BrowserContext:
 
     def _adopt_persistent_initial_pages(self) -> None:
         self._adopt_existing_pages()
+        if not self._pages:
+            # The launcher uses --no-startup-window, so preserve Playwright's one-page persistent
+            # context contract by creating the first target lazily after CDP is connected.
+            self._new_page(method="BrowserType.launch_persistent_context")
 
     @property
     def background_pages(self) -> list[Any]:

--- a/python/rustwright/sync_api.py
+++ b/python/rustwright/sync_api.py
@@ -22482,11 +22482,12 @@ const value = String(payload.value ?? '');
 const forced = !!payload.forced;
 const tagName = String(el.tagName || '').toUpperCase();
 const inputType = tagName === 'INPUT' ? String(el.type || 'text').toLowerCase() : '';
-const nonFillableInputTypes = new Set(['button', 'checkbox', 'file', 'image', 'radio', 'reset', 'submit']);
+const valueInputTypes = new Set(['color', 'date', 'time', 'datetime-local', 'month', 'range', 'week']);
+const textInputTypes = new Set(['', 'email', 'number', 'password', 'search', 'tel', 'text', 'url']);
 const disabled = typeof el.matches === 'function' && el.matches(':disabled');
 const readonly = !!el.readOnly;
 const info = {
-  non_fillable_input: tagName === 'INPUT' && nonFillableInputTypes.has(inputType),
+  non_fillable_input: tagName === 'INPUT' && !valueInputTypes.has(inputType) && !textInputTypes.has(inputType),
   input_type: inputType,
   is_select: tagName === 'SELECT',
 };
@@ -22496,26 +22497,45 @@ const fillable = tagName === 'INPUT' || tagName === 'TEXTAREA' || el.isContentEd
 if (!fillable) return { ok: false, type: forced ? 'force-non-fillable' : 'non-fillable', info };
 if (forced && (!visible(el) || disabled || readonly)) return { ok: true };
 if (!forced && (!visible(el) || disabled || readonly)) return { ok: false, type: 'fallback' };
-if ('value' in el) {
-  el.scrollIntoView({ block: 'center', inline: 'center' });
-  if (typeof el.focus === 'function') el.focus({ preventScroll: true });
-  el.value = value;
-  if (value !== '' && el.value !== value) {
-    return {
-      ok: false,
-      type: inputType === 'number' ? 'number-text' : 'malformed',
-      value: el.value,
-      info,
-    };
-  }
-} else {
-  el.scrollIntoView({ block: 'center', inline: 'center' });
-  if (typeof el.focus === 'function') el.focus({ preventScroll: true });
-  el.textContent = value;
+let fillValue = value;
+if (inputType === 'number') {
+  fillValue = value.trim();
+  if (Number.isNaN(Number(fillValue))) return { ok: false, type: 'number-text', info };
 }
-el.dispatchEvent(new Event('input', { bubbles: true }));
-el.dispatchEvent(new Event('change', { bubbles: true }));
-return { ok: true };
+el.scrollIntoView({ block: 'center', inline: 'center' });
+if ('value' in el) {
+  if (valueInputTypes.has(inputType)) {
+    fillValue = value.trim();
+    if (inputType === 'color') fillValue = fillValue.toLowerCase();
+    if (typeof el.focus === 'function') el.focus({ preventScroll: true });
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      el.ownerDocument.defaultView.HTMLInputElement.prototype,
+      'value'
+    ).set;
+    valueSetter.call(el, fillValue);
+    if (el.value !== fillValue) return { ok: false, type: 'malformed', value: el.value, info };
+    el.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    return { ok: true };
+  }
+  if (tagName === 'INPUT') {
+    el.select();
+  } else {
+    el.selectionStart = 0;
+    el.selectionEnd = el.value.length;
+  }
+  if (typeof el.focus === 'function') el.focus({ preventScroll: true });
+} else {
+  if (typeof el.focus === 'function') el.focus({ preventScroll: true });
+  const range = el.ownerDocument.createRange();
+  range.selectNodeContents(el);
+  const selection = el.ownerDocument.defaultView.getSelection();
+  if (selection) {
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+}
+return { ok: true, needsInput: true, fillValue };
 }""",
             payload,
             timeout=timeout,
@@ -22525,6 +22545,8 @@ return { ok: true };
             return False
         result_type = result.get("type")
         if result.get("ok"):
+            if result.get("needsInput"):
+                self._insert_fill_text(str(result.get("fillValue", value)))
             self._page._slow_mo()
             return True
         if result_type == "fallback":
@@ -22542,6 +22564,12 @@ return { ok: true };
         if result_type == "select":
             info = {**info, "is_select": True}
         raise self._fill_type_error(action, info, force=result_type == "force-non-fillable")
+
+    def _insert_fill_text(self, value: str) -> None:
+        if value:
+            self._page.keyboard.insert_text(value)
+        else:
+            self._page.keyboard.press("Delete")
 
     def _try_fast_simple_css_dom_click(self, *, timeout: Optional[float]) -> bool:
         if not _unsafe_dom_fastpath_enabled():
@@ -23112,11 +23140,12 @@ const value = String(payload.value ?? '');
 const forced = !!payload.forced;
 const tagName = String(el.tagName || '').toUpperCase();
 const inputType = tagName === 'INPUT' ? String(el.type || 'text').toLowerCase() : '';
-const nonFillableInputTypes = new Set(['button', 'checkbox', 'file', 'image', 'radio', 'reset', 'submit']);
+const valueInputTypes = new Set(['color', 'date', 'time', 'datetime-local', 'month', 'range', 'week']);
+const textInputTypes = new Set(['', 'email', 'number', 'password', 'search', 'tel', 'text', 'url']);
 const disabled = disabledState(el);
 const readonly = !!el.readOnly;
 const info = {
-  non_fillable_input: tagName === 'INPUT' && nonFillableInputTypes.has(inputType),
+  non_fillable_input: tagName === 'INPUT' && !valueInputTypes.has(inputType) && !textInputTypes.has(inputType),
   input_type: inputType,
   is_select: tagName === 'SELECT',
 };
@@ -23126,26 +23155,45 @@ const fillable = tagName === 'INPUT' || tagName === 'TEXTAREA' || el.isContentEd
 if (!fillable) return { ok: false, type: forced ? 'force-non-fillable' : 'non-fillable', info };
 if (forced && (!visible(el) || disabled || readonly)) return { ok: true };
 if (!forced && (!visible(el) || disabled || readonly)) return { ok: false, type: 'fallback' };
-if ('value' in el) {
-  el.scrollIntoView({ block: 'center', inline: 'center' });
-  if (typeof el.focus === 'function') el.focus({ preventScroll: true });
-  el.value = value;
-  if (value !== '' && el.value !== value) {
-    return {
-      ok: false,
-      type: inputType === 'number' ? 'number-text' : 'malformed',
-      value: el.value,
-      info,
-    };
-  }
-} else {
-  el.scrollIntoView({ block: 'center', inline: 'center' });
-  if (typeof el.focus === 'function') el.focus({ preventScroll: true });
-  el.textContent = value;
+let fillValue = value;
+if (inputType === 'number') {
+  fillValue = value.trim();
+  if (Number.isNaN(Number(fillValue))) return { ok: false, type: 'number-text', info };
 }
-el.dispatchEvent(new Event('input', { bubbles: true }));
-el.dispatchEvent(new Event('change', { bubbles: true }));
-return { ok: true };
+el.scrollIntoView({ block: 'center', inline: 'center' });
+if ('value' in el) {
+  if (valueInputTypes.has(inputType)) {
+    fillValue = value.trim();
+    if (inputType === 'color') fillValue = fillValue.toLowerCase();
+    if (typeof el.focus === 'function') el.focus({ preventScroll: true });
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      el.ownerDocument.defaultView.HTMLInputElement.prototype,
+      'value'
+    ).set;
+    valueSetter.call(el, fillValue);
+    if (el.value !== fillValue) return { ok: false, type: 'malformed', value: el.value, info };
+    el.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    return { ok: true };
+  }
+  if (tagName === 'INPUT') {
+    el.select();
+  } else {
+    el.selectionStart = 0;
+    el.selectionEnd = el.value.length;
+  }
+  if (typeof el.focus === 'function') el.focus({ preventScroll: true });
+} else {
+  if (typeof el.focus === 'function') el.focus({ preventScroll: true });
+  const range = el.ownerDocument.createRange();
+  range.selectNodeContents(el);
+  const selection = el.ownerDocument.defaultView.getSelection();
+  if (selection) {
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+}
+return { ok: true, needsInput: true, fillValue };
 """
             ),
             payload,
@@ -23156,6 +23204,8 @@ return { ok: true };
             return False
         result_type = result.get("type")
         if result.get("ok"):
+            if result.get("needsInput"):
+                self._insert_fill_text(str(result.get("fillValue", value)))
             self._page._slow_mo()
             return True
         if result_type == "fallback":
@@ -23315,11 +23365,12 @@ const value = String(payload.value ?? '');
 const forced = !!payload.forced;
 const tagName = String(el.tagName || '').toUpperCase();
 const inputType = tagName === 'INPUT' ? String(el.type || 'text').toLowerCase() : '';
-const nonFillableInputTypes = new Set(['button', 'checkbox', 'file', 'image', 'radio', 'reset', 'submit']);
+const valueInputTypes = new Set(['color', 'date', 'time', 'datetime-local', 'month', 'range', 'week']);
+const textInputTypes = new Set(['', 'email', 'number', 'password', 'search', 'tel', 'text', 'url']);
 const disabled = disabledState(el);
 const readonly = !!el.readOnly;
 const info = {
-  non_fillable_input: tagName === 'INPUT' && nonFillableInputTypes.has(inputType),
+  non_fillable_input: tagName === 'INPUT' && !valueInputTypes.has(inputType) && !textInputTypes.has(inputType),
   input_type: inputType,
   is_select: tagName === 'SELECT',
 };
@@ -23329,26 +23380,45 @@ const fillable = tagName === 'INPUT' || tagName === 'TEXTAREA' || el.isContentEd
 if (!fillable) return { ok: false, type: forced ? 'force-non-fillable' : 'non-fillable', info };
 if (forced && (!visible(el) || disabled || readonly)) return { ok: true };
 if (!forced && (!visible(el) || disabled || readonly)) return { ok: false, type: 'fallback' };
-if ('value' in el) {
-  el.scrollIntoView({ block: 'center', inline: 'center' });
-  if (typeof el.focus === 'function') el.focus({ preventScroll: true });
-  el.value = value;
-  if (value !== '' && el.value !== value) {
-    return {
-      ok: false,
-      type: inputType === 'number' ? 'number-text' : 'malformed',
-      value: el.value,
-      info,
-    };
-  }
-} else {
-  el.scrollIntoView({ block: 'center', inline: 'center' });
-  if (typeof el.focus === 'function') el.focus({ preventScroll: true });
-  el.textContent = value;
+let fillValue = value;
+if (inputType === 'number') {
+  fillValue = value.trim();
+  if (Number.isNaN(Number(fillValue))) return { ok: false, type: 'number-text', info };
 }
-el.dispatchEvent(new Event('input', { bubbles: true }));
-el.dispatchEvent(new Event('change', { bubbles: true }));
-return { ok: true };
+el.scrollIntoView({ block: 'center', inline: 'center' });
+if ('value' in el) {
+  if (valueInputTypes.has(inputType)) {
+    fillValue = value.trim();
+    if (inputType === 'color') fillValue = fillValue.toLowerCase();
+    if (typeof el.focus === 'function') el.focus({ preventScroll: true });
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      el.ownerDocument.defaultView.HTMLInputElement.prototype,
+      'value'
+    ).set;
+    valueSetter.call(el, fillValue);
+    if (el.value !== fillValue) return { ok: false, type: 'malformed', value: el.value, info };
+    el.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+    el.dispatchEvent(new Event('change', { bubbles: true }));
+    return { ok: true };
+  }
+  if (tagName === 'INPUT') {
+    el.select();
+  } else {
+    el.selectionStart = 0;
+    el.selectionEnd = el.value.length;
+  }
+  if (typeof el.focus === 'function') el.focus({ preventScroll: true });
+} else {
+  if (typeof el.focus === 'function') el.focus({ preventScroll: true });
+  const range = el.ownerDocument.createRange();
+  range.selectNodeContents(el);
+  const selection = el.ownerDocument.defaultView.getSelection();
+  if (selection) {
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+}
+return { ok: true, needsInput: true, fillValue };
 """
             ),
             payload,
@@ -23359,6 +23429,8 @@ return { ok: true };
             return False
         result_type = result.get("type")
         if result.get("ok"):
+            if result.get("needsInput"):
+                self._insert_fill_text(str(result.get("fillValue", value)))
             self._page._slow_mo()
             return True
         if result_type == "fallback":
@@ -23403,18 +23475,19 @@ if (strict && (strictFrameViolation || matches.length > 1)) {{
 if (!el) return {{ ok: false, type: 'pending', info }};
 const value = {value_json};
 const forced = {force_literal};
-const nonFillableInputTypes = new Set(['button', 'checkbox', 'file', 'image', 'radio', 'reset', 'submit']);
+const valueInputTypes = new Set(['color', 'date', 'time', 'datetime-local', 'month', 'range', 'week']);
+const textInputTypes = new Set(['', 'email', 'number', 'password', 'search', 'tel', 'text', 'url']);
 const tagName = String(el.tagName || '').toUpperCase();
 const inputType = tagName === 'INPUT' ? String(el.type || 'text').toLowerCase() : '';
 info.visible = visible(el);
 info.enabled = !disabledState(el);
 info.tag_name = tagName;
 info.input_type = inputType;
-info.non_fillable_input = tagName === 'INPUT' && nonFillableInputTypes.has(inputType);
+info.non_fillable_input = tagName === 'INPUT' && !valueInputTypes.has(inputType) && !textInputTypes.has(inputType);
 info.is_select = tagName === 'SELECT';
 info.fillable_for_fill = tagName === 'INPUT' || tagName === 'TEXTAREA' || el.isContentEditable;
 info.editable_for_fill = info.fillable_for_fill && !disabledState(el) && !el.readOnly;
-if (tagName === 'INPUT' && nonFillableInputTypes.has(inputType)) {{
+if (info.non_fillable_input) {{
   return {{ ok: false, type: 'input-type', inputType, info }};
 }}
 if (tagName === 'SELECT') {{
@@ -23428,26 +23501,45 @@ if (forced && (!visible(el) || disabledState(el) || el.readOnly)) return {{ ok: 
 if (!forced && (!visible(el) || disabledState(el) || el.readOnly)) {{
   return {{ ok: false, type: 'pending', info }};
 }}
-if ('value' in el) {{
-  el.scrollIntoView({{ block: 'center', inline: 'center' }});
-  if (typeof el.focus === 'function') el.focus({{ preventScroll: true }});
-  el.value = value;
-  if (value !== '' && el.value !== value) {{
-    return {{
-      ok: false,
-      type: inputType === 'number' ? 'number-text' : 'malformed',
-      value: el.value,
-      info,
-    }};
-  }}
-}} else {{
-  el.scrollIntoView({{ block: 'center', inline: 'center' }});
-  if (typeof el.focus === 'function') el.focus({{ preventScroll: true }});
-  el.textContent = value;
+let fillValue = value;
+if (inputType === 'number') {{
+  fillValue = value.trim();
+  if (Number.isNaN(Number(fillValue))) return {{ ok: false, type: 'number-text', info }};
 }}
-el.dispatchEvent(new Event('input', {{ bubbles: true }}));
-el.dispatchEvent(new Event('change', {{ bubbles: true }}));
-return {{ ok: true, info }};
+el.scrollIntoView({{ block: 'center', inline: 'center' }});
+if ('value' in el) {{
+  if (valueInputTypes.has(inputType)) {{
+    fillValue = value.trim();
+    if (inputType === 'color') fillValue = fillValue.toLowerCase();
+    if (typeof el.focus === 'function') el.focus({{ preventScroll: true }});
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      el.ownerDocument.defaultView.HTMLInputElement.prototype,
+      'value'
+    ).set;
+    valueSetter.call(el, fillValue);
+    if (el.value !== fillValue) return {{ ok: false, type: 'malformed', value: el.value, info }};
+    el.dispatchEvent(new Event('input', {{ bubbles: true, composed: true }}));
+    el.dispatchEvent(new Event('change', {{ bubbles: true }}));
+    return {{ ok: true, info }};
+  }}
+  if (tagName === 'INPUT') {{
+    el.select();
+  }} else {{
+    el.selectionStart = 0;
+    el.selectionEnd = el.value.length;
+  }}
+  if (typeof el.focus === 'function') el.focus({{ preventScroll: true }});
+}} else {{
+  if (typeof el.focus === 'function') el.focus({{ preventScroll: true }});
+  const range = el.ownerDocument.createRange();
+  range.selectNodeContents(el);
+  const selection = el.ownerDocument.defaultView.getSelection();
+  if (selection) {{
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }}
+}}
+return {{ ok: true, needsInput: true, fillValue, info }};
 """
         last_info: dict[str, Any] = {}
         while True:
@@ -23469,6 +23561,8 @@ return {{ ok: true, info }};
                         f"strict mode violation: locator resolved to {count} elements while trying to {action}"
                     )
             if isinstance(result, dict) and result.get("ok"):
+                if result.get("needsInput"):
+                    self._insert_fill_text(str(result.get("fillValue", value)))
                 self._page._slow_mo()
                 return
             if isinstance(result, dict) and result.get("type") == "pending":

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8868,21 +8868,53 @@ fn launch_chromium_attempt(
     }
 
     let mut default_args = vec![
-        "--no-first-run".to_string(),
-        "--no-default-browser-check".to_string(),
+        "--disable-field-trial-config".to_string(),
         "--disable-background-networking".to_string(),
         "--disable-background-timer-throttling".to_string(),
+        "--disable-backgrounding-occluded-windows".to_string(),
+        "--disable-back-forward-cache".to_string(),
+        "--disable-breakpad".to_string(),
+        "--disable-client-side-phishing-detection".to_string(),
+        "--disable-component-extensions-with-background-pages".to_string(),
+        "--disable-component-update".to_string(),
+        "--no-default-browser-check".to_string(),
+        "--disable-default-apps".to_string(),
         "--disable-dev-shm-usage".to_string(),
-        "--disable-blink-features=AutomationControlled".to_string(),
-        "--disable-renderer-backgrounding".to_string(),
+        "--disable-extensions".to_string(),
+        "--disable-features=AvoidUnnecessaryBeforeUnloadCheckSync,BoundaryEventDispatchTracksNodeRemoval,DestroyProfileOnBrowserClose,DialMediaRouteProvider,GlobalMediaControls,HttpsUpgrades,LensOverlay,MediaRouter,PaintHolding,ThirdPartyStoragePartitioning,Translate,AutoDeElevate,RenderDocument,OptimizationHints".to_string(),
+        "--enable-features=CDPScreenshotNewSurface".to_string(),
+        "--allow-pre-commit-input".to_string(),
+        "--disable-hang-monitor".to_string(),
+        "--disable-ipc-flooding-protection".to_string(),
         "--disable-popup-blocking".to_string(),
         "--disable-prompt-on-repost".to_string(),
-        "--enable-features=CDPScreenshotNewSurface".to_string(),
+        "--disable-renderer-backgrounding".to_string(),
+        "--force-color-profile=srgb".to_string(),
+        "--metrics-recording-only".to_string(),
+        "--no-first-run".to_string(),
+        "--password-store=basic".to_string(),
+        "--use-mock-keychain".to_string(),
+        "--no-service-autorun".to_string(),
+        "--export-tagged-pdf".to_string(),
+        "--disable-search-engine-choice-screen".to_string(),
+        "--unsafely-disable-devtools-self-xss-warnings".to_string(),
+        "--edge-skip-compat-layer-relaunch".to_string(),
+        "--disable-infobars".to_string(),
+        "--disable-sync".to_string(),
+        "--enable-unsafe-swiftshader".to_string(),
+        // Playwright also passes --enable-automation, but it exposes navigator.webdriver.
+        "--disable-blink-features=AutomationControlled".to_string(),
+        // Keep Rustwright's deliberate audio suppression in both headed and headless modes.
         "--mute-audio".to_string(),
+        "--no-startup-window".to_string(),
     ];
     if options.headless {
-        default_args.push("--headless=new".to_string());
+        default_args.push("--headless".to_string());
         default_args.push("--hide-scrollbars".to_string());
+        default_args.push(
+            "--blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4"
+                .to_string(),
+        );
     }
     if !options.chromium_sandbox {
         default_args.push("--no-sandbox".to_string());
@@ -8909,7 +8941,8 @@ fn launch_chromium_attempt(
     if single_process_fallback && !has_chromium_arg(&options.args, "--single-process") {
         command.arg("--single-process");
     }
-    command.arg("about:blank");
+    // Playwright defaults to --remote-debugging-pipe. Rustwright keeps its port transport until
+    // that transport migration is complete; --no-startup-window still avoids an eager target.
 
     let mut child = match command.spawn() {
         Ok(child) => child,

--- a/tests/test_rustwright_sync_api.py
+++ b/tests/test_rustwright_sync_api.py
@@ -4950,6 +4950,65 @@ def test_launch_defaults_to_fast_cdp_screenshot_surface(playwright, tmp_path: Pa
         browser.close()
 
 
+def test_launch_defaults_align_with_playwright_without_automation_signals(playwright, tmp_path: Path):
+    args_file = tmp_path / "launch-playwright-default-args.txt"
+    wrapper = chromium_arg_probe_wrapper(tmp_path, playwright.chromium.executable_path, args_file)
+
+    browser = playwright.chromium.launch(headless=True, executable_path=str(wrapper))
+    try:
+        page = browser.new_page()
+        page.set_content("<title>Playwright defaults</title>")
+
+        launch_args = args_file.read_text(encoding="utf-8").splitlines()
+        expected_args = {
+            "--allow-pre-commit-input",
+            "--disable-back-forward-cache",
+            "--disable-backgrounding-occluded-windows",
+            "--disable-breakpad",
+            "--disable-client-side-phishing-detection",
+            "--disable-component-extensions-with-background-pages",
+            "--disable-component-update",
+            "--disable-default-apps",
+            "--disable-extensions",
+            "--disable-field-trial-config",
+            "--disable-hang-monitor",
+            "--disable-infobars",
+            "--disable-ipc-flooding-protection",
+            "--disable-search-engine-choice-screen",
+            "--disable-sync",
+            "--edge-skip-compat-layer-relaunch",
+            "--enable-unsafe-swiftshader",
+            "--export-tagged-pdf",
+            "--force-color-profile=srgb",
+            "--metrics-recording-only",
+            "--no-service-autorun",
+            "--no-startup-window",
+            "--password-store=basic",
+            "--unsafely-disable-devtools-self-xss-warnings",
+            "--use-mock-keychain",
+            "--disable-blink-features=AutomationControlled",
+            "--mute-audio",
+            "--blink-settings=primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4",
+        }
+        expected_disabled_features = (
+            "--disable-features=AvoidUnnecessaryBeforeUnloadCheckSync,"
+            "BoundaryEventDispatchTracksNodeRemoval,DestroyProfileOnBrowserClose,"
+            "DialMediaRouteProvider,GlobalMediaControls,HttpsUpgrades,LensOverlay,"
+            "MediaRouter,PaintHolding,ThirdPartyStoragePartitioning,Translate,"
+            "AutoDeElevate,RenderDocument,OptimizationHints"
+        )
+
+        assert expected_args <= set(launch_args)
+        assert expected_disabled_features in launch_args
+        assert "--enable-features=CDPScreenshotNewSurface" in launch_args
+        assert "about:blank" not in launch_args
+        assert "--enable-automation" not in launch_args
+        assert "--remote-debugging-pipe" not in launch_args
+        assert any(arg.startswith("--remote-debugging-port=") for arg in launch_args)
+    finally:
+        browser.close()
+
+
 def test_launch_ignore_default_args_filters_selected_defaults(playwright, tmp_path: Path):
     args_file = tmp_path / "launch-ignore-args.txt"
     wrapper = chromium_arg_probe_wrapper(tmp_path, playwright.chromium.executable_path, args_file)

--- a/tests/test_rustwright_sync_api.py
+++ b/tests/test_rustwright_sync_api.py
@@ -9380,6 +9380,7 @@ def test_fill_sets_value_and_dispatches_events(page):
         <input id="checkbox-name" type="checkbox" value="old">
         <input id="number-code" type="number">
         <input id="date-code" type="date">
+        <textarea id="notes">old notes</textarea>
         <select id="plan"><option value="basic">Basic</option><option value="pro" selected>Pro</option></select>
         <button id="button-name" value="button-value">Button</button>
         <div id="editable-name" contenteditable>editable</div>
@@ -9397,6 +9398,10 @@ def test_fill_sets_value_and_dispatches_events(page):
 
     assert page.evaluate("document.querySelector('#name').value") == "Ada"
     assert page.text_content("#seen") == "Ada"
+    page.locator("#notes").fill("updated notes")
+    assert page.locator("#notes").input_value() == "updated notes"
+    page.locator("#editable-name").fill("updated editable")
+    assert page.text_content("#editable-name") == "updated editable"
     with pytest.raises(Error, match="not an <input>.*role allowing"):
         page.locator("#plain-name").fill("normal plain", timeout=500)
     with pytest.raises(Error, match="\\[contenteditable\\] element"):
@@ -9432,6 +9437,67 @@ def test_fill_sets_value_and_dispatches_events(page):
         page.locator("#plain-name").fill("forced plain", force=True)
     with pytest.raises(Error, match='Input of type "checkbox"'):
         page.locator("#checkbox-name").fill("forced checkbox", force=True)
+
+
+def test_fill_commits_react_controlled_input_value(page):
+    page.set_content(
+        """
+        <input id="controlled" value="Initial">
+        <script>
+        const input = document.querySelector('#controlled');
+        const nativeValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+        let trackedValue = nativeValue.get.call(input);
+        let stateValue = trackedValue;
+
+        // React-controlled inputs install an instance-level value setter. A direct
+        // assignment updates this tracker before `input` fires, so React dedupes the
+        // event and restores its previous state. This reproduces that boundary
+        // without adding React as a test dependency.
+        Object.defineProperty(input, 'value', {
+          configurable: true,
+          get() {
+            return nativeValue.get.call(this);
+          },
+          set(value) {
+            trackedValue = String(value);
+            nativeValue.set.call(this, value);
+          },
+        });
+
+        window.committedValue = stateValue;
+        window.inputEvents = [];
+        input.addEventListener('input', event => {
+          window.inputEvents.push({
+            bubbles: event.bubbles,
+            composed: event.composed,
+            isTrusted: event.isTrusted,
+            constructor: event.constructor.name,
+          });
+          const nextValue = nativeValue.get.call(input);
+          if (nextValue === trackedValue) {
+            nativeValue.set.call(input, stateValue);
+            return;
+          }
+          stateValue = nextValue;
+          input.value = stateValue;
+          window.committedValue = stateValue;
+        });
+        </script>
+        """
+    )
+
+    page.locator("#controlled").fill("Alex")
+
+    assert page.locator("#controlled").input_value() == "Alex"
+    assert page.evaluate("window.committedValue") == "Alex"
+    assert page.evaluate("window.inputEvents") == [
+        {
+            "bubbles": True,
+            "composed": True,
+            "isTrusted": True,
+            "constructor": "InputEvent",
+        }
+    ]
 
 
 def test_type_inserts_at_focus_caret_like_playwright(page):


### PR DESCRIPTION
## What

### Locator.fill

- Make Locator.fill select and focus text inputs, textareas, and contenteditable elements before completing the edit through the browser input path.
- Keep direct value handling for date-like input types, using the native input setter and Playwright-compatible input/change event flags.
- Add a dependency-free regression fixture that reproduces controlled-input value tracker deduplication.

### Chromium launch flags

- Align Chromium's startup, background-service, feature, rendering, and GPU switches with Playwright 1.59 defaults.
- Launch with `--no-startup-window` and no positional `about:blank`; persistent contexts create their required first blank target lazily over CDP after connection.
- Preserve Rustwright's anti-bot posture and existing transport by retaining `--disable-blink-features=AutomationControlled`, `--mute-audio`, and the port-based CDP connection.

## Why

### Locator.fill

The previous injected fill path assigned el.value directly and then dispatched synthetic input/change events. Controlled input frameworks can observe that instance-level assignment in their value tracker, dedupe the later input event, and restore the prior state. Playwright 1.59 instead selects ordinary editable text and completes it through browser text insertion, allowing the controlled state update to commit.

### Chromium launch flags

Rustwright previously left Chromium background services and caches enabled, used a different GPU configuration, and eagerly opened a separate blank target. Matching Playwright's defaults removes unnecessary startup work and renderer overhead while keeping Rustwright's deliberate automation-signal suppression.

Adopted switches include `--allow-pre-commit-input`, `--disable-back-forward-cache`, `--disable-backgrounding-occluded-windows`, `--disable-breakpad`, `--disable-client-side-phishing-detection`, `--disable-component-extensions-with-background-pages`, `--disable-component-update`, `--disable-default-apps`, `--disable-extensions`, `--disable-field-trial-config`, `--disable-hang-monitor`, `--disable-infobars`, `--disable-ipc-flooding-protection`, `--disable-search-engine-choice-screen`, `--disable-sync`, `--enable-unsafe-swiftshader`, `--export-tagged-pdf`, `--force-color-profile=srgb`, `--metrics-recording-only`, `--no-service-autorun`, `--no-startup-window`, `--password-store=basic`, `--unsafely-disable-devtools-self-xss-warnings`, and `--use-mock-keychain`. The exact Playwright 1.59 `--disable-features=` list, `--enable-features=CDPScreenshotNewSurface`, Edge relaunch guard, and headless pointer settings are mirrored as well.

Intentional differences:

- `--enable-automation` remains excluded because it exposes automation through `navigator.webdriver` and would regress the anti-bot contract.
- `--remote-debugging-pipe` remains excluded because a transport migration is outside this change; `--remote-debugging-port` is the known transport difference.
- Rustwright's `--disable-blink-features=AutomationControlled` and `--mute-audio` defaults remain enabled.

## Memory evidence

Directional host measurement: launch headless, open a public Greenhouse job board without clicking or submitting, wait about five seconds after DOM content loads, then sum RSS for the Chromium process tree.

| Build | Run | Total RSS | Renderer processes |
| --- | ---: | ---: | ---: |
| Before | 1 | 418.1 MiB | 2 |
| Before | 2 | 392.1 MiB | 2 |
| After | 1 | 371.0 MiB | 1 |
| After | 2 | 341.9 MiB | 1 |

Average RSS decreased from 405.1 MiB to 356.5 MiB, a 48.6 MiB (12.0%) directional reduction, with one fewer renderer in both after runs.

## Testing

- [x] cargo check --locked
- [x] Targeted pytest: 24 fill, keyboard, input-value, and locator typing tests passed with 1,038 unrelated tests deselected
- [x] Regression test failed before the fill fix with Initial retained instead of Alex, then passed after the fix
- [x] Same-origin frame, out-of-process iframe, async clear, textarea, contenteditable, checkbox/select rejection, and fast-path coverage passed
- [x] Live headless read-back on a public Greenhouse job form retained Alex in #first_name; no submit or button action was performed
- [x] maturin develop completed with Cargo 1.95 and Python 3.13
- [x] Windowless launch, new context/page, persistent initial-page adoption, and the React-controlled fill regression passed (4 tests)
- [x] Existing targeted launch/browser/context/page coverage passed (12 tests)
- [x] Live page, worker, and service-worker automation-signal smoke tests passed (3 tests); anti-bot analyzer tests passed (15 tests)
- [x] Actual Chromium process command line contained all 29 asserted defaults, omitted `about:blank` and `--enable-automation`, and retained port transport
- [x] Two before and two after host RSS/renderer runs completed successfully against the same public page

## Checklist

- [x] I kept this change focused.
- [x] I added or updated tests for behavior changes.
- [x] I did not include private credentials, tokens, or internal-only artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
