### PR TITLE
Add version upgrade release skill

### DIFF
--- a/.claude/skills/version-upgrade/SKILL.md
+++ b/.claude/skills/version-upgrade/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: version-upgrade
+description: Prepare, validate, and publish a Rustwright version across the Python/PyPI and Node.js/npm packages. Use when asked to bump or upgrade the Rustwright version, prepare a release PR, tag a release, publish Rustwright, or verify both package registries.
+---
+
+# Version Upgrade
+
+Release one Rustwright version through the repository's existing PyPI and npm
+workflows. Treat "npm and Node.js" as one target: npm is the registry for the
+Node.js package. The two release targets are Python on PyPI and Node.js on npm.
+Do not publish `rustwright-core` to crates.io.
+
+## Arguments and mode
+
+Read `$ARGUMENTS` for an exact SemVer version and an optional mode.
+
+- Accept stable versions such as `0.1.1` and prereleases in the shared
+  Cargo/npm/PyPI subset: `0.2.0-alpha.1`, `0.2.0-beta.1`, or
+  `0.2.0-rc.1`. Reject other SemVer prerelease labels because PyPI may not
+  accept or may ambiguously normalize them.
+- If the caller asks only to check, verify, or report a release or registry
+  status, enter verify-only mode. Perform read-only GitHub, Git, PyPI, and npm
+  queries and return the result without creating a branch, changing a file,
+  dispatching a workflow, merging, tagging, or publishing.
+- If no version is supplied, use the helper's default: increment a stable
+  patch version or the final numeric prerelease component.
+- Treat `prepare`, `PR only`, or `dry run` as prepare-only mode. Stop after the
+  release PR and both successful preview artifact dry runs.
+- Enter full-release mode only when the caller explicitly says `publish`,
+  `release now`, or `full release` in the current request. Invoking this skill,
+  asking for a version bump, or omitting a mode never by itself authorizes an
+  irreversible registry publication; default those cases to prepare-only mode.
+- Do not pause for choices that can be derived from the repository. Stop only
+  for a dirty worktree, missing authorization or secret, failed validation, a
+  required human review, or another condition that makes publishing unsafe.
+
+## 1. Inspect current state
+
+1. Read `AGENTS.md` and `docs/RELEASING.md`; repository instructions and the
+   current workflows override examples in this skill.
+2. Require a clean worktree. Never discard local changes.
+3. Fetch `origin/main` and all tags. Start from the current `origin/main`, not a
+   stale local branch.
+4. Inspect `.github/workflows/release-pypi.yml` and
+   `.github/workflows/release-npm.yml`. Both must still publish from the same
+   `v<version>` tag.
+5. Search open and merged release PRs, Git tags, PyPI, and npm before deciding
+   where to start. For PyPI, compare every release key after canonicalizing
+   both sides with `packaging.version.Version`; for example, PyPI may represent
+   `0.2.0-alpha.1` as the equivalent `0.2.0a1`. Compare npm versions with
+   SemVer rules.
+6. Require monotonic releases across all three histories. A new target must be
+   strictly newer than every release version in Git tags, PyPI, and npm. A
+   prepared or tagged target may equal the newest version, but must never be
+   published if any newer release already exists in any history. Treat an
+   invalid `v*` release tag as a blocker rather than silently ignoring it.
+7. Classify the target as new, on an open release PR, prepared on main, tagged
+   or publishing, partially published, or fully published. Reuse an existing
+   PR only after inspecting its complete commit history and diff. Its head must
+   be in this repository, its base must be current `main`, every version field
+   must equal the target, and its diff must contain only the expected version
+   files. A filename allowlist is not sufficient: inspect every hunk and
+   require changes only to the exact version fields plus the two local package
+   entries regenerated in the lockfiles. Reject dependency changes, unrelated
+   lines in an allowed file, mode changes, renames, binaries, or extra commit
+   content. When uncertain, reproduce the bump from the PR base in a clean
+   temporary worktree and compare the resulting patch. Rerun every check and
+   preview against its current head. Treat an unexpected file, commit, base,
+   or fork as a blocker rather than inheriting it. If the target is already
+   consistent on `origin/main` but has no tag or
+   registry publication, treat it as a prepared release and resume at the
+   final merged-commit dry runs in section 4. If it is fully published, report
+   success without mutation. Handle partial publication as described below.
+   Never reuse an equivalent published version or move a release tag.
+8. Before resuming any existing tag, validate its provenance. Require an
+   annotated `v<version>` tag whose target commit is reachable from current
+   `origin/main`, contains the same target in every version field, and matches
+   the `headSha` of its tag-triggered release runs. Stop on a lightweight tag,
+   mismatched metadata or run SHA, unreachable commit, or unexpected tag
+   target. Do not approve or rerun publication from an unverified tag.
+
+## 2. Prepare the version bump
+
+For a new target only, create `release/v<version>` from `origin/main`. Use the
+repository helper to update the four source manifests and shipped runtime
+metadata:
+
+```bash
+python3 .claude/skills/version-upgrade/scripts/bump_version.py <version>
+```
+
+Omit `<version>` only when the caller did not specify one. Then regenerate,
+rather than manually edit, both lockfiles:
+
+```bash
+cargo check
+(cd node && npm install --package-lock-only --ignore-scripts)
+python3 .claude/skills/version-upgrade/scripts/bump_version.py --check <version>
+```
+
+The check must confirm one exact version in all of these locations:
+
+- `pyproject.toml`
+- `Cargo.toml`
+- `node/Cargo.toml`
+- `node/package.json`
+- the Rustwright creator version in `python/rustwright/sync_api.py`
+- the Rustwright trace version in `python/rustwright/sync_api.py`
+- the source-checkout fallback in `python/rustwright/cli.py`
+- the source-checkout fallback in `python/rustwright/_backend.py`
+- the `rustwright-core` and `rustwright-node` entries in `Cargo.lock`
+- both top-level package versions in `node/package-lock.json`
+
+Run the release checks from `docs/RELEASING.md`:
+
+```bash
+cargo check --locked
+cargo test --locked
+(cd node && npm ci --ignore-scripts && npm run build && npm run smoke)
+```
+
+Do not weaken, skip, or silently narrow a failing check.
+
+## 3. Push and dry-run both packages
+
+1. Review the complete diff and staged diff for accidental disclosures.
+2. Commit only the nine expected version files listed above. Use the
+   authenticated GitHub account's
+   public `users.noreply.github.com` identity as required by `AGENTS.md`.
+3. Install the tracked pre-push hook with `python3 tools/install_hooks.py`.
+4. Push the release branch without bypassing hooks and open a PR titled
+   `chore(release): bump version to <version>`.
+5. Dispatch both release workflows against the release branch with
+   `dry_run=true`. Capture both run URLs and wait for both runs to succeed.
+   These preview runs must build the PyPI wheels/sdist and the assembled npm
+   tarball; they must not enter either publish job. They are early artifact
+   checks only and do not validate the merged commit that will be tagged.
+6. Add the successful preview run URLs to the PR description or a PR comment.
+
+If either dry run fails, diagnose it, fix the release branch, rerun both when a
+shared input changed, and do not merge until both pass.
+
+## 4. Merge and publish
+
+Skip this section in prepare-only mode.
+
+1. Wait for required PR checks. Merge using the repository's normal merge
+   policy; do not bypass required reviews or protections.
+2. Refresh `origin/main`, choose its current commit as the release candidate,
+   verify that commit contains the exact target version in all manifests and
+   lockfiles, and verify the worktree is clean.
+3. Dispatch both release workflows against `main` with `dry_run=true`. Capture
+   each run's `headSha`; both must equal the same release-candidate commit and
+   both runs must succeed. If the runs resolve to different commits or main
+   moves before dispatch, refresh main and rerun both against one new candidate.
+   A successful release-branch preview is never a substitute for these final
+   merged-commit dry runs.
+4. Re-fetch main immediately before tagging and require `origin/main` to still
+   equal the tested candidate. If main moved for any reason, select its new
+   head and repeat both final dry runs; do not knowingly publish a stale
+   candidate. Re-verify the target version at the unchanged candidate, then
+   create an annotated `v<version>` tag on it using the GitHub noreply identity.
+   Push only that tag. Never retag a branch commit, unmerged commit, stale
+   commit, or untested commit.
+5. Locate the tag-triggered runs of `release-pypi.yml` and `release-npm.yml` and
+   monitor both to completion.
+6. If an `npm` or `pypi` environment approval is pending, approve it only when
+   the authenticated actor is an allowed reviewer and the invocation is in
+   full-release mode. Never change environment protections or repository
+   secrets to make approval succeed. If human approval is mandatory, report
+   the two run URLs and the exact pending environments.
+
+If a final merged-commit dry run fails, fix forward with a new PR and repeat the
+final dry runs. Do not create the release tag first.
+
+If one registry publishes and the other fails, keep the tag unchanged. For a
+transient failure or corrected environment/secret, rerun the failed jobs or
+dispatch only the failed workflow from the existing tag with `dry_run=false`,
+as documented in `docs/RELEASING.md`. A workflow dispatch from the old tag does
+not consume workflow-code fixes merged later. If workflow code or package
+source must change, merge the fix, choose a new version, and publish both
+targets from a new immutable tag; record the old version as partially
+published. Never move the old tag to pick up a fix.
+
+## 5. Verify and report
+
+Verify the exact version through the PyPI JSON API and `npm view`. For npm,
+stable versions must be on `latest` and prereleases must be on `next`. Run the
+clean-install smoke tests from `docs/RELEASING.md` when practical.
+
+Return a compact release summary containing:
+
+- version and tag;
+- release PR;
+- PyPI and npm workflow runs;
+- PyPI and npm package URLs;
+- verification status or the single concrete blocker.

