### PR TITLE
Cloud CDP benchmark: dispatch workflow + replication-grade results

### DIFF
--- a/.github/workflows/form-fill-cloud-benchmark.yml
+++ b/.github/workflows/form-fill-cloud-benchmark.yml
@@ -40,7 +40,11 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # The job never pushes; do not leave the job token in git config
+          # for later steps that execute repository build code.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -55,8 +59,10 @@ jobs:
       - name: Build rustwright in its benchmark environment
         run: |
           python -m venv .venv-rw
-          # Exact pins: this step runs before the secret-bearing benchmark
-          # step, so nothing mutable is installed on the way there.
+          # Exact pins keep the third-party dependency chain deterministic.
+          # The repository's own Rust build code necessarily executes here;
+          # that code is what this workflow exists to benchmark and is
+          # reviewed through normal PR review.
           .venv-rw/bin/pip install maturin==1.14.1 psutil==7.2.2
           # maturin locates the target venv via VIRTUAL_ENV; invoking its binary
           # from .venv-rw/bin does not set it, and the venv is not named ".venv".
@@ -79,6 +85,12 @@ jobs:
           REPS: ${{ inputs.reps }}
           CONCURRENCY: ${{ inputs.concurrency }}
         run: |
+          # Constrain BACKENDS before it is word-split below: env routing
+          # already prevents shell injection, and this rejects CLI-option
+          # smuggling (e.g. "rustwright --weakness") through the split.
+          case "$BACKENDS" in
+            (*[!a-z\ ]*) echo "invalid backends: must be space-separated lowercase words"; exit 1 ;;
+          esac
           # shellcheck disable=SC2086  # BACKENDS is an intentional space-separated list
           PYTHONPATH="$PWD/benchmarks/form_fill" \
             .venv-rw/bin/python benchmarks/form_fill/harness/run_suite.py \
@@ -91,12 +103,18 @@ jobs:
 
       - name: Print benchmark summary
         if: always()
-        run: cat out/suite/suite_summary.txt
+        run: |
+          if [ -f out/suite/suite_summary.txt ]; then
+            cat out/suite/suite_summary.txt
+          else
+            echo "No summary produced (benchmark aborted before writing output)."
+          fi
 
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: form-fill-cloud-benchmark
           path: out/suite/
-          if-no-files-found: warn
+          if-no-files-found: error
+          retention-days: 30

--- a/.github/workflows/form-fill-cloud-benchmark.yml
+++ b/.github/workflows/form-fill-cloud-benchmark.yml
@@ -39,13 +39,11 @@ jobs:
     timeout-minutes: 120
 
     steps:
-      # NOTE: Pin this action to a full commit SHA before merge.
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      # NOTE: Pin this action to a full commit SHA before merge.
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
 
@@ -57,8 +55,9 @@ jobs:
       - name: Build rustwright in its benchmark environment
         run: |
           python -m venv .venv-rw
-          .venv-rw/bin/pip install -U pip maturin
-          .venv-rw/bin/pip install psutil
+          # Exact pins: this step runs before the secret-bearing benchmark
+          # step, so nothing mutable is installed on the way there.
+          .venv-rw/bin/pip install maturin==1.14.1 psutil==7.2.2
           # maturin locates the target venv via VIRTUAL_ENV; invoking its binary
           # from .venv-rw/bin does not set it, and the venv is not named ".venv".
           VIRTUAL_ENV="$PWD/.venv-rw" .venv-rw/bin/maturin develop --release
@@ -66,31 +65,37 @@ jobs:
       - name: Install reference Playwright in its benchmark environment
         run: |
           python -m venv .venv-pw
-          .venv-pw/bin/pip install "playwright==1.59.0"
-          .venv-pw/bin/pip install psutil
+          .venv-pw/bin/pip install playwright==1.59.0 psutil==7.2.2
 
       - name: Run form-fill cloud benchmark suite
         env:
           SKYVERN_CLOUD_API_KEY: ${{ secrets.SKYVERN_CLOUD_API_KEY }}
           SKYVERN_BASE_URL: https://api.skyvern.com
-        run: >-
-          PYTHONPATH=$PWD/benchmarks/form_fill
-          .venv-rw/bin/python benchmarks/form_fill/harness/run_suite.py
-          --cases "${{ inputs.cases_file }}"
-          --backends ${{ inputs.backends }}
-          --reps ${{ inputs.reps }}
-          --concurrency ${{ inputs.concurrency }}
-          --python rustwright=$PWD/.venv-rw/bin/python playwright=$PWD/.venv-pw/bin/python
-          --output out/suite
+          # Dispatch inputs are passed via env, never interpolated into the
+          # shell, so input text cannot inject commands. run_suite.py further
+          # constrains --backends to {rustwright, playwright}.
+          CASES_FILE: ${{ inputs.cases_file }}
+          BACKENDS: ${{ inputs.backends }}
+          REPS: ${{ inputs.reps }}
+          CONCURRENCY: ${{ inputs.concurrency }}
+        run: |
+          # shellcheck disable=SC2086  # BACKENDS is an intentional space-separated list
+          PYTHONPATH="$PWD/benchmarks/form_fill" \
+            .venv-rw/bin/python benchmarks/form_fill/harness/run_suite.py \
+            --cases "$CASES_FILE" \
+            --backends $BACKENDS \
+            --reps "$REPS" \
+            --concurrency "$CONCURRENCY" \
+            --python "rustwright=$PWD/.venv-rw/bin/python" "playwright=$PWD/.venv-pw/bin/python" \
+            --output out/suite
 
       - name: Print benchmark summary
         if: always()
         run: cat out/suite/suite_summary.txt
 
