### PR TITLE
docs: add Rustwright MCP to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ See [`LIMITATIONS.md`](LIMITATIONS.md) for detail.
 ## Roadmap
 
 - [ ] **Language bindings** — one Rust engine, many languages: Go, Java, C#/.NET, Ruby, and PHP (plus a native Rust API)
+- [ ] **Rustwright MCP server** — expose browser automation as tools for MCP-compatible AI agents
 - [ ] CI / Testbox-backed benchmark evidence
 - [ ] Broaden the Node.js surface (contexts, routing, locators)
 - [ ] Close remaining OOPIF gaps


### PR DESCRIPTION
## Summary

- add a Rustwright MCP server to the README roadmap
- describe it as exposing browser automation to MCP-compatible AI agents

## Testing

- not run (documentation-only change)