### PR TITLE
feat(release): allow stable versions; bump to 0.1.0

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -262,20 +262,19 @@ jobs:
           name: npm-package
           path: npm-dist
 
-      - name: Require a prerelease version
+      - name: Select dist-tag from version
+        id: dist_tag
         shell: bash
         run: |
           set -euo pipefail
           version="${GITHUB_REF_NAME#v}"
           case "$version" in
-            *-*) ;;
-            *)
-              echo "The experimental npm package requires a prerelease version such as 0.2.0-alpha.1" >&2
-              exit 1
-              ;;
+            *-*) tag=next ;;
+            *) tag=latest ;;
           esac
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
-      - name: Publish experimental package with provenance
-        run: npm publish ./npm-dist/*.tgz --provenance --access public --tag next
+      - name: Publish package with provenance
+        run: npm publish ./npm-dist/*.tgz --provenance --access public --tag "${{ steps.dist_tag.outputs.tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -66,16 +66,6 @@ jobs:
           if any(version != expected for version in versions.values()):
               raise SystemExit(f"Package versions do not match: {versions}")
 
-          # Match the npm workflow, which rejects stable versions: a single tag
-          # must publish to both registries or neither. This alpha project ships
-          # prereleases only (e.g. 0.2.0-alpha.1), so reject a stable version here
-          # too rather than let PyPI publish something npm would refuse.
-          if "-" not in expected:
-              raise SystemExit(
-                  f"Refusing to publish stable version {expected!r}: this project "
-                  f"publishes prereleases only (e.g. 0.2.0-alpha.1), matching release-npm.yml."
-              )
-
           if os.environ["GITHUB_REF_TYPE"] == "tag":
               tag_version = os.environ["GITHUB_REF_NAME"].removeprefix("v")
               if tag_version != expected:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustwright-core"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "rustwright-node"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-core"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Rust CDP core for a Python Playwright-compatible automation API"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -22,7 +22,7 @@ No crates.io settings or token are currently required. Do not publish `rustwrigh
 
 ## Prepare a release
 
-- [ ] Choose one version in prerelease SemVer form, for example `0.2.0-alpha.1`. The npm workflow deliberately publishes under the `next` dist-tag and rejects a stable version.
+- [ ] Choose a SemVer version. Prereleases (for example `0.2.0-alpha.1`) publish to the npm `next` dist-tag; stable versions (for example `0.1.0`) publish to `latest`.
 - [ ] Set that exact string in these source-of-truth fields:
   - `pyproject.toml` → `[project].version`
   - `Cargo.toml` → `[package].version` for `rustwright-core`
@@ -66,7 +66,7 @@ The four source manifests and both lockfiles are all `0.1.0` today; there is no 
 
 - [ ] Approve the `pypi` and `npm` GitHub environment deployments. The tag starts both workflows; publishing is also guarded to `Skyvern-AI/rustwright`.
 - [ ] If a publish job alone must be retried, dispatch that workflow from the existing tag and clear `dry_run`. A branch dispatch cannot publish.
-- [ ] Never move or reuse a published version tag. Fix forward with a new prerelease version.
+- [ ] Never move or reuse a published version tag. Fix forward with a new version.
 
 ## Verify the registries
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-node"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 edition = "2021"
 publish = false
 

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rustwright",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rustwright",
-      "version": "0.1.0-alpha.4",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustwright",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.0",
   "private": true,
   "description": "Node.js bindings for Rustwright's Rust CDP core",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustwright"
-version = "0.1.0-alpha.4"
+version = "0.1.0"
 description = "A Rust-backed, CDP-first Python automation library with a Playwright-compatible sync API"
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
## What

Make v0.1.0 the official release: lift the prerelease-only guards in both release workflows, route the npm dist-tag by version (prerelease -> `next`, stable -> `latest`), bump all six version files to 0.1.0, and update RELEASING.md.

## Why

The prerelease-only guards were deliberate while the project was pre-launch. The repo is now public, the release pipeline is proven end to end on the alphas (PyPI 0.1.0a2/a3/a4 published; npm publish verified through provenance), so 0.1.0 is the first official version. Tagging `v0.1.0` after this merges will publish PyPI 0.1.0 and npm 0.1.0 under the `latest` dist-tag with provenance. Nothing publishes on merge; publishing stays tag-gated and environment-approved.

## Testing

- [x] Both workflow YAMLs validate; dist-tag selection is a two-line case on the tag version
- [x] cargo check --locked; all 8 version fields agree at 0.1.0
- [x] Build/test path unchanged from the alpha.4 tag run (all prebuilds green, addons libpython-free)

## Checklist

- [x] I kept this change focused.
- [x] I added or updated tests for behavior changes. (n/a: release config + version bump)
- [x] I did not include private credentials, tokens, or internal-only artifacts.