-      # NOTE: Pin this action to a full commit SHA before merge.
       - name: Upload benchmark results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: form-fill-cloud-benchmark
           path: out/suite/

--- a/.github/workflows/form-fill-cloud-benchmark.yml
+++ b/.github/workflows/form-fill-cloud-benchmark.yml
@@ -1,0 +1,97 @@
+# Dispatch-only; requires the repository secret SKYVERN_CLOUD_API_KEY; browsers run in remote Skyvern cloud sessions (no local browser); runs never submit forms.
+name: Form-fill cloud benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      cases_file:
+        description: Benchmark cases file
+        type: string
+        default: benchmarks/form_fill/cases/smoke_nav.json
+      backends:
+        description: Space-separated backends to benchmark
+        type: string
+        default: rustwright playwright
+      reps:
+        description: Repetitions per case and backend
+        type: string
+        default: "2"
+      concurrency:
+        description: Maximum concurrent benchmark cases
+        type: string
+        default: "4"
+      runner_label:
+        description: Runner label
+        type: choice
+        default: blacksmith-8vcpu-ubuntu-2404
+        options:
+          - blacksmith-8vcpu-ubuntu-2404
+          - blacksmith-4vcpu-ubuntu-2404
+          - ubuntu-latest
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: Rustwright and Playwright cloud benchmark
+    runs-on: ${{ inputs.runner_label }}
+    timeout-minutes: 120
+
+    steps:
+      # NOTE: Pin this action to a full commit SHA before merge.
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      # NOTE: Pin this action to a full commit SHA before merge.
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: stable
+
+      - name: Build rustwright in its benchmark environment
+        run: |
+          python -m venv .venv-rw
+          .venv-rw/bin/pip install -U pip maturin
+          .venv-rw/bin/pip install psutil
+          # maturin locates the target venv via VIRTUAL_ENV; invoking its binary
+          # from .venv-rw/bin does not set it, and the venv is not named ".venv".
+          VIRTUAL_ENV="$PWD/.venv-rw" .venv-rw/bin/maturin develop --release
+
+      - name: Install reference Playwright in its benchmark environment
+        run: |
+          python -m venv .venv-pw
+          .venv-pw/bin/pip install "playwright==1.59.0"
+          .venv-pw/bin/pip install psutil
+
+      - name: Run form-fill cloud benchmark suite
+        env:
+          SKYVERN_CLOUD_API_KEY: ${{ secrets.SKYVERN_CLOUD_API_KEY }}
+          SKYVERN_BASE_URL: https://api.skyvern.com
+        run: >-
+          PYTHONPATH=$PWD/benchmarks/form_fill
+          .venv-rw/bin/python benchmarks/form_fill/harness/run_suite.py
+          --cases "${{ inputs.cases_file }}"
+          --backends ${{ inputs.backends }}
+          --reps ${{ inputs.reps }}
+          --concurrency ${{ inputs.concurrency }}
+          --python rustwright=$PWD/.venv-rw/bin/python playwright=$PWD/.venv-pw/bin/python
+          --output out/suite
+
+      - name: Print benchmark summary
+        if: always()
+        run: cat out/suite/suite_summary.txt
+
+      # NOTE: Pin this action to a full commit SHA before merge.
+      - name: Upload benchmark results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: form-fill-cloud-benchmark
+          path: out/suite/
+          if-no-files-found: warn

--- a/benchmarks/form_fill/RESULTS.md
+++ b/benchmarks/form_fill/RESULTS.md
@@ -2,14 +2,17 @@
 
 ## Cloud CDP benchmark (2026-07-16) — replication-grade
 
-Three green CI runs on Blacksmith 8-vCPU Ubuntu 24.04 runners, each rep driving
-a fresh remote Skyvern cloud browser over CDP (browser memory off-box):
-reference Playwright 1.59.0 vs rustwright built from source at main. **182/182
-sessions completed, zero failures, 36 cases.** Website time is excluded from
-the latency metric (navigation and page waits are timed as separate bands),
-and the live lane shows both backends wait comparably (0.94×), so the
-exclusion does not favor either side. Full methodology, per-case tables, and
-caveats: [`reports/rustwright_benchmark_report.html`](reports/rustwright_benchmark_report.html).
+Three green CI runs on Blacksmith 8-vCPU Ubuntu 24.04 runners (rustwright-cloud
+repository CI; run IDs below), each rep driving a fresh remote Skyvern cloud
+browser over CDP (browser memory off-box): reference Playwright 1.59.0 vs
+rustwright built from source — engine and suite at rustwright-cloud commit
+`e63087b` (its `main` of 2026-07-16). **182/182 sessions completed, zero
+failures, 36 cases.** Website time is excluded from the latency metric
+(navigation and page waits are timed as separate bands); the live lane shows
+both backends wait comparably (0.94×), and since rustwright waited slightly
+*less*, the exclusion removes a small rustwright advantage — it cannot flatter
+rustwright's latency numbers. Full methodology, per-case tables, and caveats:
+[`reports/rustwright_benchmark_report.html`](reports/rustwright_benchmark_report.html).
 
 | Lane (Actions run ID) | Sessions | Client PSS peak, rw ÷ pw | Library latency, rw ÷ pw |
 |---|---:|---:|---:|
