### PR TITLE
Add form-fill benchmark harness (rustwright vs Playwright)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,3 +32,9 @@ data/WebVoyager_data.jsonl
 data/GAIA_web.jsonl
 data/reference_answer.json
 benchmarks/external
+benchmarks/form_fill/out
+benchmarks/form_fill/.venv
+benchmarks/form_fill/venv
+benchmarks/form_fill/__pycache__
+benchmarks/form_fill/.env
+benchmarks/form_fill/artifacts

--- a/benchmarks/form_fill/.gitattributes
+++ b/benchmarks/form_fill/.gitattributes
@@ -1,0 +1,1 @@
+assets/*.pdf binary

--- a/benchmarks/form_fill/.gitignore
+++ b/benchmarks/form_fill/.gitignore
@@ -1,0 +1,7 @@
+out/
+.venv/
+venv/
+__pycache__/
+*.py[cod]
+.env
+artifacts/

--- a/benchmarks/form_fill/Dockerfile.record
+++ b/benchmarks/form_fill/Dockerfile.record
@@ -1,0 +1,15 @@
+ARG RUSTWRIGHT_BASE_IMAGE=rustwright-form-fill-base:latest
+FROM ${RUSTWRIGHT_BASE_IMAGE}
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        x11-utils \
+        xvfb \
+    && rm -rf /var/lib/apt/lists/* \
+    && python -m pip install --no-cache-dir "matplotlib>=3.9,<4"
+
+# Keep benchmark-only edits on a cheap layer while still inheriting the
+# repository image's built Rustwright package and browser installation.
+COPY benchmarks/form_fill /workspace/benchmarks/form_fill

--- a/benchmarks/form_fill/README.md
+++ b/benchmarks/form_fill/README.md
@@ -1,0 +1,178 @@
+# Form-fill benchmark
+
+> **Responsible use is a requirement.** This workload fills a real job
+> application with dummy data and never submits it by design. Only target a
+> posting you have a legitimate reason and permission to test, respect the
+> site's terms of service and rate limits, and never remove or weaken the
+> no-submit guardrail.
+
+This demo runs one backend-switchable Python workload through reference
+Playwright and Rustwright. It scrolls to each configured field, highlights the
+control, enters dummy applicant data, captures a screenshot, validates the
+retained value, and writes `timeline.json` plus `timings.json`. The target is
+always supplied through the required `BENCH_JOB_URL` environment variable.
+
+The checked-in `field_map.example.json` is a declarative map written for one
+specific Greenhouse posting. Its custom question selectors will not be
+portable to every posting. Copy and adapt the map for the authorized target
+instead of adding a target URL to the workload. Keep submit controls out of the
+field list. Controls whose options require live search requests are marked
+`network_dependent` and skipped because the actual fill phase runs offline.
+Omit that flag only for controls whose options are already available offline.
+
+## Safety guardrail
+
+Before filling anything, the workload finds the configured submit controls,
+intercepts both submit events and programmatic form submission before page
+scripts run, disables service workers, and installs a browser-context route
+that aborts every state-changing HTTP method during startup. Browser-level
+WebSocket routing intercepts new sockets without connecting them to a network
+peer, while pre-document guards disable page and worker constructors for
+WebSocket, WebTransport, EventSource, WebRTC, and dedicated/shared workers. As
+soon as the form reaches its ready selector, the
+browser context is forced offline for the entire fill and validation phase. It
+then disables the visible submit controls.
+At the end it verifies that the page did not navigate, no submission was
+attempted, all submit controls remain guarded, and no submission-confirmation
+text appeared. The workload contains no action that clicks a submit control.
+Reports include only the number of network requests blocked by the startup
+interlock, never their URLs.
+
+File fixtures are passed to the browser with `set_input_files`. If the site
+tries to upload a selected file immediately, the network interlock blocks that
+request; the benchmark never waits for or asserts a server-side upload. Some
+sites clear their file widget after that blocked request, which is allowed only
+for file-field highlight cleanup and is visible in the captured screenshot.
+
+These checks are defense in depth, not permission to target arbitrary sites.
+
+## What is measured
+
+Each Docker run emits two 10 Hz memory series:
+
+- `stack_pss.csv` sums proportional set size (PSS) for the workload Python
+  process and its descendant driver/browser processes. This avoids
+  double-counting shared pages and is categorized as the benchmark stack.
+- `cgroup.csv` and `cgroup_memory_peak_bytes.txt` cover the whole capped
+  container, including harness and recording overhead. The kernel peak can
+  capture spikes between sampled points.
+
+`epochs.json` aligns sampler, workload, and optional ffmpeg timestamps.
+`timeline.json` separates launch, browser/network navigation, scripted pauses,
+and actions. Rendered charts shade browser-time and scripted-pause bands so
+they are not mistaken for library execution time.
+
+Remote CDP runs only measure the local client/driver container. The remote
+browser is outside both local PSS and cgroup scope, so remote memory is not an
+end-to-end browser-memory comparison.
+
+## Fairness protocol
+
+For an A/B comparison:
+
+1. Build one repository image and derive the recording image from it.
+2. Run the exact same `fill_form.py` and field map for both backends.
+3. Keep the container memory, swap, CPU, shared-memory cap, viewport, target,
+   pauses, and run order fixed.
+4. Set `BENCH_CHROMIUM_EXECUTABLE` to one executable for both backends. The
+   Docker harness defaults both to the Rustwright image's Chromium symlink.
+5. Run variants sequentially, repeat enough times, and report failures as
+   failures rather than dropping them from the sample.
+6. Treat local results as diagnostics. Per the repository's
+   [`BENCHMARK.md`](../../BENCHMARK.md), durable claims must be reproduced in
+   capped, sharded Docker workloads on the Testbox path with provenance.
+
+Recording adds Xvfb and ffmpeg overhead. Compare recorded runs with recorded
+runs, and non-recorded runs with non-recorded runs.
+
+## Build the Docker images
+
+From the repository root:
+
+```bash
+benchmarks/form_fill/harness/build_images.sh
+```
+
+The first build uses the repository's root `Dockerfile` and tags its result as
+`rustwright-form-fill-base:latest`. `Dockerfile.record` then uses that image as
+its `FROM` base and adds Xvfb plus the plotting dependency. Override the tags
+with `FORM_FILL_BASE_IMAGE` and `FORM_FILL_RECORD_IMAGE` if needed.
+
+## Run the capped local Docker comparison
+
+```bash
+export BENCH_JOB_URL="https://job-board.example/jobs/authorized-test-target"
+benchmarks/form_fill/harness/run_pair.sh
+```
+
+Artifacts are written under the ignored `benchmarks/form_fill/out/` directory.
+Defaults are an 8 GiB memory/swap cap, 4 CPUs, and 1 GiB shared memory; use
+`BENCH_MEMORY_LIMIT`, `BENCH_CPUS`, and `BENCH_SHM_SIZE` to change them for all
+variants. Use `BENCH_FIELD_CONFIG_HOST=/path/to/field-map.json` for an adapted
+map. `BENCH_PAUSE_SCALE=0` is useful for a quick smoke test, but must be held
+constant across comparisons.
+
+To run one variant:
+
+```bash
+benchmarks/form_fill/harness/run_one.sh rustwright rustwright-smoke
+```
+
+## Record and render
+
+```bash
+benchmarks/form_fill/harness/record_one.sh playwright playwright-record
+benchmarks/form_fill/harness/record_one.sh rustwright rustwright-record
+benchmarks/form_fill/harness/render.sh
+```
+
+The renderer writes two synchronized animated PSS videos, a PSS/cgroup
+comparison chart, and demo-grade statistics under `out/rendered/`. Videos,
+screenshots, CSVs, logs, and generated reports are intentionally ignored.
+
+## Run directly on the host
+
+Create an isolated environment, install this checkout and the reference
+Playwright package, install a compatible Chromium, then run:
+
+```bash
+python -m venv benchmarks/form_fill/.venv
+source benchmarks/form_fill/.venv/bin/activate
+python -m pip install -e . "playwright==1.59.0"
+python -m playwright install chromium
+
+BACKEND=rustwright \
+BENCH_JOB_URL="https://job-board.example/jobs/authorized-test-target" \
+python benchmarks/form_fill/fill_form.py
+
+BACKEND=playwright \
+BENCH_JOB_URL="https://job-board.example/jobs/authorized-test-target" \
+python benchmarks/form_fill/fill_form.py
+```
+
+Set `BENCH_CHROMIUM_EXECUTABLE` to the same browser binary for both commands.
+Host runs are convenient for development but are not durable benchmark
+evidence.
+
+## Connect to a remote browser over CDP
+
+Any provider-neutral Chrome DevTools Protocol WebSocket URL works; the code
+sends no provider-specific headers and makes no provider API calls:
+
+```bash
+export BENCH_JOB_URL="https://job-board.example/jobs/authorized-test-target"
+export CDP_URL="wss://cdp-provider.example/session"
+benchmarks/form_fill/harness/run_remote.sh rustwright rustwright-remote
+```
+
+For a direct host run, `fill_form_remote.py` is an explicit wrapper around the
+same workload and requires both `BENCH_JOB_URL` and `CDP_URL`.
+
+The endpoint must permit creation of a dedicated browser context. The workload
+fails closed if it cannot create one; it never reuses, takes offline, or closes
+a provider-owned context.
+
+Remote uploads are skipped by default because provider file-transfer behavior
+varies. Set `BENCH_SKIP_UPLOADS=0` when the endpoint supports local file upload.
+A Skyvern browser session is one public way to obtain a CDP URL, but session
+creation and credentials are deliberately outside this benchmark.

--- a/benchmarks/form_fill/assets/cover-letter.pdf
+++ b/benchmarks/form_fill/assets/cover-letter.pdf
@@ -1,0 +1,33 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 82 >>
+stream
+BT /F1 18 Tf 72 720 Td (Alex Testerson Cover Letter - Benchmark Dummy Data) Tj ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+448
+%%EOF

--- a/benchmarks/form_fill/assets/resume.pdf
+++ b/benchmarks/form_fill/assets/resume.pdf
@@ -1,0 +1,33 @@
+%PDF-1.4
+%‚„œ”
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 76 >>
+stream
+BT /F1 18 Tf 72 720 Td (Alex Testerson Resume - Benchmark Dummy Data) Tj ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000015 00000 n 
+0000000064 00000 n 
+0000000121 00000 n 
+0000000247 00000 n 
+0000000317 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+442
+%%EOF

--- a/benchmarks/form_fill/field_map.example.json
+++ b/benchmarks/form_fill/field_map.example.json
@@ -1,0 +1,187 @@
+{
+  "version": 1,
+  "description": "Example selectors captured from one specific Greenhouse posting. Adapt this map to the posting you are authorized to test.",
+  "ready_selector": "input#first_name",
+  "submit_selector": "button[type=submit], input[type=submit]",
+  "fields": [
+    {
+      "label": "First Name",
+      "slug": "first_name",
+      "kind": "text",
+      "selector": "#first_name",
+      "value": "Alex"
+    },
+    {
+      "label": "Last Name",
+      "slug": "last_name",
+      "kind": "text",
+      "selector": "#last_name",
+      "value": "Testerson"
+    },
+    {
+      "label": "Preferred First Name",
+      "slug": "preferred_name",
+      "kind": "text",
+      "selector": "#preferred_name",
+      "value": "Alex"
+    },
+    {
+      "label": "Email",
+      "slug": "email",
+      "kind": "text",
+      "selector": "#email",
+      "value": "alex.testerson@example.com"
+    },
+    {
+      "label": "Country",
+      "slug": "country",
+      "kind": "combobox",
+      "network_dependent": true,
+      "selector": "#country",
+      "visual": ".select__control:has(#country)",
+      "value": "United States",
+      "selected_text": "+1"
+    },
+    {
+      "label": "Phone",
+      "slug": "phone",
+      "kind": "text",
+      "selector": "#phone",
+      "value": "(555) 010-4477"
+    },
+    {
+      "label": "Resume",
+      "slug": "resume",
+      "kind": "file",
+      "selector": "#resume",
+      "visual": ".file-upload",
+      "visual_index": 0,
+      "asset": "assets/resume.pdf"
+    },
+    {
+      "label": "Cover Letter",
+      "slug": "cover_letter",
+      "kind": "file",
+      "selector": "#cover_letter",
+      "visual": ".file-upload",
+      "visual_index": 1,
+      "asset": "assets/cover-letter.pdf"
+    },
+    {
+      "label": "School",
+      "slug": "school",
+      "kind": "combobox",
+      "network_dependent": true,
+      "selector": "#school--0",
+      "visual": ".select__control:has(#school--0)",
+      "value": "Aalborg University"
+    },
+    {
+      "label": "Degree",
+      "slug": "degree",
+      "kind": "combobox",
+      "network_dependent": true,
+      "selector": "#degree--0",
+      "visual": ".select__control:has(#degree--0)",
+      "value": "Bachelor's Degree"
+    },
+    {
+      "label": "Location",
+      "slug": "location",
+      "kind": "text",
+      "selector": "#question_31369421003",
+      "value": "Baltimore, MD"
+    },
+    {
+      "label": "LinkedIn Profile",
+      "slug": "linkedin_profile",
+      "kind": "text",
+      "selector": "#question_31369422003",
+      "value": "https://www.linkedin.com/in/alex-testerson-benchmark"
+    },
+    {
+      "label": "How did you hear about this open position?",
+      "slug": "referral_source",
+      "kind": "combobox",
+      "network_dependent": true,
+      "selector": "#question_31369423003",
+      "visual": ".select__control:has(#question_31369423003)",
+      "value": "LinkedIn"
+    },
+    {
+      "label": "When are you looking to start a new position?",
+      "slug": "start_date",
+      "kind": "text",
+      "selector": "#question_31369424003",
+      "value": "Within four weeks"
+    },
+    {
+      "label": "Target hourly rate",
+      "slug": "hourly_rate",
+      "kind": "text",
+      "selector": "#question_31369425003",
+      "value": "$75/hour"
+    },
+    {
+      "label": "Authorized to work in the United States?",
+      "slug": "work_authorization",
+      "kind": "combobox",
+      "network_dependent": true,
+      "selector": "#question_31369426003",
+      "visual": ".select__control:has(#question_31369426003)",
+      "value": "Yes"
+    },
+    {
+      "label": "Require employment visa sponsorship?",
+      "slug": "visa_sponsorship",
+      "kind": "combobox",
+      "network_dependent": true,
+      "selector": "#question_31369427003",
+      "visual": ".select__control:has(#question_31369427003)",
+      "value": "No"
+    },
+    {
+      "label": "Additional information for consideration?",
+      "slug": "additional_information",
+      "kind": "text",
+      "selector": "#question_31369428003",
+      "value": "Available for interviews on weekday afternoons. This is benchmark-only dummy data."
+    },
+    {
+      "label": "Gender",
+      "slug": "gender",
+      "kind": "combobox",
+      "network_dependent": true,
+      "selector": "#gender",
+      "visual": ".select__control:has(#gender)",
+      "value": "Decline To Self Identify"
+    },
+    {
+      "label": "Are you Hispanic/Latino?",
+      "slug": "hispanic_ethnicity",
+      "kind": "combobox",
+      "network_dependent": true,
+      "selector": "#hispanic_ethnicity",
+      "visual": ".select__control:has(#hispanic_ethnicity)",
+      "value": "Decline To Self Identify"
+    },
+    {
+      "label": "Veteran Status",
+      "slug": "veteran_status",
+      "kind": "combobox",
+      "network_dependent": true,
+      "selector": "#veteran_status",
+      "visual": ".select__control:has(#veteran_status)",
+      "value": "I don't wish to answer"
+    },
+    {
+      "label": "Disability Status",
+      "slug": "disability_status",
+      "kind": "combobox",
+      "network_dependent": true,
+      "selector": "#disability_status",
+      "visual": ".select__control:has(#disability_status)",
+      "value": "I do not want to answer"
+    }
+  ]
+}

--- a/benchmarks/form_fill/fill_form.py
+++ b/benchmarks/form_fill/fill_form.py
@@ -1,0 +1,467 @@
+#!/usr/bin/env python3
+"""Run the same guarded form-fill choreography with Playwright or Rustwright."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+DEFAULT_CONFIG = SCRIPT_DIR / "field_map.example.json"
+HIGHLIGHT_JS = """element => {
+    element.__formFillBenchmarkStyles = [
+        element.style.outline,
+        element.style.outlineOffset,
+        element.style.boxShadow,
+    ];
+    element.style.outline = '3px solid #ff3b30';
+    element.style.outlineOffset = '2px';
+    element.style.boxShadow = '0 0 0 4px rgba(255,59,48,.25)';
+}"""
+RESTORE_HIGHLIGHT_JS = """element => {
+    const saved = element.__formFillBenchmarkStyles || ['', '', ''];
+    element.style.outline = saved[0];
+    element.style.outlineOffset = saved[1];
+    element.style.boxShadow = saved[2];
+    delete element.__formFillBenchmarkStyles;
+}"""
+INIT_SUBMIT_GUARD_JS = """(() => {
+    const state = {
+        attempted: false,
+        selector: null,
+        blockedPersistentTransports: 0,
+    };
+    Object.defineProperty(window, '__formFillBenchmarkSubmitGuard', {
+        configurable: false,
+        writable: false,
+        value: state,
+    });
+    const block = event => {
+        state.attempted = true;
+        event.preventDefault();
+        event.stopImmediatePropagation();
+    };
+    document.addEventListener('submit', block, true);
+    const prototype = HTMLFormElement.prototype;
+    for (const method of ['submit', 'requestSubmit']) {
+        Object.defineProperty(prototype, method, {
+            configurable: false,
+            writable: false,
+            value: function guardedSubmission() {
+                state.attempted = true;
+                throw new Error('Form submission is disabled by the benchmark guard');
+            },
+        });
+    }
+    if ('ServiceWorkerContainer' in window) {
+        Object.defineProperty(ServiceWorkerContainer.prototype, 'register', {
+            configurable: false,
+            writable: false,
+            value: function blockedServiceWorkerRegistration() {
+                return Promise.reject(
+                    new Error('Service workers are disabled by the benchmark guard')
+                );
+            },
+        });
+    }
+    const blockedTransport = name => class BlockedPersistentTransport {
+        constructor() {
+            state.blockedPersistentTransports += 1;
+            throw new DOMException(
+                `${name} is disabled by the benchmark guard`,
+                'SecurityError'
+            );
+        }
+    };
+    for (const name of [
+        'WebSocket',
+        'WebTransport',
+        'EventSource',
+        'RTCPeerConnection',
+        'webkitRTCPeerConnection',
+        'Worker',
+        'SharedWorker',
+    ]) {
+        if (name in window) {
+            Object.defineProperty(window, name, {
+                configurable: false,
+                writable: false,
+                value: blockedTransport(name),
+            });
+        }
+    }
+})();"""
+DISABLE_SUBMIT_CONTROLS_JS = """selector => {
+    const state = window.__formFillBenchmarkSubmitGuard;
+    if (!state) {
+        throw new Error('Pre-document form submission guard is not installed');
+    }
+    state.selector = selector;
+    const controls = Array.from(document.querySelectorAll(selector));
+    for (const control of controls) {
+        control.disabled = true;
+        control.setAttribute('data-form-fill-benchmark-guarded', 'true');
+    }
+    return controls.length;
+}"""
+READ_SUBMIT_GUARD_JS = """selector => {
+    const state = window.__formFillBenchmarkSubmitGuard;
+    const controls = Array.from(document.querySelectorAll(selector));
+    return {
+        installed: Boolean(state),
+        attempted: Boolean(state && state.attempted),
+        blockedPersistentTransports: state ? state.blockedPersistentTransports : 0,
+        controlCount: controls.length,
+        guardedCount: controls.filter(control =>
+            control.disabled &&
+            control.getAttribute('data-form-fill-benchmark-guarded') === 'true'
+        ).length,
+    };
+}"""
+
+
+def required_environment(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise ValueError(f"{name} is required")
+    return value
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if payload.get("version") != 1:
+        raise ValueError(f"Unsupported field-map version in {path}")
+    if not payload.get("ready_selector") or not payload.get("submit_selector"):
+        raise ValueError("The field map requires ready_selector and submit_selector")
+    fields = payload.get("fields")
+    if not isinstance(fields, list) or not fields:
+        raise ValueError("The field map must contain at least one field")
+    slugs: set[str] = set()
+    for field in fields:
+        required = {"label", "slug", "kind", "selector"}
+        missing = required.difference(field)
+        if missing:
+            raise ValueError(f"Field is missing keys {sorted(missing)}: {field!r}")
+        if field["kind"] not in {"text", "combobox", "file"}:
+            raise ValueError(f"Unsupported field kind: {field['kind']!r}")
+        if field["slug"] in slugs:
+            raise ValueError(f"Duplicate field slug: {field['slug']!r}")
+        slugs.add(field["slug"])
+        if field["kind"] == "file":
+            if "asset" not in field:
+                raise ValueError(f"File field is incomplete: {field['label']!r}")
+        elif "value" not in field:
+            raise ValueError(f"Field has no value: {field['label']!r}")
+    return payload
+
+
+def visual_locator(page: Any, field: dict[str, Any]) -> Any:
+    locator = page.locator(field.get("visual", field["selector"]))
+    if "visual_index" in field:
+        locator = locator.nth(int(field["visual_index"]))
+    return locator
+
+
+def perform_action(
+    page: Any,
+    field: dict[str, Any],
+    config_dir: Path,
+) -> None:
+    control = page.locator(field["selector"])
+    if field["kind"] == "text":
+        control.fill(field["value"])
+        actual = control.evaluate("element => element.value")
+        if actual != field["value"]:
+            raise AssertionError(
+                f"{field['label']} did not retain its value: {actual!r}"
+            )
+        return
+
+    if field["kind"] == "file":
+        asset_root = (config_dir / "assets").resolve()
+        if asset_root.parent != config_dir.resolve():
+            raise ValueError("assets directory must not escape the field-map directory")
+        asset = (config_dir / field["asset"]).resolve()
+        if asset.parent != asset_root:
+            raise ValueError(
+                f"{field['label']} asset must be a direct child of {asset_root}"
+            )
+        if asset.suffix.lower() != ".pdf":
+            raise ValueError(f"{field['label']} asset must be a PDF fixture")
+        if not asset.is_file():
+            raise FileNotFoundError(f"Missing upload asset for {field['label']}: {asset}")
+        if asset.stat().st_size > 1024 * 1024:
+            raise ValueError(f"{field['label']} asset exceeds the 1 MiB fixture limit")
+        control.set_input_files(str(asset))
+        # Some forms immediately replace the input after attempting an upload.
+        # The context route blocks that request, so successful API completion is
+        # the strongest safe assertion available without allowing data to leave.
+        return
+
+    control.click()
+    control.type(field["value"])
+    option = page.locator("[role=option]").first
+    option_text = option.evaluate(
+        "element => (element.innerText || element.textContent || '').trim()"
+    )
+    if field["value"].lower() not in option_text.lower():
+        raise AssertionError(
+            f"{field['label']} first option was {option_text!r}, "
+            f"expected {field['value']!r}"
+        )
+    option.click()
+    selected_text = visual_locator(page, field).evaluate(
+        "element => (element.innerText || element.textContent || '').trim()"
+    )
+    expected = field.get("selected_text", field["value"])
+    if expected.lower() not in selected_text.lower():
+        raise AssertionError(
+            f"{field['label']} did not retain selection {expected!r}: "
+            f"{selected_text!r}"
+        )
+
+
+def make_remote_context(browser: Any) -> Any:
+    try:
+        return browser.new_context(
+            viewport={"width": 400, "height": 600}, service_workers="block"
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            "The remote CDP endpoint must allow a dedicated browser context; "
+            "the benchmark will not reuse or mutate a provider-owned context"
+        ) from exc
+
+
+def install_network_guard(context: Any) -> tuple[list[str], list[str]]:
+    """Block state changes and persistent transports below page JavaScript."""
+    blocked_methods: list[str] = []
+    blocked_websockets: list[str] = []
+
+    def guard(route: Any) -> None:
+        method = route.request.method.upper()
+        if method in {"GET", "HEAD", "OPTIONS"}:
+            route.continue_()
+            return
+        blocked_methods.append(method)
+        route.abort("blockedbyclient")
+
+    context.route("**/*", guard)
+
+    def guard_websocket(route: Any) -> None:
+        # A routed WebSocket has no network peer unless the handler calls
+        # connect_to_server(). Leaving it disconnected avoids the synchronous
+        # close-in-callback deadlock seen in some Playwright/Chromium pairs.
+        blocked_websockets.append("websocket")
+
+    context.route_web_socket("**/*", guard_websocket)
+    return blocked_methods, blocked_websockets
+
+
+def main() -> None:
+    backend = os.environ.get("BACKEND", "playwright")
+    if backend not in {"playwright", "rustwright"}:
+        raise ValueError("BACKEND must be playwright or rustwright")
+    if backend == "rustwright":
+        from rustwright.sync_api import sync_playwright
+    else:
+        from playwright.sync_api import sync_playwright
+
+    job_url = required_environment("BENCH_JOB_URL")
+    config_path = Path(os.environ.get("BENCH_FIELD_CONFIG", DEFAULT_CONFIG)).resolve()
+    config = load_config(config_path)
+    output_dir = Path(os.environ.get("OUT_DIR", SCRIPT_DIR / "out" / backend)).resolve()
+    screenshots_dir = output_dir / "screenshots"
+    screenshots_dir.mkdir(parents=True, exist_ok=True)
+    pause_scale = float(os.environ.get("BENCH_PAUSE_SCALE", "1"))
+    if pause_scale < 0:
+        raise ValueError("BENCH_PAUSE_SCALE must be non-negative")
+    remote = bool(os.environ.get("CDP_URL", "").strip())
+    skip_uploads_value = os.environ.get("BENCH_SKIP_UPLOADS", "1" if remote else "0")
+    if skip_uploads_value not in {"0", "1"}:
+        raise ValueError("BENCH_SKIP_UPLOADS must be 0 or 1")
+    skip_uploads = skip_uploads_value == "1"
+    skipped_fields = [
+        field["label"]
+        for field in config["fields"]
+        if field.get("network_dependent")
+        or (skip_uploads and field["kind"] == "file")
+    ]
+    fields = [
+        field
+        for field in config["fields"]
+        if not field.get("network_dependent")
+        and not (skip_uploads and field["kind"] == "file")
+    ]
+
+    script_start_epoch = time.time()
+    total_start = time.monotonic()
+    timeline: list[dict[str, Any]] = []
+    timeline_cursor_s = 0.0
+    scripted_pause_ms = 0.0
+    per_field: list[dict[str, Any]] = []
+    screenshot_count = 0
+
+    def finish_interval(label: str, kind: str, end_s: float | None = None) -> None:
+        nonlocal timeline_cursor_s
+        if end_s is None:
+            end_s = time.monotonic() - total_start
+        timeline.append(
+            {"label": label, "kind": kind, "t0_s": timeline_cursor_s, "t1_s": end_s}
+        )
+        timeline_cursor_s = end_s
+
+    def pause(milliseconds: float) -> None:
+        nonlocal scripted_pause_ms
+        actual_ms = milliseconds * pause_scale
+        time.sleep(actual_ms / 1000.0)
+        scripted_pause_ms += actual_ms
+        finish_interval(f"scripted pause ({actual_ms:g} ms)", "pause")
+
+    with sync_playwright() as playwright:
+        cdp_url = os.environ.get("CDP_URL", "").strip()
+        if cdp_url:
+            browser = playwright.chromium.connect_over_cdp(cdp_url, timeout=120_000)
+            context = make_remote_context(browser)
+            context_mode = "remote_isolated_context"
+            launch_label = "library startup and remote CDP connect"
+        else:
+            launch_options: dict[str, Any] = {
+                "headless": os.environ.get("HEADED") != "1"
+            }
+            executable = os.environ.get("BENCH_CHROMIUM_EXECUTABLE", "").strip()
+            if executable:
+                launch_options["executable_path"] = executable
+            browser = playwright.chromium.launch(**launch_options)
+            context = browser.new_context(
+                viewport={"width": 400, "height": 600}, service_workers="block"
+            )
+            context_mode = "local_context"
+            launch_label = "library and browser launch"
+        if context.service_workers:
+            raise AssertionError("Refusing to use a context with active service workers")
+        blocked_request_methods, blocked_websockets = install_network_guard(context)
+        context.add_init_script(INIT_SUBMIT_GUARD_JS)
+        page = context.new_page()
+        launch_ms = (time.monotonic() - total_start) * 1000.0
+        finish_interval(launch_label, "launch", launch_ms / 1000.0)
+
+        try:
+            navigation_start = time.monotonic()
+            page.goto(job_url, wait_until="domcontentloaded", timeout=120_000)
+            page.wait_for_selector(config["ready_selector"], timeout=120_000)
+            # The page and field metadata are now present. Keep the entire
+            # input phase offline so no event handler can transmit dummy data,
+            # even through an idempotent-looking request or existing transport.
+            context.set_offline(True)
+            loaded_url = page.url
+            navigation_ms = (time.monotonic() - navigation_start) * 1000.0
+            finish_interval("page load", "nav")
+            pause(5_000)
+
+            submit_count = page.evaluate(
+                DISABLE_SUBMIT_CONTROLS_JS, config["submit_selector"]
+            )
+            if submit_count < 1:
+                raise AssertionError("Expected at least one submit control to guard")
+            finish_interval("install no-submit guard", "action")
+
+            fill_start = time.monotonic()
+            for index, field in enumerate(fields, start=1):
+                field_start = time.monotonic()
+                visual = visual_locator(page, field)
+                visual.scroll_into_view_if_needed()
+                visual.evaluate(HIGHLIGHT_JS)
+                finish_interval(f"{field['label']}: focus and highlight", "action")
+                pause(200)
+                try:
+                    perform_action(page, field, config_path.parent)
+                    finish_interval(f"{field['label']}: interact", "action")
+                    pause(100)
+                    screenshot_path = (
+                        screenshots_dir / f"{index:03d}_{field['slug']}.png"
+                    )
+                    page.screenshot(path=str(screenshot_path))
+                    screenshot_count += 1
+                finally:
+                    if field["kind"] != "file" or visual.count() > 0:
+                        visual.evaluate(RESTORE_HIGHLIGHT_JS)
+                finish_interval(f"{field['label']}: capture and restore", "action")
+                per_field.append(
+                    {
+                        "label": field["label"],
+                        "ms": round((time.monotonic() - field_start) * 1000.0, 3),
+                    }
+                )
+            fill_ms = (time.monotonic() - fill_start) * 1000.0
+
+            if page.url != loaded_url:
+                raise AssertionError(f"Page unexpectedly navigated away: {page.url}")
+            guard = page.evaluate(READ_SUBMIT_GUARD_JS, config["submit_selector"])
+            if not guard["installed"] or guard["attempted"]:
+                raise AssertionError(f"No-submit guard state is unsafe: {guard!r}")
+            if guard["controlCount"] != submit_count or guard["guardedCount"] != submit_count:
+                raise AssertionError(f"Submit controls lost their guard: {guard!r}")
+            body_text = page.locator("body").evaluate(
+                "element => (element.innerText || element.textContent || '').toLowerCase()"
+            )
+            for forbidden in (
+                "application submitted",
+                "thanks for applying",
+                "thank you for applying",
+            ):
+                if forbidden in body_text:
+                    raise AssertionError(
+                        f"Submission-like confirmation text appeared: {forbidden!r}"
+                    )
+            if screenshot_count != len(fields) or len(per_field) != len(fields):
+                raise AssertionError("A field action or screenshot did not complete")
+        finally:
+            context.close()
+            browser.close()
+
+    total_end_s = time.monotonic() - total_start
+    finish_interval("validation and teardown", "action", total_end_s)
+    total_ms = total_end_s * 1000.0
+    result = {
+        "launch_ms": round(launch_ms, 3),
+        "navigation_ms": round(navigation_ms, 3),
+        "fill_ms": round(fill_ms, 3),
+        "per_field": per_field,
+        "total_ms": round(total_ms, 3),
+        "scripted_pause_ms": round(scripted_pause_ms, 3),
+        "action_ms": round(total_ms - scripted_pause_ms, 3),
+        "fields_filled": len(per_field),
+        "skipped_fields": skipped_fields,
+        "screenshots": screenshot_count,
+        "backend": backend,
+        "connection": "remote_cdp" if remote else "local",
+        "context_mode": context_mode,
+        "submit_guard": "installed_and_not_triggered",
+        "offline_during_fill": True,
+        "blocked_state_changing_requests": len(blocked_request_methods),
+        "blocked_websockets": len(blocked_websockets),
+        "blocked_persistent_transport_attempts": guard[
+            "blockedPersistentTransports"
+        ],
+    }
+    timeline_payload = {
+        "script_start_epoch": script_start_epoch,
+        "intervals": timeline,
+    }
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "timeline.json").write_text(
+        json.dumps(timeline_payload, indent=2) + "\n", encoding="utf-8"
+    )
+    (output_dir / "timings.json").write_text(
+        json.dumps(result, indent=2) + "\n", encoding="utf-8"
+    )
+    print("BENCH_RESULT " + json.dumps(result, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/form_fill/fill_form_remote.py
+++ b/benchmarks/form_fill/fill_form_remote.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Explicit remote-CDP entry point for the shared form-fill workload."""
+
+from __future__ import annotations
+
+import os
+
+from fill_form import main
+
+
+if __name__ == "__main__":
+    if not os.environ.get("CDP_URL", "").strip():
+        raise ValueError("CDP_URL is required for the remote workload")
+    main()

--- a/benchmarks/form_fill/harness/build_images.sh
+++ b/benchmarks/form_fill/harness/build_images.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+repo_root="$(cd "$script_dir/../../.." && pwd -P)"
+base_image="${FORM_FILL_BASE_IMAGE:-rustwright-form-fill-base:latest}"
+record_image="${FORM_FILL_RECORD_IMAGE:-rustwright-form-fill-record:latest}"
+
+docker build --tag "$base_image" "$repo_root"
+docker build \
+  --build-arg "RUSTWRIGHT_BASE_IMAGE=$base_image" \
+  --file "$script_dir/../Dockerfile.record" \
+  --tag "$record_image" \
+  "$repo_root"

--- a/benchmarks/form_fill/harness/measure.py
+++ b/benchmarks/form_fill/harness/measure.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Coordinate workload, cgroup/PSS samplers, epochs, and optional recording."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import IO
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SUITE_DIR = SCRIPT_DIR.parent
+OUTPUT_ROOT = Path("/output")
+OUTPUT_NAME = re.compile(r"[A-Za-z0-9._-]+")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--backend", choices=("playwright", "rustwright"), required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--record", action="store_true")
+    return parser.parse_args()
+
+
+def start_process(command: list[str], log: IO[bytes], **kwargs: object) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, **kwargs)
+
+
+def stop_process(
+    process: subprocess.Popen[bytes] | None,
+    stop_signal: signal.Signals = signal.SIGTERM,
+    timeout: float = 10,
+) -> int:
+    if process is None:
+        return 0
+    if process.poll() is None:
+        process.send_signal(stop_signal)
+    try:
+        return process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        return process.wait(timeout=5)
+
+
+def wait_for_file(path: Path, process: subprocess.Popen[bytes], timeout: float = 5) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if path.is_file() and path.stat().st_size > 0:
+            return
+        if process.poll() is not None:
+            raise RuntimeError(f"process exited before creating {path.name}")
+        time.sleep(0.02)
+    raise TimeoutError(f"timed out waiting for {path.name}")
+
+
+def wait_for_display(display: str, process: subprocess.Popen[bytes]) -> None:
+    deadline = time.monotonic() + 5
+    environment = {**os.environ, "DISPLAY": display}
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError("Xvfb exited before becoming ready")
+        result = subprocess.run(
+            ["xdpyinfo"],
+            env=environment,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        time.sleep(0.02)
+    raise TimeoutError("timed out waiting for Xvfb")
+
+
+def has_data_rows(path: Path) -> bool:
+    return path.is_file() and len(path.read_text(encoding="ascii").splitlines()) >= 2
+
+
+def validated_output(path: Path) -> Path:
+    """Limit destructive cleanup to one named run under the output mount."""
+    root = OUTPUT_ROOT.resolve()
+    if not path.is_absolute() or not OUTPUT_NAME.fullmatch(path.name):
+        raise ValueError("output must be an absolute, simply named run directory")
+    if path.is_symlink() or path.parent.resolve() != root:
+        raise ValueError(f"output must be a non-symlink direct child of {OUTPUT_ROOT}")
+    resolved = path.resolve()
+    if resolved.parent != root:
+        raise ValueError(f"output resolves outside {OUTPUT_ROOT}")
+    return resolved
+
+
+def main() -> int:
+    args = parse_args()
+    output = validated_output(args.output)
+    if output.exists():
+        shutil.rmtree(output)
+    output.mkdir(parents=True)
+    log_path = output / "run.log"
+    epochs: dict[str, float] = {}
+    processes: list[subprocess.Popen[bytes]] = []
+    cgroup_sampler: subprocess.Popen[bytes] | None = None
+    stack_sampler: subprocess.Popen[bytes] | None = None
+    xvfb: subprocess.Popen[bytes] | None = None
+    ffmpeg: subprocess.Popen[bytes] | None = None
+    workload: subprocess.Popen[bytes] | None = None
+    final_code = 125
+
+    with log_path.open("wb", buffering=0) as log:
+        try:
+            cgroup_sampler = start_process(
+                [
+                    sys.executable,
+                    str(SCRIPT_DIR / "sample_cgroup_memory.py"),
+                    "--output",
+                    str(output / "cgroup.csv"),
+                    "--peak-output",
+                    str(output / "cgroup_memory_peak_bytes.txt"),
+                ],
+                log,
+            )
+            processes.append(cgroup_sampler)
+            epochs["cgroup_sampler_start"] = time.time()
+            wait_for_file(output / "cgroup.csv", cgroup_sampler)
+
+            workload_environment = {
+                **os.environ,
+                "BACKEND": args.backend,
+                "OUT_DIR": str(output),
+            }
+            if args.record:
+                display = ":99"
+                xvfb = start_process(
+                    [
+                        "Xvfb",
+                        display,
+                        "-screen",
+                        "0",
+                        "520x700x24",
+                        "-nolisten",
+                        "tcp",
+                        "-ac",
+                    ],
+                    log,
+                )
+                processes.append(xvfb)
+                wait_for_display(display, xvfb)
+                time.sleep(1)
+                epochs["ffmpeg_start"] = time.time()
+                ffmpeg = start_process(
+                    [
+                        "ffmpeg",
+                        "-hide_banner",
+                        "-loglevel",
+                        "warning",
+                        "-y",
+                        "-f",
+                        "x11grab",
+                        "-framerate",
+                        "24",
+                        "-video_size",
+                        "520x700",
+                        "-i",
+                        f"{display}.0+0,0",
+                        "-an",
+                        "-c:v",
+                        "libx264",
+                        "-preset",
+                        "ultrafast",
+                        "-threads",
+                        "1",
+                        "-crf",
+                        "18",
+                        "-fps_mode",
+                        "cfr",
+                        "-r",
+                        "24",
+                        "-pix_fmt",
+                        "yuv420p",
+                        "-movflags",
+                        "+faststart",
+                        str(output / "recording.mp4"),
+                    ],
+                    log,
+                )
+                processes.append(ffmpeg)
+                time.sleep(0.2)
+                if ffmpeg.poll() is not None:
+                    raise RuntimeError("ffmpeg exited before the workload started")
+                workload_environment.update({"DISPLAY": display, "HEADED": "1"})
+            else:
+                time.sleep(1)
+
+            epochs["workload_start"] = time.time()
+            workload = start_process(
+                [sys.executable, str(SUITE_DIR / "fill_form.py")],
+                log,
+                env=workload_environment,
+            )
+            processes.append(workload)
+            epochs["stack_sampler_start"] = time.time()
+            stack_sampler = start_process(
+                [
+                    sys.executable,
+                    str(SCRIPT_DIR / "sample_stack_memory.py"),
+                    "--root-pid",
+                    str(workload.pid),
+                    "--output",
+                    str(output / "stack_pss.csv"),
+                ],
+                log,
+            )
+            processes.append(stack_sampler)
+            workload_code = workload.wait()
+            epochs["workload_end"] = time.time()
+            workload = None
+
+            stack_code = stop_process(stack_sampler)
+            stack_sampler = None
+            if args.record:
+                # ffmpeg commonly reports a non-zero status when SIGINT is the
+                # requested, graceful stop. Validate the finalized file below
+                # instead of treating that signal status as a workload failure.
+                stop_process(ffmpeg, signal.SIGINT, timeout=20)
+                epochs["ffmpeg_stop"] = time.time()
+                ffmpeg = None
+            time.sleep(0.2)
+            cgroup_code = stop_process(cgroup_sampler)
+            cgroup_sampler = None
+
+            final_code = workload_code
+            if final_code == 0 and (stack_code != 0 or cgroup_code != 0):
+                final_code = 125
+            required = [
+                output / "timeline.json",
+                output / "timings.json",
+                output / "cgroup_memory_peak_bytes.txt",
+            ]
+            if final_code == 0 and not all(path.is_file() and path.stat().st_size for path in required):
+                final_code = 125
+            if final_code == 0 and not has_data_rows(output / "cgroup.csv"):
+                final_code = 125
+            if final_code == 0 and not has_data_rows(output / "stack_pss.csv"):
+                final_code = 125
+            if args.record and final_code == 0:
+                recording = output / "recording.mp4"
+                if not recording.is_file() or recording.stat().st_size == 0:
+                    final_code = 125
+        except Exception as error:
+            log.write(f"measurement harness failed: {error}\n".encode("utf-8"))
+            final_code = 125
+        finally:
+            if workload is not None:
+                stop_process(workload)
+            stop_process(stack_sampler)
+            stop_process(ffmpeg, signal.SIGINT, timeout=20)
+            stop_process(cgroup_sampler)
+            stop_process(xvfb)
+            for process in reversed(processes):
+                stop_process(process)
+
+    now = time.time()
+    epochs.setdefault("workload_start", now)
+    epochs.setdefault("stack_sampler_start", now)
+    epochs.setdefault("workload_end", now)
+    (output / "epochs.json").write_text(
+        json.dumps(epochs, indent=2) + "\n", encoding="utf-8"
+    )
+    wall_time = epochs["workload_end"] - epochs["workload_start"]
+    (output / "wall_time.txt").write_text(f"{wall_time:.6f}\n", encoding="ascii")
+    (output / "exit_code.txt").write_text(f"{final_code}\n", encoding="ascii")
+    return final_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/form_fill/harness/record_one.sh
+++ b/benchmarks/form_fill/harness/record_one.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 2 )); then
+  echo "Usage: $0 <playwright|rustwright> <output-label>" >&2
+  exit 2
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+BENCH_RECORD=1 "$script_dir/run_one.sh" "$1" "$2"

--- a/benchmarks/form_fill/harness/render.sh
+++ b/benchmarks/form_fill/harness/render.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+suite_dir="$(cd "$script_dir/.." && pwd -P)"
+out_dir="${BENCH_OUT_DIR:-$suite_dir/out}"
+image="${FORM_FILL_RECORD_IMAGE:-rustwright-form-fill-record:latest}"
+
+docker run --rm \
+  --volume "$out_dir:/output" \
+  --entrypoint python \
+  "$image" \
+  /workspace/benchmarks/form_fill/render_artifacts.py \
+  --playwright-run "/output/${PLAYWRIGHT_LABEL:-playwright-record}" \
+  --rustwright-run "/output/${RUSTWRIGHT_LABEL:-rustwright-record}" \
+  --output-dir /output/rendered

--- a/benchmarks/form_fill/harness/run_one.sh
+++ b/benchmarks/form_fill/harness/run_one.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <playwright|rustwright> <output-label>" >&2
+}
+
+if (( $# != 2 )); then
+  usage
+  exit 2
+fi
+
+backend="$1"
+label="$2"
+case "$backend" in
+  playwright|rustwright) ;;
+  *) usage; exit 2 ;;
+esac
+if [[ ! "$label" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "output-label may contain only letters, digits, dots, underscores, and hyphens" >&2
+  exit 2
+fi
+: "${BENCH_JOB_URL:?BENCH_JOB_URL must be set to an authorized target}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+suite_dir="$(cd "$script_dir/.." && pwd -P)"
+out_dir="${BENCH_OUT_DIR:-$suite_dir/out}"
+mkdir -p "$out_dir"
+
+record="${BENCH_RECORD:-0}"
+if [[ "$record" == "1" ]]; then
+  image="${FORM_FILL_RECORD_IMAGE:-rustwright-form-fill-record:latest}"
+else
+  image="${FORM_FILL_BASE_IMAGE:-rustwright-form-fill-base:latest}"
+fi
+
+docker_args=(
+  --rm
+  --memory="${BENCH_MEMORY_LIMIT:-8g}"
+  --memory-swap="${BENCH_MEMORY_LIMIT:-8g}"
+  --cpus="${BENCH_CPUS:-4}"
+  --shm-size="${BENCH_SHM_SIZE:-1g}"
+  --volume "$out_dir:/output"
+  --env BENCH_JOB_URL
+  --env "BENCH_CHROMIUM_EXECUTABLE=${BENCH_CHROMIUM_EXECUTABLE:-/usr/local/bin/rustwright-chromium}"
+  --entrypoint python
+)
+
+for variable in CDP_URL BENCH_PAUSE_SCALE BENCH_SKIP_UPLOADS; do
+  if [[ -n "${!variable:-}" ]]; then
+    docker_args+=(--env "$variable")
+  fi
+done
+
+if [[ -n "${BENCH_FIELD_CONFIG_HOST:-}" ]]; then
+  config_dir="$(cd "$(dirname "$BENCH_FIELD_CONFIG_HOST")" && pwd -P)"
+  config_name="$(basename "$BENCH_FIELD_CONFIG_HOST")"
+  docker_args+=(
+    --volume "$config_dir:/bench-config:ro"
+    --env "BENCH_FIELD_CONFIG=/bench-config/$config_name"
+  )
+fi
+
+if [[ "$backend" == "playwright" ]]; then
+  docker_args+=(--env "PYTHONPATH=/opt/playwright-reference")
+fi
+
+measure_args=(
+  /workspace/benchmarks/form_fill/harness/measure.py
+  --backend "$backend"
+  --output "/output/$label"
+)
+if [[ "$record" == "1" ]]; then
+  measure_args+=(--record)
+fi
+
+docker run "${docker_args[@]}" "$image" "${measure_args[@]}"

--- a/benchmarks/form_fill/harness/run_pair.sh
+++ b/benchmarks/form_fill/harness/run_pair.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+overall=0
+
+echo "[1/2] reference Playwright"
+"$script_dir/run_one.sh" playwright "${PLAYWRIGHT_LABEL:-playwright}" || overall=$?
+
+echo "[2/2] Rustwright"
+"$script_dir/run_one.sh" rustwright "${RUSTWRIGHT_LABEL:-rustwright}" || {
+  code=$?
+  if (( overall == 0 )); then
+    overall=$code
+  fi
+}
+
+exit "$overall"

--- a/benchmarks/form_fill/harness/run_remote.sh
+++ b/benchmarks/form_fill/harness/run_remote.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (( $# != 2 )); then
+  echo "Usage: $0 <playwright|rustwright> <output-label>" >&2
+  exit 2
+fi
+: "${CDP_URL:?CDP_URL must be set to a provider-neutral CDP endpoint}"
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+BENCH_SKIP_UPLOADS="${BENCH_SKIP_UPLOADS:-1}" \
+  "$script_dir/run_one.sh" "$1" "$2"

--- a/benchmarks/form_fill/harness/sample_cgroup_memory.py
+++ b/benchmarks/form_fill/harness/sample_cgroup_memory.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Sample cgroup-v2 current memory and preserve the kernel peak counter."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import signal
+import time
+from pathlib import Path
+
+
+stop_requested = False
+
+
+def request_stop(_signum: int, _frame: object) -> None:
+    global stop_requested
+    stop_requested = True
+
+
+for handled_signal in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(handled_signal, request_stop)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--peak-output", type=Path, required=True)
+    parser.add_argument("--interval", type=float, default=0.1)
+    parser.add_argument(
+        "--cgroup-root", type=Path, default=Path("/sys/fs/cgroup")
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.interval <= 0:
+        raise ValueError("sample interval must be positive")
+    current_path = args.cgroup_root / "memory.current"
+    peak_path = args.cgroup_root / "memory.peak"
+    if not current_path.is_file() or not peak_path.is_file():
+        raise RuntimeError("readable cgroup-v2 memory.current and memory.peak are required")
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    started = time.monotonic()
+    next_sample = started
+    try:
+        with args.output.open("w", newline="", encoding="ascii", buffering=1) as handle:
+            writer = csv.writer(handle)
+            writer.writerow(("t_rel_s", "bytes"))
+            while not stop_requested:
+                sampled = time.monotonic()
+                current_bytes = int(current_path.read_text(encoding="ascii").strip())
+                writer.writerow((f"{sampled - started:.6f}", current_bytes))
+                next_sample += args.interval
+                remaining = next_sample - time.monotonic()
+                if remaining > 0:
+                    time.sleep(remaining)
+                else:
+                    next_sample = time.monotonic()
+    finally:
+        args.peak_output.write_text(
+            peak_path.read_text(encoding="ascii").strip() + "\n",
+            encoding="ascii",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/form_fill/harness/sample_stack_memory.py
+++ b/benchmarks/form_fill/harness/sample_stack_memory.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Sample PSS for a workload process and its descendant driver/browser stack."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import signal
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+stop_requested = False
+
+
+def request_stop(_signum: int, _frame: object) -> None:
+    global stop_requested
+    stop_requested = True
+
+
+for handled_signal in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(handled_signal, request_stop)
+
+
+@dataclass(frozen=True)
+class Process:
+    pid: int
+    ppid: int
+    name: str
+    argv: tuple[str, ...]
+
+
+def read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except (FileNotFoundError, PermissionError, ProcessLookupError, OSError):
+        return None
+
+
+def read_process(pid_dir: Path) -> Process | None:
+    status_text = read_text(pid_dir / "status")
+    if status_text is None:
+        return None
+    status = {}
+    for line in status_text.splitlines():
+        if ":" in line:
+            key, value = line.split(":", 1)
+            status[key] = value.strip()
+    try:
+        pid = int(pid_dir.name)
+        ppid = int(status["PPid"])
+    except (KeyError, ValueError):
+        return None
+    argv = tuple(
+        part for part in (read_text(pid_dir / "cmdline") or "").split("\0") if part
+    )
+    return Process(pid=pid, ppid=ppid, name=status.get("Name", ""), argv=argv)
+
+
+def read_pss_bytes(pid: int) -> int | None:
+    rollup = read_text(Path("/proc") / str(pid) / "smaps_rollup")
+    if rollup is None:
+        return None
+    for line in rollup.splitlines():
+        if line.startswith("Pss:"):
+            try:
+                return int(line.split()[1]) * 1024
+            except (IndexError, ValueError):
+                return None
+    return None
+
+
+def descendants(processes: dict[int, Process], root_pid: int) -> set[int]:
+    selected = {root_pid} if root_pid in processes else set()
+    changed = True
+    while changed:
+        changed = False
+        for process in processes.values():
+            if process.pid not in selected and process.ppid in selected:
+                selected.add(process.pid)
+                changed = True
+    return selected
+
+
+def direct_category(process: Process, root_pid: int) -> str | None:
+    argv = " ".join(process.argv).lower()
+    executable = Path(process.argv[0]).name.lower() if process.argv else ""
+    token = " ".join((process.name.lower(), executable, argv))
+    if process.pid == root_pid or executable.startswith("python"):
+        return "python"
+    if executable == "node" or executable.startswith("node-"):
+        return "driver"
+    if any(marker in token for marker in ("chrome", "chromium", "headless_shell")):
+        return "browser"
+    return None
+
+
+def inherited_category(
+    pid: int,
+    processes: dict[int, Process],
+    selected: set[int],
+    categories: dict[int, str],
+) -> str:
+    current = processes[pid]
+    seen = {pid}
+    while current.ppid in selected and current.ppid not in seen:
+        parent_pid = current.ppid
+        if parent_pid in categories:
+            return categories[parent_pid]
+        seen.add(parent_pid)
+        current = processes[parent_pid]
+    return "python"
+
+
+def scan(root_pid: int) -> tuple[int, int, int, int] | None:
+    processes = {}
+    for pid_dir in Path("/proc").iterdir():
+        if not pid_dir.name.isdigit():
+            continue
+        process = read_process(pid_dir)
+        if process is not None:
+            processes[process.pid] = process
+    if root_pid not in processes:
+        return None
+    selected = descendants(processes, root_pid)
+    categories = {
+        pid: category
+        for pid in selected
+        if (category := direct_category(processes[pid], root_pid)) is not None
+    }
+    totals = {"python": 0, "driver": 0, "browser": 0}
+    for pid in sorted(selected):
+        pss_bytes = read_pss_bytes(pid)
+        if pss_bytes is None:
+            continue
+        category = categories.get(pid) or inherited_category(
+            pid, processes, selected, categories
+        )
+        categories[pid] = category
+        totals[category] += pss_bytes
+    return (
+        sum(totals.values()),
+        totals["python"],
+        totals["driver"],
+        totals["browser"],
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root-pid", type=int, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--interval", type=float, default=0.1)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.root_pid <= 0 or args.interval <= 0:
+        raise ValueError("root PID and interval must be positive")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    started = time.monotonic()
+    next_sample = started
+    with args.output.open("w", newline="", encoding="ascii", buffering=1) as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            ("t_rel_s", "total_bytes", "python_bytes", "driver_bytes", "browser_bytes")
+        )
+        while not stop_requested:
+            sampled = time.monotonic()
+            values = scan(args.root_pid)
+            if values is None:
+                break
+            writer.writerow((f"{sampled - started:.6f}", *values))
+            next_sample += args.interval
+            remaining = next_sample - time.monotonic()
+            if remaining > 0:
+                time.sleep(remaining)
+            else:
+                next_sample = time.monotonic()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/form_fill/render_artifacts.py
+++ b/benchmarks/form_fill/render_artifacts.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Render local-diagnostic form-fill memory charts and synchronized videos."""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import csv
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+
+
+FPS = 24
+MIB = 1024 * 1024
+COLORS = {"playwright": "#2a78d6", "rustwright": "#1baf7a"}
+
+
+@dataclass(frozen=True)
+class Run:
+    key: str
+    name: str
+    color: str
+    path: Path
+    epochs: dict[str, float]
+    timeline: dict[str, Any]
+    timings: dict[str, Any]
+    stack_t: list[float]
+    stack_mib: list[float]
+    cgroup_t: list[float]
+    cgroup_mib: list[float]
+    cgroup_peak_mib: float
+
+    def relative_times(self, sample_times: list[float], epoch_key: str) -> list[float]:
+        offset = self.epochs[epoch_key] - self.epochs["workload_start"]
+        return [value + offset for value in sample_times]
+
+    def phase_ranges(self, kinds: set[str], origin_epoch: float) -> list[tuple[float, float]]:
+        script_start = float(self.timeline["script_start_epoch"])
+        ranges = []
+        for interval in self.timeline["intervals"]:
+            if interval["kind"] in kinds:
+                ranges.append(
+                    (
+                        script_start + float(interval["t0_s"]) - origin_epoch,
+                        script_start + float(interval["t1_s"]) - origin_epoch,
+                    )
+                )
+        return ranges
+
+
+def read_csv(path: Path, time_column: str, value_column: str) -> tuple[list[float], list[float]]:
+    with path.open(newline="", encoding="ascii") as handle:
+        rows = list(csv.DictReader(handle))
+    if len(rows) < 2:
+        raise ValueError(f"{path} needs at least two samples")
+    times = [float(row[time_column]) for row in rows]
+    values = [int(row[value_column]) / MIB for row in rows]
+    if any(right <= left for left, right in zip(times, times[1:])):
+        raise ValueError(f"{path} sample times must increase")
+    return times, values
+
+
+def load_run(key: str, path: Path) -> Run:
+    stack_t, stack_mib = read_csv(path / "stack_pss.csv", "t_rel_s", "total_bytes")
+    cgroup_t, cgroup_mib = read_csv(path / "cgroup.csv", "t_rel_s", "bytes")
+    return Run(
+        key=key,
+        name="Playwright" if key == "playwright" else "Rustwright",
+        color=COLORS[key],
+        path=path,
+        epochs={
+            name: float(value)
+            for name, value in json.loads(
+                (path / "epochs.json").read_text(encoding="utf-8")
+            ).items()
+        },
+        timeline=json.loads((path / "timeline.json").read_text(encoding="utf-8")),
+        timings=json.loads((path / "timings.json").read_text(encoding="utf-8")),
+        stack_t=stack_t,
+        stack_mib=stack_mib,
+        cgroup_t=cgroup_t,
+        cgroup_mib=cgroup_mib,
+        cgroup_peak_mib=int(
+            (path / "cgroup_memory_peak_bytes.txt").read_text(encoding="ascii")
+        )
+        / MIB,
+    )
+
+
+def add_phase_bands(axis: Any, run: Run, origin_epoch: float) -> None:
+    for start, end in run.phase_ranges({"nav"}, origin_epoch):
+        axis.axvspan(start, end, color=run.color, alpha=0.08, linewidth=0)
+    for start, end in run.phase_ranges({"pause"}, origin_epoch):
+        axis.axvspan(start, end, color="#777777", alpha=0.035, linewidth=0)
+
+
+def style_axis(axis: Any, ylabel: str) -> None:
+    axis.set_facecolor("#fcfcfb")
+    axis.grid(axis="y", color="#e1e0d9", linewidth=0.7)
+    axis.set_axisbelow(True)
+    axis.spines[["top", "right"]].set_visible(False)
+    axis.set_ylabel(ylabel)
+
+
+def render_comparison(runs: list[Run], output_dir: Path) -> None:
+    figure, axes = plt.subplots(2, 1, figsize=(16, 9), dpi=100, sharex=True)
+    figure.patch.set_facecolor("#fcfcfb")
+    figure.suptitle("Form-fill memory profile — local diagnostic", fontsize=23, weight="bold")
+    axes[0].set_title("Workload stack proportional set size (Python + driver + browser)")
+    axes[1].set_title("Whole capped-container cgroup memory")
+    for axis, ylabel in zip(axes, ("Stack PSS (MiB)", "Cgroup memory (MiB)")):
+        style_axis(axis, ylabel)
+
+    for run in runs:
+        stack_x = run.relative_times(run.stack_t, "stack_sampler_start")
+        cgroup_x = run.relative_times(run.cgroup_t, "cgroup_sampler_start")
+        axes[0].plot(stack_x, run.stack_mib, color=run.color, label=run.name, linewidth=1.7)
+        axes[1].plot(cgroup_x, run.cgroup_mib, color=run.color, label=run.name, linewidth=1.7)
+        add_phase_bands(axes[0], run, run.epochs["workload_start"])
+        add_phase_bands(axes[1], run, run.epochs["workload_start"])
+    axes[0].legend(frameon=False)
+    axes[1].legend(frameon=False)
+    axes[1].set_xlabel("Seconds from workload start")
+    figure.text(
+        0.5,
+        0.012,
+        "Colored shading: page/browser time · gray shading: scripted choreography pauses",
+        ha="center",
+        fontsize=9,
+        color="#555555",
+    )
+    figure.tight_layout(rect=(0, 0.04, 1, 0.94))
+    figure.savefig(output_dir / "comparison.png", facecolor=figure.get_facecolor())
+    plt.close(figure)
+
+
+def video_metadata(path: Path) -> tuple[float, int]:
+    payload = json.loads(
+        subprocess.check_output(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=nb_frames,r_frame_rate:format=duration",
+                "-of",
+                "json",
+                str(path),
+            ],
+            text=True,
+        )
+    )
+    duration = float(payload["format"]["duration"])
+    stream = payload["streams"][0]
+    numerator, denominator = map(int, stream["r_frame_rate"].split("/"))
+    rate = numerator / denominator
+    if abs(rate - FPS) > 0.01:
+        raise ValueError(f"{path} is {rate} fps; expected {FPS}")
+    frames_value = stream.get("nb_frames")
+    frames = int(frames_value) if frames_value not in (None, "N/A") else round(duration * FPS)
+    return duration, frames
+
+
+def render_memory_video(run: Run, output_dir: Path, shared_max: float) -> None:
+    recording = run.path / "recording.mp4"
+    duration, frames = video_metadata(recording)
+    origin = run.epochs["ffmpeg_start"]
+    x = [
+        value + run.epochs["stack_sampler_start"] - origin
+        for value in run.stack_t
+    ]
+    figure, axis = plt.subplots(figsize=(5.2, 7), dpi=100)
+    figure.patch.set_facecolor("#fcfcfb")
+    style_axis(axis, "Stack PSS (MiB)")
+    axis.set_xlim(0, duration)
+    axis.set_ylim(0, shared_max)
+    axis.set_xlabel("Seconds from recording start")
+    axis.set_title(f"{run.name} form-fill stack memory", weight="bold")
+    add_phase_bands(axis, run, origin)
+    (line,) = axis.plot([], [], color=run.color, linewidth=1.8)
+    (head,) = axis.plot([], [], "o", color=run.color, markersize=6)
+    label = axis.annotate("", xy=(0, 0), xytext=(8, 8), textcoords="offset points")
+
+    output = output_dir / f"{run.key}_memory.mp4"
+    process = subprocess.Popen(
+        [
+            "ffmpeg",
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "rgba",
+            "-s",
+            "520x700",
+            "-r",
+            str(FPS),
+            "-i",
+            "pipe:0",
+            "-an",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-frames:v",
+            str(frames),
+            str(output),
+        ],
+        stdin=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if process.stdin is None:
+        raise RuntimeError("ffmpeg stdin was not created")
+    try:
+        for frame in range(frames):
+            current = frame / FPS
+            count = max(1, bisect.bisect_right(x, current))
+            visible_x = x[:count]
+            visible_y = run.stack_mib[:count]
+            line.set_data(visible_x, visible_y)
+            head.set_data([visible_x[-1]], [visible_y[-1]])
+            label.xy = (visible_x[-1], visible_y[-1])
+            label.set_text(f"{visible_y[-1]:.1f} MiB")
+            figure.canvas.draw()
+            process.stdin.write(figure.canvas.buffer_rgba())
+    finally:
+        process.stdin.close()
+    error = process.stderr.read().decode("utf-8", errors="replace") if process.stderr else ""
+    return_code = process.wait()
+    plt.close(figure)
+    if return_code:
+        raise RuntimeError(f"ffmpeg failed for {run.name}: {error}")
+
+
+def write_stats(runs: list[Run], output_dir: Path) -> None:
+    payload = {
+        "classification": "example run, demo-grade local diagnostic",
+        "runs": {
+            run.key: {
+                "wall_time_s": round(
+                    run.epochs["workload_end"] - run.epochs["workload_start"], 6
+                ),
+                "sampled_stack_pss_peak_mib": round(max(run.stack_mib), 6),
+                "kernel_cgroup_peak_mib": round(run.cgroup_peak_mib, 6),
+                "fields_filled": run.timings["fields_filled"],
+            }
+            for run in runs
+        },
+    }
+    (output_dir / "stats.json").write_text(
+        json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--playwright-run", type=Path, required=True)
+    parser.add_argument("--rustwright-run", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    runs = [
+        load_run("playwright", args.playwright_run.resolve()),
+        load_run("rustwright", args.rustwright_run.resolve()),
+    ]
+    render_comparison(runs, output_dir)
+    write_stats(runs, output_dir)
+    shared_max = max(max(run.stack_mib) for run in runs) * 1.1
+    for run in runs:
+        render_memory_video(run, output_dir, shared_max)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add a backend-switchable, no-submit form-fill workload for Rustwright and reference Playwright.
- Add capped Docker measurement and recording harnesses with cgroup and stack-PSS sampling, epochs, timelines, renderers, and comparison charts.
- Add provider-neutral remote CDP support through `CDP_URL`, requiring a dedicated browser context.
- Document methodology, fairness constraints, build/run workflows, and the repository benchmark policy.

## What it measures

The harness runs identical Python choreography against the same Chromium executable and target configuration. It records launch, navigation, scripted-pause, field-action, and teardown intervals. Stack PSS covers the workload plus descendant driver/browser processes; cgroup metrics cover the entire capped container. Rendered charts shade browser-time and pause intervals.

## How to run

```bash
benchmarks/form_fill/harness/build_images.sh
export BENCH_JOB_URL="https://job-board.example/jobs/authorized-test-target"
benchmarks/form_fill/harness/run_pair.sh
```

Copy and adapt `field_map.example.json` for an authorized target. Generated output stays under the ignored `benchmarks/form_fill/out/` tree. Durable performance claims still require the capped, sharded Testbox workflow described in `BENCHMARK.md`.

## Responsible use

This workload fills a real job application with dummy data and never submits it by design. Users must target only postings they have a legitimate reason and permission to test, respect site terms and rate limits, and never remove or weaken the no-submit guardrail. The workload blocks form submission, state-changing requests, persistent transports, and runs the actual fill phase offline.

## Verification

- Python compilation, shell syntax, ShellCheck, JSON parsing, and diff checks pass.
- Focused persistent-transport guard checks pass with both backends.
- A capped packaged Docker run completed end to end with timeline, cgroup/PSS samples, screenshots, and the no-submit guard intact.
- The exact outgoing revision passed the adversarial pre-push review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)