### PR TITLE
chore(release): bump version to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustwright-core"
-version = "0.1.0-alpha.4"
+version = "0.1.1"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "rustwright-node"
-version = "0.1.0-alpha.4"
+version = "0.1.1"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-core"
-version = "0.1.0-alpha.4"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.85"
 description = "Rust CDP core for a Python Playwright-compatible automation API"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-node"
-version = "0.1.0-alpha.4"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rustwright",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rustwright",
-      "version": "0.1.0-alpha.4",
+      "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^2.18.4"

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustwright",
-  "version": "0.1.0-alpha.4",
+  "version": "0.1.1",
   "private": true,
   "description": "Node.js bindings for Rustwright's Rust CDP core",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustwright"
-version = "0.1.0-alpha.4"
+version = "0.1.1"
 description = "A Rust-backed, CDP-first Python automation library with a Playwright-compatible sync API"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/python/rustwright/_backend.py
+++ b/python/rustwright/_backend.py
@@ -28,7 +28,7 @@ def _version() -> str:
     try:
         return metadata.version("rustwright")
     except metadata.PackageNotFoundError:
-        return "0.1.0+local"
+        return "0.1.1+local"
 
 
 def backend_marker(api_module: str | None = None) -> BackendMarker:

--- a/python/rustwright/cli.py
+++ b/python/rustwright/cli.py
@@ -77,7 +77,7 @@ def _version() -> str:
     try:
         return metadata.version("rustwright")
     except metadata.PackageNotFoundError:
-        return "0.1.0"
+        return "0.1.1"
 
 
 def _normal_browser_name(name: str) -> str:

--- a/python/rustwright/sync_api.py
+++ b/python/rustwright/sync_api.py
@@ -5625,7 +5625,7 @@ def _write_har(
             )
     log: dict[str, Any] = {
         "version": "1.2",
-        "creator": {"name": "Rustwright", "version": "0.1.0"},
+        "creator": {"name": "Rustwright", "version": "0.1.1"},
         "entries": entries,
     }
     if resolved_har_mode != "minimal":
@@ -11610,7 +11610,7 @@ class Tracing(_EventEmitter):
                 "type": "context-options",
                 "origin": "library",
                 "browserName": "chromium",
-                "playwrightVersion": "rustwright-0.1.0",
+                "playwrightVersion": "rustwright-0.1.1",
                 "options": _trace_option_payload(self._context),
                 "platform": sys.platform,
                 "wallTime": self._start_wall_time_ms,


### PR DESCRIPTION
Bump Rustwright to **0.1.1** across all four source manifests, the shipped runtime metadata, and both lockfiles.

## Notes
- Baseline correction: `main`'s manifests had regressed to `0.1.0-alpha.4` (introduced by an earlier rustwright-cloud sync PR) while the published/tagged release and runtime metadata were `0.1.0`. This PR restores consistency and moves everything to `0.1.1`.
- All nine version-bearing files updated: `pyproject.toml`, `Cargo.toml`, `node/Cargo.toml`, `node/package.json`, `python/rustwright/sync_api.py`, `python/rustwright/cli.py`, `python/rustwright/_backend.py`, `Cargo.lock`, `node/package-lock.json`.

## Local checks
- `cargo check --locked` ✅
- `cargo test --locked` ✅ (37 passed)
- `cd node && npm ci --ignore-scripts && npm run build && npm run smoke` ✅

Preview dry-run workflow runs will be added as a comment.