@@ -33,13 +36,23 @@ caveats: [`reports/rustwright_benchmark_report.html`](reports/rustwright_benchma
   Linux).
 
 Reproduce (dispatch-only workflow; requires the `SKYVERN_CLOUD_API_KEY`
-repository secret):
+repository secret). One dispatch per lane:
 
 ```bash
 gh workflow run form-fill-cloud-benchmark.yml \
   -f cases_file=benchmarks/form_fill/cases/controlled.json \
   -f backends="rustwright playwright" -f reps=3 -f concurrency=6
+gh workflow run form-fill-cloud-benchmark.yml \
+  -f cases_file=benchmarks/form_fill/cases/controlled_more.json \
+  -f backends="rustwright playwright" -f reps=3 -f concurrency=6
+gh workflow run form-fill-cloud-benchmark.yml \
+  -f cases_file=benchmarks/form_fill/cases/nav_the_internet.json \
+  -f backends="rustwright playwright" -f reps=2 -f concurrency=6
 ```
+
+Reruns build rustwright from the dispatched ref, so numbers will drift as the
+engine evolves; the figures above correspond to the commit recorded in this
+section.
 
 ## Recorded demo results (2026-07-14, June-alpha build)
 

--- a/benchmarks/form_fill/RESULTS.md
+++ b/benchmarks/form_fill/RESULTS.md
@@ -1,4 +1,47 @@
-# Form-fill benchmark — recorded demo results
+# Form-fill benchmark — results
+
+## Cloud CDP benchmark (2026-07-16) — replication-grade
+
+Three green CI runs on Blacksmith 8-vCPU Ubuntu 24.04 runners, each rep driving
+a fresh remote Skyvern cloud browser over CDP (browser memory off-box):
+reference Playwright 1.59.0 vs rustwright built from source at main. **182/182
+sessions completed, zero failures, 36 cases.** Website time is excluded from
+the latency metric (navigation and page waits are timed as separate bands),
+and the live lane shows both backends wait comparably (0.94×), so the
+exclusion does not favor either side. Full methodology, per-case tables, and
+caveats: [`reports/rustwright_benchmark_report.html`](reports/rustwright_benchmark_report.html).
+
+| Lane (Actions run ID) | Sessions | Client PSS peak, rw ÷ pw | Library latency, rw ÷ pw |
+|---|---:|---:|---:|
+| controlled ×10, reps=3 (`29465108042`) | 60/60 | 0.25× | 1.80× |
+| controlled_more ×9, reps=3 (`29476022036`) | 54/54 | 0.24× | 1.29× |
+| live sites ×17, reps=2 (`29476022706`) | 68/68 | 0.27× | 1.79× |
+
+- **Memory: ~4× smaller client footprint** — 28 vs 110 MB median peak PSS,
+  smaller in every one of the 36 cases (per-case range 25–69 vs 86–152 MB).
+  This confirms and strengthens the demo-era "−71% client memory" figure
+  (−75% here, on real Linux PSS).
+- **Latency: slower on every case over remote CDP** (1.13–2.58×). Raw CDP
+  `evaluate` round-trips are at parity (55 vs 56 ms), so the deficit is not
+  the wire: it concentrates in connection setup (2.31×) and object-returning
+  `evaluate` (~2.1–2.6×), over a ~1.2× per-operation baseline. This
+  supersedes the single-pair demo "actions −19.9% / −30.8%" observations
+  below, which came from an unpinned June-alpha build.
+- Optimization targets tracked for follow-up work: connect/attach setup,
+  object-eval serialization, and `query_selector_all` handle materialization
+  (~270 ms/handle in the smoke-stage weakness lane; not yet re-measured on
+  Linux).
+
+Reproduce (dispatch-only workflow; requires the `SKYVERN_CLOUD_API_KEY`
+repository secret):
+
+```bash
+gh workflow run form-fill-cloud-benchmark.yml \
+  -f cases_file=benchmarks/form_fill/cases/controlled.json \
+  -f backends="rustwright playwright" -f reps=3 -f concurrency=6
+```
+
+## Recorded demo results (2026-07-14, June-alpha build)
 
 Demo-grade results from single run pairs of this harness, recorded 2026-07-14.
 Per [`BENCHMARK.md`](../../BENCHMARK.md), these are **illustrative demo numbers,
