### PR TITLE
add a release profile (lto + strip), ~43% smaller binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,8 @@ hashbrown = "=0.14.5"
 quote = "=1.0.37"
 proc-macro2 = "=1.0.86"
 unicode-ident = "=1.0.24"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
+strip = "symbols"


### PR DESCRIPTION
there is no `[profile.release]` in the repo, so the published cdylib is built without LTO and without stripping symbols. turning those on:

- shrinks the pyo3 cdylib from 9.65MB to 5.53MB (~43% smaller), measured locally on macOS with default features
- should also speed up the client-side CDP work, since LTO inlines across serde/tokio (did not measure that, would need the browser bench)

so a smaller pip wheel / npm download per platform, and the CPU part rustwright actually competes on gets faster.

left out `panic = "abort"` on purpose since pyo3/napi catch panics at the FFI boundary to turn them into Python/JS exceptions. if CI build time gets annoying, `lto = "thin"` gets most of the win for less compile cost.