--- a/.claude/skills/version-upgrade/agents/openai.yaml
+++ b/.claude/skills/version-upgrade/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Version Upgrade"
+  short_description: "Bump and publish Rustwright releases"
+  default_prompt: "Use $version-upgrade to prepare the next Rustwright version and publish it only if I explicitly request a full release."

--- a/.claude/skills/version-upgrade/scripts/bump_version.py
+++ b/.claude/skills/version-upgrade/scripts/bump_version.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Update and verify Rustwright's shared package version."""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+
+ROOT = Path(__file__).resolve().parents[4]
+SEMVER = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:alpha|beta|rc)\.(?:0|[1-9]\d*)))?$"
+)
+SOURCE_FILES = {
+    "pyproject.toml": (ROOT / "pyproject.toml", "project"),
+    "Cargo.toml": (ROOT / "Cargo.toml", "package"),
+    "node/Cargo.toml": (ROOT / "node/Cargo.toml", "package"),
+}
+RUNTIME_VERSION_FIELDS = (
+    (
+        "python/rustwright/sync_api.py HAR creator",
+        ROOT / "python/rustwright/sync_api.py",
+        re.compile(
+            r'("creator"\s*:\s*\{\s*"name"\s*:\s*"Rustwright"\s*,\s*'
+            r'"version"\s*:\s*")([^"]+)(")'
+        ),
+    ),
+    (
+        "python/rustwright/sync_api.py trace metadata",
+        ROOT / "python/rustwright/sync_api.py",
+        re.compile(r'("playwrightVersion"\s*:\s*"rustwright-)([^"]+)(")'),
+    ),
+    (
+        "python/rustwright/cli.py source fallback",
+        ROOT / "python/rustwright/cli.py",
+        re.compile(
+            r'(except metadata\.PackageNotFoundError:\s*\n\s*return ")([^"]+)(")'
+        ),
+    ),
+    (
+        "python/rustwright/_backend.py source fallback",
+        ROOT / "python/rustwright/_backend.py",
+        re.compile(
+            r'(except metadata\.PackageNotFoundError:\s*\n\s*return ")([^"]+)(\+local")'
+        ),
+    ),
+)
+
+
+def parse_version(value: str) -> Tuple[int, int, int, Tuple[str, ...]]:
+    match = SEMVER.fullmatch(value)
+    if not match:
+        raise ValueError(
+            f"{value!r} is not a supported release version; expected "
+            "MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-(alpha|beta|rc).N"
+        )
+    prerelease = tuple(match.group(4).split(".")) if match.group(4) else ()
+    for identifier in prerelease:
+        if identifier.isdigit() and len(identifier) > 1 and identifier.startswith("0"):
+            raise ValueError(f"numeric prerelease identifier has a leading zero: {value!r}")
+    return int(match.group(1)), int(match.group(2)), int(match.group(3)), prerelease
+
+
+def compare_versions(left: str, right: str) -> int:
+    left_version = parse_version(left)
+    right_version = parse_version(right)
+    left_core, right_core = left_version[:3], right_version[:3]
+    if left_core != right_core:
+        return (left_core > right_core) - (left_core < right_core)
+
+    left_pre, right_pre = left_version[3], right_version[3]
+    if not left_pre or not right_pre:
+        return (not left_pre) - (not right_pre)
+    for left_id, right_id in zip(left_pre, right_pre):
+        if left_id == right_id:
+            continue
+        left_numeric, right_numeric = left_id.isdigit(), right_id.isdigit()
+        if left_numeric and right_numeric:
+            return (int(left_id) > int(right_id)) - (int(left_id) < int(right_id))
+        if left_numeric != right_numeric:
+            return -1 if left_numeric else 1
+        return (left_id > right_id) - (left_id < right_id)
+    return (len(left_pre) > len(right_pre)) - (len(left_pre) < len(right_pre))
+
+
+def next_version(current: str) -> str:
+    major, minor, patch, prerelease = parse_version(current)
+    if not prerelease:
+        return f"{major}.{minor}.{patch + 1}"
+    if prerelease[-1].isdigit():
+        bumped = (*prerelease[:-1], str(int(prerelease[-1]) + 1))
+    else:
+        bumped = (*prerelease, "1")
+    return f"{major}.{minor}.{patch}-{'.'.join(bumped)}"
+
+
+def toml_version(path: Path, section: str) -> str:
+    current_section = None  # type: Optional[str]
+    versions = []
+    for line in path.read_text().splitlines():
+        section_match = re.match(r"^\s*\[([^]]+)]\s*(?:#.*)?$", line)
+        if section_match:
+            current_section = section_match.group(1)
+            continue
+        if current_section != section:
+            continue
+        version_match = re.match(
+            r'^\s*version\s*=\s*["\']([^"\']+)["\']\s*(?:#.*)?$', line
+        )
+        if version_match:
+            versions.append(version_match.group(1))
+    if len(versions) != 1:
+        raise RuntimeError(
+            f"expected one version in [{section}] of {path.relative_to(ROOT)}, "
+            f"found {len(versions)}"
+        )
+    return versions[0]
+
+
+def source_versions() -> Dict[str, str]:
+    versions = {
+        label: toml_version(path, section)
+        for label, (path, section) in SOURCE_FILES.items()
+    }
+    versions["node/package.json"] = json.loads(
+        (ROOT / "node/package.json").read_text()
+    )["version"]
+    for label, path, pattern in RUNTIME_VERSION_FIELDS:
+        runtime_versions = pattern.findall(path.read_text())
+        if len(runtime_versions) != 1:
+            raise RuntimeError(
+                f"expected one {label}, found {len(runtime_versions)}"
+            )
+        versions[label] = runtime_versions[0][1]
+    return versions
+
+
+def replace_toml_version(path: Path, section: str, version: str) -> None:
+    lines = path.read_text().splitlines(keepends=True)
+    current_section = None  # type: Optional[str]
+    replacements = 0
+    for index, line in enumerate(lines):
+        section_match = re.match(r"^\s*\[([^]]+)]\s*(?:#.*)?$", line)
+        if section_match:
+            current_section = section_match.group(1)
+            continue
+        if current_section != section:
+            continue
+        version_match = re.match(
+            r'^(\s*version\s*=\s*)["\'][^"\']+["\'](\s*(?:#.*)?(?:\n)?)$', line
+        )
+        if version_match:
+            lines[index] = f'{version_match.group(1)}"{version}"{version_match.group(2)}'
+            replacements += 1
+    if replacements != 1:
+        raise RuntimeError(
+            f"expected one version in [{section}] of {path.relative_to(ROOT)}, "
+            f"found {replacements}"
+        )
+    path.write_text("".join(lines))
+
+
+def replace_json_version(path: Path, version: str) -> None:
+    data = json.loads(path.read_text())
+    data["version"] = version
+    path.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+
+
+def replace_runtime_version(version: str) -> None:
+    updated_files = {}  # type: Dict[Path, str]
+    for label, path, pattern in RUNTIME_VERSION_FIELDS:
+        text = updated_files.get(path, path.read_text())
+        updated, replacements = pattern.subn(
+            lambda match: f"{match.group(1)}{version}{match.group(3)}", text
+        )
+        if replacements != 1:
+            raise RuntimeError(f"expected one {label}, found {replacements}")
+        updated_files[path] = updated
+    for path, text in updated_files.items():
+        path.write_text(text)
+
+
+def lock_versions() -> Dict[str, str]:
+    selected = {}  # type: Dict[str, str]
+    package = {}  # type: Dict[str, str]
+    for line in (ROOT / "Cargo.lock").read_text().splitlines():
+        if line.strip() == "[[package]]":
+            if package.get("name") in {"rustwright-core", "rustwright-node"}:
+                selected[package["name"]] = package.get("version", "")
+            package = {}
+            continue
+        field_match = re.match(r'^(name|version) = "([^"]+)"$', line)
+        if field_match:
+            package[field_match.group(1)] = field_match.group(2)
+    if package.get("name") in {"rustwright-core", "rustwright-node"}:
+        selected[package["name"]] = package.get("version", "")
+    if set(selected) != {"rustwright-core", "rustwright-node"}:
+        raise RuntimeError(f"missing Rustwright packages in Cargo.lock: {selected}")
+
+    node_lock = json.loads((ROOT / "node/package-lock.json").read_text())
+    return {
+        "Cargo.lock rustwright-core": selected["rustwright-core"],
+        "Cargo.lock rustwright-node": selected["rustwright-node"],
+        "node/package-lock.json": node_lock["version"],
+        'node/package-lock.json packages[""]': node_lock["packages"][""]["version"],
+    }
+
+
+def require_one_version(
+    versions: Dict[str, str], expected: Optional[str] = None
+) -> str:
+    unique = set(versions.values())
+    if len(unique) != 1:
+        details = ", ".join(f"{name}={value}" for name, value in versions.items())
+        raise RuntimeError(f"package versions do not match: {details}")
+    actual = next(iter(unique))
+    parse_version(actual)
+    if expected is not None and actual != expected:
+        raise RuntimeError(f"expected version {expected}, found {actual}")
+    return actual
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", nargs="?", help="target SemVer; defaults to next version")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify manifests and lockfiles without changing files",
+    )
+    args = parser.parse_args()
+
+    try:
+        current = require_one_version(source_versions())
+        if args.check:
+            target = args.version or current
+            parse_version(target)
+            require_one_version({**source_versions(), **lock_versions()}, target)
+            print(f"Validated Rustwright version {target} in all manifests and lockfiles")
+            return 0
+
+        target = args.version or next_version(current)
+        parse_version(target)
+        if compare_versions(target, current) <= 0:
+            raise ValueError(f"target version {target} must be newer than {current}")
+
+        for path, section in SOURCE_FILES.values():
+            replace_toml_version(path, section, target)
+        replace_json_version(ROOT / "node/package.json", target)
+        replace_runtime_version(target)
+        require_one_version(source_versions(), target)
+        print(f"Updated Rustwright source manifests from {current} to {target}")
+        print("Regenerate Cargo.lock and node/package-lock.json before --check")
+        return 0
+    except (KeyError, OSError, RuntimeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,6 +2,14 @@
 
 This guide is for the release owner.
 
+## Agent-assisted release
+
+Use `/version-upgrade <version> prepare` to create and validate a release PR
+without publishing. Use `/version-upgrade <version> full release` only when the
+agent should merge the prepared release, run final dry runs on the merged
+commit, tag it, and publish to both PyPI and npm. The skill is defined in
+`.claude/skills/version-upgrade/SKILL.md`.
+
 ## One-time setup
 
 - [ ] Confirm the `rustwright` name is still available on both PyPI and npm. A name is not reserved until the first successful publish.
@@ -28,6 +36,11 @@ No crates.io settings or token are currently required. Do not publish `rustwrigh
   - `Cargo.toml` → `[package].version` for `rustwright-core`
   - `node/Cargo.toml` → `[package].version` for `rustwright-node`
   - `node/package.json` → `version`
+- [ ] Set the same string in the shipped runtime metadata:
+  - `python/rustwright/sync_api.py` → Rustwright creator `version` in `_write_har`
+  - `python/rustwright/sync_api.py` → `playwrightVersion` in `_write_trace_zip`
+  - `python/rustwright/cli.py` → source-checkout fallback in `_version`
+  - `python/rustwright/_backend.py` → source-checkout fallback in `_version` (before `+local`)
 - [ ] Regenerate the lockfiles; do not edit generated entries by hand:
 
   ```bash
@@ -36,7 +49,7 @@ No crates.io settings or token are currently required. Do not publish `rustwrigh
   ```
 
 - [ ] Confirm `Cargo.lock` now has the same version for `rustwright-core` and `rustwright-node`, and `node/package-lock.json` has it in both top-level version fields.
-- [ ] Confirm all six files are staged: `pyproject.toml`, `Cargo.toml`, `node/Cargo.toml`, `node/package.json`, `Cargo.lock`, and `node/package-lock.json`.
+- [ ] Confirm all nine files are staged: `pyproject.toml`, `Cargo.toml`, `node/Cargo.toml`, `node/package.json`, `python/rustwright/sync_api.py`, `python/rustwright/cli.py`, `python/rustwright/_backend.py`, `Cargo.lock`, and `node/package-lock.json`.
 - [ ] Run local release checks:
 
   ```bash
@@ -45,7 +58,7 @@ No crates.io settings or token are currently required. Do not publish `rustwrigh
   (cd node && npm ci --ignore-scripts && npm run build && npm run smoke)
   ```
 
-The four source manifests and both lockfiles are all `0.1.0` today; there is no current version mismatch. The source `node/package.json` intentionally remains `"private": true`; the npm workflow removes that field only in its temporary assembled package.
+Before tagging, the four source manifests, shipped runtime metadata, and both lockfiles must have one matching version. The source `node/package.json` intentionally remains `"private": true`; the npm workflow removes that field only in its temporary assembled package.
 
 ## Dry run
 


### PR DESCRIPTION
## Summary
- add a `/version-upgrade` skill that prepares or explicitly publishes one Rustwright version to PyPI and npm
- add a deterministic helper that updates and validates all manifests, lockfiles, and shipped runtime metadata
- document agent-assisted release modes and preserve explicit approval for irreversible publication

The PyPI and npm release workflows already existed; this skill orchestrates their dry-run, tag, publish, recovery, and verification paths.

## Test plan
- [x] validate the skill structure with `quick_validate.py`
- [x] verify the current `0.1.0` metadata across manifests, lockfiles, HAR, trace, CLI, and backend fallbacks
- [x] exercise a temporary `0.1.1` bump and confirm every source field updates
- [x] test stable and alpha/beta/rc version parsing and rejection of incompatible prerelease forms
- [x] run the repository adversarial review on the exact outgoing commit