@@ -7,7 +50,7 @@ repeated testbox runs. They are recorded here so that published figures (README
 media, demo GIFs) have a citable, reproducible source. Raw data:
 [`results/`](results/).
 
-## Protocol
+### Protocol
 
 - One Python script, byte-identical for both backends; only the import differs
   (`BACKEND=playwright|rustwright`). See [`fill_form.py`](fill_form.py).
@@ -31,7 +74,7 @@ media, demo GIFs) have a citable, reproducible source. Raw data:
 - Scripted demo pauses (~11.7 s per run) are identical constants in both runs
   and are excluded from "actions" time.
 
-## Local recorded pair (`results/stats_local_recorded.json`)
+### Local recorded pair (`results/stats_local_recorded.json`)
 
 | Metric | Playwright | Rustwright | Δ |
 |---|---:|---:|---:|
@@ -50,7 +93,7 @@ full-stack numbers are close because both backends drive the same
 Chromium; rustwright's chromium tree measured heavier in this pair due to
 launch-flag differences since aligned with Playwright's defaults.
 
-## Remote CDP pair (`results/stats_remote_cdp.json`)
+### Remote CDP pair (`results/stats_remote_cdp.json`)
 
 Same workload via `connect_over_cdp` to a fresh remote browser session per run
 (WAN), so container memory contains only the client stack. File-upload fields
@@ -66,10 +109,10 @@ browser-host paths); 20 fields filled per run.
 
 These are single-pair observations over a WAN and network conditions were
 not controlled; they should not be read as a general protocol-efficiency
-result. Repeated runs under controlled latency would be needed to
-establish that.
+result. The replication-grade cloud CDP section above now provides that
+measurement and supersedes this pair's latency deltas.
 
-## Reproduce
+### Reproduce (demo pairs)
 
 ```bash
 # a Greenhouse-style posting you are authorized to test against:

--- a/benchmarks/form_fill/RESULTS.md
+++ b/benchmarks/form_fill/RESULTS.md
@@ -2,12 +2,16 @@
 
 ## Cloud CDP benchmark (2026-07-16) — replication-grade
 
-Three green CI runs on Blacksmith 8-vCPU Ubuntu 24.04 runners (rustwright-cloud
-repository CI; run IDs below), each rep driving a fresh remote Skyvern cloud
-browser over CDP (browser memory off-box): reference Playwright 1.59.0 vs
-rustwright built from source — engine and suite at rustwright-cloud commit
-`e63087b` (its `main` of 2026-07-16). **182/182 sessions completed, zero
-failures, 36 cases.** Website time is excluded from the latency metric
+Three green CI runs on Blacksmith 8-vCPU Ubuntu 24.04 runners (run IDs below
+are on the private `Skyvern-AI/rustwright-cloud` CI, accessible to org
+members; the per-lane summary tables those runs produced are committed
+verbatim under
+[`results/cloud_cdp_2026-07-16/`](results/cloud_cdp_2026-07-16/) for public
+audit). Each rep drives a fresh remote Skyvern cloud browser over CDP
+(browser memory off-box): reference Playwright 1.59.0 vs rustwright built
+from source — engine and suite at rustwright-cloud commit `e63087b` (its
+`main` of 2026-07-16). **182/182 sessions completed, zero failures, 36
+cases.** Website time is excluded from the latency metric
 (navigation and page waits are timed as separate bands); the live lane shows
 both backends wait comparably (0.94×), and since rustwright waited slightly
 *less*, the exclusion removes a small rustwright advantage — it cannot flatter
@@ -25,11 +29,13 @@ rustwright's latency numbers. Full methodology, per-case tables, and caveats:
   This confirms and strengthens the demo-era "−71% client memory" figure
   (−75% here, on real Linux PSS).
 - **Latency: slower on every case over remote CDP** (1.13–2.58×). Raw CDP
-  `evaluate` round-trips are at parity (55 vs 56 ms), so the deficit is not
-  the wire: it concentrates in connection setup (2.31×) and object-returning
-  `evaluate` (~2.1–2.6×), over a ~1.2× per-operation baseline. This
-  supersedes the single-pair demo "actions −19.9% / −30.8%" observations
-  below, which came from an unpinned June-alpha build.
+  `evaluate` round-trips are at parity (55 vs 56 ms), so the per-message
+  transport itself is not the gap: the deficit concentrates in connection
+  setup (2.31×) and object-returning `evaluate` (~2.1–2.6×), over a ~1.2×
+  per-operation baseline — consistent with extra round trips and
+  serialization work on those paths, whose cost the remote link amplifies.
+  This supersedes the single-pair demo "actions −19.9% / −30.8%"
+  observations below, which came from an unpinned June-alpha build.
 - Optimization targets tracked for follow-up work: connect/attach setup,
   object-eval serialization, and `query_selector_all` handle materialization
   (~270 ms/handle in the smoke-stage weakness lane; not yet re-measured on
@@ -50,9 +56,15 @@ gh workflow run form-fill-cloud-benchmark.yml \
   -f backends="rustwright playwright" -f reps=2 -f concurrency=6
 ```
 
-Reruns build rustwright from the dispatched ref, so numbers will drift as the
-engine evolves; the figures above correspond to the commit recorded in this
-section.
+These commands dispatch the current default branch and track current stable
+Rust, Python 3.11.x, the runner image, and the remote browser service — they
+reproduce the *protocol*, not the recorded environment. Expect drift; the
+figures above correspond to the suite/engine commit recorded in this section,
+with the raw per-lane tables those runs produced committed under
+[`results/cloud_cdp_2026-07-16/`](results/cloud_cdp_2026-07-16/).
+"Replication" here means the finding — direction and rough magnitude —
+reproduced across three independent runs and two different case mixes, not
+that identical conditions can be replayed bit-for-bit.
 
 ## Recorded demo results (2026-07-14, June-alpha build)
 
@@ -60,7 +72,8 @@ Demo-grade results from single run pairs of this harness, recorded 2026-07-14.
 Per [`BENCHMARK.md`](../../BENCHMARK.md), these are **illustrative demo numbers,
 not durable benchmark claims** — durable claims should come from capped,
 repeated testbox runs. They are recorded here so that published figures (README
-media, demo GIFs) have a citable, reproducible source. Raw data:
+media, demo GIFs) have a citable, archived source; the unpinned June-alpha
+build means they are auditable but not experimentally reproducible. Raw data:
 [`results/`](results/).
 
 ### Protocol
@@ -122,8 +135,9 @@ browser-host paths); 20 fields filled per run.
 
 These are single-pair observations over a WAN and network conditions were
 not controlled; they should not be read as a general protocol-efficiency
-result. The replication-grade cloud CDP section above now provides that
-measurement and supersedes this pair's latency deltas.
+result. The cloud CDP section above supersedes this pair's latency deltas
+with repeated, multi-case measurement over the same class of remote
+connection (it does not add network shaping or latency control).
 
 ### Reproduce (demo pairs)
 

--- a/benchmarks/form_fill/results/cloud_cdp_2026-07-16/controlled/suite_summary.txt
+++ b/benchmarks/form_fill/results/cloud_cdp_2026-07-16/controlled/suite_summary.txt
@@ -1,0 +1,23 @@
+case | category | backend | lib_latency_ms(median) | lib_latency_ms(p95) | probe_ms(median) | probe_ms(p95) | page_wait_ms(median) | page_wait_ms(p95) | pss_peak_mb(median) | equivalent_work | soft_failures | ok/total
+controlled_click_20_buttons | navigation | rustwright | 15569.581 | 15626.219 | 798.880 | 801.144 | 0.000 | 0.000 | 68.811 | 3/3 | True | 0
+controlled_click_20_buttons | navigation | playwright | 12601.079 | 12683.525 | 680.115 | 681.084 | 0.000 | 0.000 | 108.275 | 3/3 | True | 0
+controlled_evaluate_rtt_100 | navigation | rustwright | 7571.825 | 7685.961 | 784.601 | 787.036 | 0.000 | 0.000 | 27.820 | 3/3 | True | 0
+controlled_evaluate_rtt_100 | navigation | playwright | 6694.005 | 7097.335 | 678.368 | 680.272 | 0.000 | 0.000 | 110.573 | 3/3 | True | 0
+controlled_object_eval_small_25 | navigation | rustwright | 6427.869 | 6480.061 | 795.360 | 802.214 | 0.000 | 0.000 | 28.006 | 3/3 | True | 0
+controlled_object_eval_small_25 | navigation | playwright | 2487.416 | 2548.611 | 679.342 | 679.388 | 0.000 | 0.000 | 107.886 | 3/3 | True | 0
+controlled_object_eval_large_10 | navigation | rustwright | 4088.890 | 4089.708 | 791.189 | 795.377 | 0.000 | 0.000 | 32.431 | 3/3 | True | 0
+controlled_object_eval_large_10 | navigation | playwright | 1978.495 | 1978.634 | 679.985 | 681.349 | 0.000 | 0.000 | 135.155 | 3/3 | True | 0
+controlled_large_dom_all_cells_20 | navigation | rustwright | 3338.706 | 3389.377 | 814.569 | 814.751 | 0.000 | 0.000 | 28.418 | 3/3 | True | 0
+controlled_large_dom_all_cells_20 | navigation | playwright | 2410.628 | 2816.916 | 696.976 | 697.510 | 0.000 | 0.000 | 106.928 | 3/3 | True | 0
+controlled_large_dom_id_lookup_100 | navigation | rustwright | 7805.036 | 7812.593 | 808.629 | 815.189 | 0.000 | 0.000 | 25.679 | 3/3 | True | 0
+controlled_large_dom_id_lookup_100 | navigation | playwright | 6740.478 | 7255.837 | 696.905 | 696.997 | 0.000 | 0.000 | 109.879 | 3/3 | True | 0
+controlled_deep_dom_query_50 | navigation | rustwright | 4994.083 | 5007.310 | 793.279 | 800.374 | 0.000 | 0.000 | 28.011 | 3/3 | True | 0
+controlled_deep_dom_query_50 | navigation | playwright | 3872.319 | 3880.775 | 678.993 | 679.385 | 0.000 | 0.000 | 110.082 | 3/3 | True | 0
+controlled_form_checkbox_click_24 | navigation | rustwright | 17993.157 | 18196.151 | 792.982 | 798.214 | 0.000 | 0.000 | 25.632 | 3/3 | True | 0
+controlled_form_checkbox_click_24 | navigation | playwright | 14834.215 | 14919.633 | 680.483 | 681.919 | 0.000 | 0.000 | 110.699 | 3/3 | True | 0
+controlled_dynamic_wait_300ms | navigation | rustwright | 2971.748 | 2991.704 | 803.601 | 805.952 | 583.675 | 585.423 | 25.564 | 3/3 | True | 0
+controlled_dynamic_wait_300ms | navigation | playwright | 1778.620 | 1791.025 | 677.244 | 679.827 | 522.037 | 526.168 | 110.040 | 3/3 | True | 0
+controlled_goto_data_url_20 | navigation | rustwright | 2126.415 | 2149.254 | 799.962 | 805.358 | 0.000 | 0.000 | 28.812 | 3/3 | True | 0
+controlled_goto_data_url_20 | navigation | playwright | 935.680 | 1008.955 | 679.361 | 679.683 | 0.000 | 0.000 | 109.892 | 3/3 | True | 0
+
+Note: library_latency_ms excludes page_wait.

--- a/benchmarks/form_fill/results/cloud_cdp_2026-07-16/controlled_more/suite_summary.txt
+++ b/benchmarks/form_fill/results/cloud_cdp_2026-07-16/controlled_more/suite_summary.txt
@@ -1,0 +1,21 @@
+case | category | backend | lib_latency_ms(median) | lib_latency_ms(p95) | probe_ms(median) | probe_ms(p95) | page_wait_ms(median) | page_wait_ms(p95) | pss_peak_mb(median) | equivalent_work | soft_failures | ok/total
+controlled_more_click_50_sequential | navigation | rustwright | 35635.644 | 35652.119 | 798.744 | 801.157 | 0.000 | 0.000 | 25.190 | 3/3 | True | 0
+controlled_more_click_50_sequential | navigation | playwright | 29780.547 | 30397.555 | 680.241 | 697.764 | 0.000 | 0.000 | 85.833 | 3/3 | True | 0
+controlled_more_evaluate_rtt_40 | navigation | rustwright | 4491.104 | 4848.561 | 820.018 | 877.617 | 0.000 | 0.000 | 24.672 | 3/3 | True | 0
+controlled_more_evaluate_rtt_40 | navigation | playwright | 3337.414 | 3381.774 | 681.913 | 696.057 | 0.000 | 0.000 | 111.231 | 3/3 | True | 0
+controlled_more_object_eval_increasing | navigation | rustwright | 3506.973 | 3519.711 | 806.168 | 811.204 | 0.000 | 0.000 | 39.576 | 3/3 | True | 0
+controlled_more_object_eval_increasing | navigation | playwright | 1596.362 | 1654.766 | 701.489 | 702.563 | 0.000 | 0.000 | 151.989 | 3/3 | True | 0
+controlled_more_property_reads_80 | navigation | rustwright | 6780.811 | 6916.337 | 823.363 | 823.618 | 0.000 | 0.000 | 26.503 | 3/3 | True | 0
+controlled_more_property_reads_80 | navigation | playwright | 5726.902 | 5761.216 | 684.325 | 705.629 | 0.000 | 0.000 | 110.600 | 3/3 | True | 0
+controlled_more_dynamic_page_wait_300ms | navigation | rustwright | 2918.287 | 2965.411 | 793.958 | 797.488 | 582.014 | 594.698 | 27.376 | 3/3 | True | 0
+controlled_more_dynamic_page_wait_300ms | navigation | playwright | 1774.968 | 1825.610 | 696.866 | 699.111 | 543.585 | 549.508 | 111.415 | 3/3 | True | 0
+controlled_more_form_field_reads_60 | navigation | rustwright | 5576.342 | 5597.729 | 812.735 | 816.699 | 0.000 | 0.000 | 26.602 | 3/3 | True | 0
+controlled_more_form_field_reads_60 | navigation | playwright | 4565.665 | 4615.664 | 699.828 | 717.413 | 0.000 | 0.000 | 110.828 | 3/3 | True | 0
+controlled_more_goto_tiny_data_url_30 | navigation | rustwright | 2169.678 | 2209.961 | 804.962 | 823.344 | 0.000 | 0.000 | 26.396 | 3/3 | True | 0
+controlled_more_goto_tiny_data_url_30 | navigation | playwright | 948.226 | 987.633 | 688.093 | 697.628 | 0.000 | 0.000 | 110.522 | 3/3 | True | 0
+controlled_more_mixed_click_eval_25 | navigation | rustwright | 20173.970 | 20283.177 | 791.574 | 793.417 | 0.000 | 0.000 | 24.898 | 3/3 | True | 0
+controlled_more_mixed_click_eval_25 | navigation | playwright | 17150.527 | 17188.154 | 683.334 | 696.458 | 0.000 | 0.000 | 111.776 | 3/3 | True | 0
+controlled_more_large_dom_row_count_40 | navigation | rustwright | 4559.210 | 4597.982 | 829.811 | 836.164 | 0.000 | 0.000 | 27.537 | 3/3 | True | 0
+controlled_more_large_dom_row_count_40 | navigation | playwright | 3545.620 | 3606.297 | 715.854 | 768.458 | 0.000 | 0.000 | 114.575 | 3/3 | True | 0
+
+Note: library_latency_ms excludes page_wait.

--- a/benchmarks/form_fill/results/cloud_cdp_2026-07-16/live_the_internet/suite_summary.txt
+++ b/benchmarks/form_fill/results/cloud_cdp_2026-07-16/live_the_internet/suite_summary.txt
@@ -1,0 +1,37 @@
+case | category | backend | lib_latency_ms(median) | lib_latency_ms(p95) | probe_ms(median) | probe_ms(p95) | page_wait_ms(median) | page_wait_ms(p95) | pss_peak_mb(median) | equivalent_work | soft_failures | ok/total
+internet_add_element_once | navigation | rustwright | 3180.226 | 3227.565 | 809.165 | 813.003 | 468.053 | 484.928 | 27.683 | 2/2 | True | 0
+internet_add_element_once | navigation | playwright | 2218.488 | 2441.867 | 689.056 | 696.851 | 374.246 | 376.711 | 101.686 | 2/2 | True | 0
+internet_add_three_elements | navigation | rustwright | 4506.168 | 4522.763 | 803.565 | 807.733 | 448.149 | 450.192 | 48.094 | 2/2 | True | 0
+internet_add_three_elements | navigation | playwright | 3274.378 | 3275.200 | 698.524 | 698.719 | 288.013 | 288.068 | 87.076 | 2/2 | True | 0
+internet_toggle_first_checkbox | navigation | rustwright | 2930.985 | 2961.138 | 807.861 | 809.906 | 558.461 | 568.257 | 27.660 | 2/2 | True | 0
+internet_toggle_first_checkbox | navigation | playwright | 1638.503 | 1655.745 | 699.146 | 699.168 | 568.465 | 591.913 | 91.200 | 2/2 | True | 0
+internet_count_dropdown_options | navigation | rustwright | 2204.975 | 2248.314 | 805.678 | 809.315 | 535.426 | 538.480 | 27.466 | 2/2 | True | 0
+internet_count_dropdown_options | navigation | playwright | 1091.022 | 1097.237 | 698.937 | 699.033 | 638.612 | 646.545 | 102.532 | 2/2 | True | 0
+internet_dynamic_loading_hidden_element | navigation | rustwright | 3068.851 | 3091.054 | 807.890 | 815.463 | 5304.350 | 5306.877 | 26.261 | 2/2 | True | 0
+internet_dynamic_loading_hidden_element | navigation | playwright | 2130.208 | 2167.318 | 700.776 | 702.707 | 5460.716 | 5486.905 | 100.253 | 2/2 | True | 0
+internet_dynamic_loading_rendered_element | navigation | rustwright | 3001.523 | 3062.759 | 805.445 | 809.872 | 5337.263 | 5340.905 | 27.451 | 2/2 | True | 0
+internet_dynamic_loading_rendered_element | navigation | playwright | 2101.019 | 2145.095 | 699.130 | 699.416 | 5446.303 | 5453.139 | 100.885 | 2/2 | True | 0
+internet_dynamic_controls_remove_checkbox | navigation | rustwright | 2999.104 | 3113.633 | 803.322 | 808.554 | 600.920 | 647.845 | 27.742 | 2/2 | True | 0
+internet_dynamic_controls_remove_checkbox | navigation | playwright | 1613.849 | 1669.277 | 695.371 | 700.123 | 663.797 | 688.855 | 100.932 | 2/2 | True | 0
+internet_login_controls_present | navigation | rustwright | 2227.538 | 2239.329 | 797.267 | 799.956 | 551.587 | 578.110 | 26.239 | 2/2 | True | 0
+internet_login_controls_present | navigation | playwright | 1079.089 | 1095.838 | 690.803 | 699.899 | 589.359 | 599.479 | 102.797 | 2/2 | True | 0
+internet_table_row_count | navigation | rustwright | 2182.168 | 2186.948 | 805.046 | 813.271 | 576.202 | 585.349 | 27.903 | 2/2 | True | 0
+internet_table_row_count | navigation | playwright | 1055.651 | 1135.675 | 683.047 | 686.057 | 611.543 | 646.566 | 101.690 | 2/2 | True | 0
+internet_challenging_dom_row_count | navigation | rustwright | 2459.747 | 2718.785 | 810.389 | 813.624 | 575.698 | 587.872 | 27.897 | 2/2 | True | 0
+internet_challenging_dom_row_count | navigation | playwright | 1057.941 | 1080.495 | 693.827 | 697.872 | 676.535 | 681.685 | 112.377 | 2/2 | True | 0
+internet_jquery_menu_navigation | navigation | rustwright | 2927.182 | 2952.486 | 804.606 | 808.324 | 663.967 | 686.919 | 26.822 | 2/2 | True | 0
+internet_jquery_menu_navigation | navigation | playwright | 1708.376 | 1737.494 | 702.071 | 706.456 | 611.279 | 624.506 | 102.634 | 2/2 | True | 0
+internet_ab_test_heading | navigation | rustwright | 2173.890 | 2178.333 | 801.546 | 810.155 | 572.015 | 579.607 | 27.522 | 2/2 | True | 0
+internet_ab_test_heading | navigation | playwright | 1070.922 | 1091.915 | 699.148 | 699.782 | 606.794 | 622.028 | 101.880 | 2/2 | True | 0
+internet_home_to_ab_test_and_back | navigation | rustwright | 3092.198 | 3364.269 | 840.453 | 883.949 | 1151.883 | 1220.416 | 27.069 | 2/2 | True | 0
+internet_home_to_ab_test_and_back | navigation | playwright | 1726.042 | 1760.002 | 681.897 | 682.148 | 1177.832 | 1234.978 | 115.311 | 2/2 | True | 0
+internet_key_presses_initial_result | navigation | rustwright | 2978.057 | 3062.050 | 808.775 | 812.779 | 582.635 | 610.648 | 27.632 | 2/2 | True | 0
+internet_key_presses_initial_result | navigation | playwright | 1651.499 | 1660.364 | 689.370 | 697.708 | 593.660 | 616.271 | 102.698 | 2/2 | True | 0
+internet_infinite_scroll_position | navigation | rustwright | 2249.143 | 2319.870 | 804.096 | 817.481 | 600.433 | 613.225 | 26.651 | 2/2 | True | 0
+internet_infinite_scroll_position | navigation | playwright | 1125.615 | 1208.218 | 689.763 | 697.929 | 621.210 | 631.252 | 113.246 | 2/2 | True | 0
+internet_status_code_navigation_history | navigation | rustwright | 3001.523 | 3023.828 | 801.394 | 810.446 | 559.929 | 588.004 | 27.907 | 2/2 | True | 0
+internet_status_code_navigation_history | navigation | playwright | 1686.339 | 1742.470 | 699.754 | 700.150 | 585.173 | 596.139 | 102.330 | 2/2 | True | 0
+internet_redirector_link_present | navigation | rustwright | 2225.467 | 2246.903 | 799.173 | 806.574 | 578.981 | 606.574 | 27.875 | 2/2 | True | 0
+internet_redirector_link_present | navigation | playwright | 1056.705 | 1071.812 | 696.626 | 697.792 | 585.149 | 592.442 | 114.293 | 2/2 | True | 0
+
+Note: library_latency_ms excludes page_wait.


### PR DESCRIPTION
## What
Publishes the **cloud CDP benchmark** on the public repo — the suite itself is already on `main` via the repo sync; this PR adds the two pieces the sync doesn't carry:

1. **`.github/workflows/form-fill-cloud-benchmark.yml`** — dispatch-only Blacksmith workflow driving remote Skyvern cloud browsers over CDP, side-by-side two-venv build (rustwright via maturin vs pinned reference Playwright 1.59.0). Proven on rustwright-cloud with three green runs. Requires the `SKYVERN_CLOUD_API_KEY` secret; does not affect normal CI.
2. **`benchmarks/form_fill/RESULTS.md`** — adds a replication-grade results section and reorganizes the existing demo-era numbers under a dated heading with an explicit supersession note.

## Results being published (3 runs, 182/182 sessions, 0 failures, 36 cases)
| Lane (run) | Sessions | PSS rw÷pw | Latency rw÷pw |
|---|---|---|---|
| controlled ×10, reps=3 (`29465108042`) | 60/60 | 0.25× | 1.80× |
| controlled_more ×9, reps=3 (`29476022036`) | 54/54 | 0.24× | 1.29× |
| live sites ×17, reps=2 (`29476022706`) | 68/68 | 0.27× | 1.79× |

- **Memory: ~4× smaller client PSS in every case** (28 vs 110 MB median) — confirms the demo-era −71% figure (−75% on real Linux PSS).
- **Latency: slower on every case over remote CDP** (1.13–2.58×); raw CDP `evaluate` at parity (55 vs 56 ms), so the deficit concentrates in connect (2.31×) and object-return/DOM-heavy paths — documented as follow-up optimization targets; perf work is deliberately out of scope here.
- Live lane validates the metric: `page_wait` comparable across backends (0.94×), so excluding website time doesn't favor either side.

## Integrity notes for review
- The demo-era single-pair latency deltas ("actions −19.9% / −30.8%") are explicitly superseded in-document; the memory figure is confirmed.
- Harness redacts browser addresses and API-key headers from all persisted logs/records; the workflow references the secret by name only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
