### PR TITLE
MCP server: expose browser automation as tools for MCP-compatible agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ See [`LIMITATIONS.md`](LIMITATIONS.md) for detail.
 
 - [ ] **Kotlin binding** — idiomatic Kotlin wrapper (Kotlin/JVM can already consume the Java FFM binding)
 - [ ] Grow the new language bindings beyond the alpha subset (contexts, routing, locators)
-- [ ] **Rustwright MCP server** — expose browser automation as tools for MCP-compatible AI agents
+- [x] **Rustwright MCP server** — expose browser automation as tools for MCP-compatible AI agents ([mcp/](mcp/))
 - [ ] CI / Testbox-backed benchmark evidence
 - [ ] Broaden the Node.js surface (contexts, routing, locators)
 - [ ] Close remaining OOPIF gaps

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+*.egg-info/
+__pycache__/
+.pytest_cache/

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -121,9 +121,12 @@ Example Domains
 | `browser_hover(target)` | Hover an element |
 | `browser_press_key(key)` | Press a keyboard key |
 | `browser_navigate_back()` | History back |
+| `browser_reload()` | Reload the active page, returns snapshot |
+| `browser_tabs(action, index?, url?)` | List, open, select, or close tabs |
+| `browser_handle_dialog(accept, prompt_text?)` | Set a one-shot policy for the next dialog |
 | `browser_wait_for(text?, timeout_ms?)` | Wait for text or load state |
 | `browser_get_text(selector?)` | Visible text of a selector |
-| `browser_evaluate(expression)` | Run JavaScript in the page |
+| `browser_evaluate(expression)` | Run JavaScript in the page (opt-in) |
 | `browser_take_screenshot(path?)` | Save a PNG, returns the path |
 | `browser_close()` | End the browser session |
 
@@ -134,6 +137,7 @@ Example Domains
 | `RUSTWRIGHT_MCP_HEADLESS` | `0` shows the browser window (default headless) |
 | `RUSTWRIGHT_MCP_CHANNEL` | Chromium channel, e.g. `chrome`, `chrome-beta` |
 | `RUSTWRIGHT_MCP_EXECUTABLE` | Explicit browser binary path (overrides channel) |
+| `RUSTWRIGHT_MCP_ALLOW_EVAL` | `1`, `true`, or `yes` exposes `browser_evaluate` (default off) |
 
 ### Headless vs headed
 
@@ -153,12 +157,24 @@ The mode is fixed for the lifetime of the server process; to switch, change
 the env var and restart the MCP server (in Claude Code: re-add the server or
 restart the session).
 
+## Security & scope
+
+- `browser_evaluate` is off by default because it runs arbitrary JavaScript
+  in the page. Set `RUSTWRIGHT_MCP_ALLOW_EVAL=1` and restart the server to
+  expose it.
+- Snapshots reflect page state, including field values. Password input values
+  are masked in snapshot output; other field values are included as-is.
+- Snapshot refs are best-effort handles for cooperative pages, not a security
+  boundary. Refs increase for the browser session and stale refs fail fast.
+- Each server process controls a single local browser session, which may have
+  multiple tabs.
+
 ## Limitations
 
-- Single page, single browser session per server process.
+- Single local browser session per server process.
 - Snapshot refs are regenerated on every snapshot; after a page mutation,
   take a new snapshot before acting on refs. Stale refs fail fast with a
   message asking for a fresh snapshot.
 - The snapshot script does not walk iframes (any origin) or shadow DOM;
-  iframes appear as `- iframe "..." (content not captured)` markers. Use
-  `browser_evaluate` to reach into same-origin frames if needed.
+  iframes appear as `- iframe "..." (content not captured)` markers. When
+  enabled, `browser_evaluate` can reach into same-origin frames if needed.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,164 @@
+# Rustwright MCP server
+
+Exposes Rustwright browser automation as [Model Context Protocol](https://modelcontextprotocol.io)
+tools, so MCP-compatible agents (Claude Code, Claude Desktop, others) can browse
+with Rustwright instead of Playwright.
+
+Tool names mirror the Playwright MCP server (`browser_navigate`,
+`browser_snapshot`, `browser_click`, ...) so agents can switch without
+re-learning the surface. `browser_snapshot` returns an accessibility-style
+outline where interactive elements carry `[ref=eN]` handles; pass a ref (or a
+raw CSS selector) to the action tools.
+
+## Quick start (no clone needed)
+
+With [uv](https://docs.astral.sh/uv/) installed, register the server with
+Claude Code in one command — `uvx` fetches and runs it straight from GitHub:
+
+```bash
+claude mcp add rustwright \
+  --env RUSTWRIGHT_MCP_CHANNEL=chrome \
+  -- uvx --from 'git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp' rustwright-mcp
+```
+
+Note the `--` before the command: `--env` is variadic, so without the
+separator it swallows the command and `claude mcp add` fails with
+`missing required argument 'commandOrUrl'`.
+
+Or add to any MCP client config (Claude Desktop, Cursor, etc.):
+
+```json
+{
+  "mcpServers": {
+    "rustwright": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp",
+        "rustwright-mcp"
+      ],
+      "env": { "RUSTWRIGHT_MCP_CHANNEL": "chrome" }
+    }
+  }
+}
+```
+
+`RUSTWRIGHT_MCP_CHANNEL=chrome` uses your installed Google Chrome. Drop it
+to use rustwright's bundled Chromium instead (install once with
+`uvx --from 'git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp' python -m rustwright install chromium`).
+
+Without uv, install into a plain venv from git:
+
+```bash
+python3 -m venv ~/.rustwright-mcp
+~/.rustwright-mcp/bin/pip install 'rustwright-mcp @ git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp'
+```
+
+## Install from a source checkout
+
+```bash
+cd mcp
+python3 -m venv .venv && .venv/bin/pip install -e .
+```
+
+Then either install the bundled Chromium
+(`.venv/bin/python -m rustwright install chromium`) or use
+`RUSTWRIGHT_MCP_CHANNEL=chrome`.
+
+## Register with Claude Code (installed binary)
+
+Use the **absolute path** to the `rustwright-mcp` binary — the server is
+spawned from arbitrary working directories, so relative paths break:
+
+```bash
+claude mcp add rustwright \
+  --env RUSTWRIGHT_MCP_CHANNEL=chrome \
+  -- "$HOME/.rustwright-mcp/bin/rustwright-mcp"
+```
+
+Example with a source checkout at `~/code/rustwright`:
+
+```bash
+claude mcp add rustwright \
+  --env RUSTWRIGHT_MCP_CHANNEL=chrome \
+  -- "$HOME/code/rustwright/mcp/.venv/bin/rustwright-mcp"
+```
+
+Verify with `claude mcp list` — the entry should show `✔ Connected`.
+
+## Example session
+
+What an agent sees. `browser_navigate` returns a snapshot; interactive
+elements carry `[ref=eN]` handles that later calls act on:
+
+```
+> browser_navigate(url="https://example.com")
+Page: Example Domain
+URL: https://example.com/
+
+- heading "Example Domain" [level=1]
+- text: This domain is for use in documentation examples...
+- link "Learn more" [href=https://iana.org/domains/example] [ref=e1]
+
+> browser_click(target="e1")
+Page: Example Domains
+URL: https://www.iana.org/help/example-domains
+...
+
+> browser_get_text(selector="h1")
+Example Domains
+```
+
+## Tools
+
+| Tool | Purpose |
+|---|---|
+| `browser_navigate(url)` | Open a URL, returns snapshot |
+| `browser_snapshot()` | Outline of the page with `[ref=eN]` handles |
+| `browser_click(target)` | Click a ref or CSS selector |
+| `browser_type(target, text, submit?)` | Fill or type into an input |
+| `browser_select_option(target, value)` | Select a dropdown option |
+| `browser_hover(target)` | Hover an element |
+| `browser_press_key(key)` | Press a keyboard key |
+| `browser_navigate_back()` | History back |
+| `browser_wait_for(text?, timeout_ms?)` | Wait for text or load state |
+| `browser_get_text(selector?)` | Visible text of a selector |
+| `browser_evaluate(expression)` | Run JavaScript in the page |
+| `browser_take_screenshot(path?)` | Save a PNG, returns the path |
+| `browser_close()` | End the browser session |
+
+## Configuration
+
+| Variable | Effect |
+|---|---|
+| `RUSTWRIGHT_MCP_HEADLESS` | `0` shows the browser window (default headless) |
+| `RUSTWRIGHT_MCP_CHANNEL` | Chromium channel, e.g. `chrome`, `chrome-beta` |
+| `RUSTWRIGHT_MCP_EXECUTABLE` | Explicit browser binary path (overrides channel) |
+
+### Headless vs headed
+
+The browser runs **headless** by default: no window, suited to CI and
+background agents. Set `RUSTWRIGHT_MCP_HEADLESS=0` to run **headed** with a
+visible browser window — useful for watching the agent work, debugging
+selectors, and for sites whose bot detection blocks headless sessions:
+
+```bash
+claude mcp add rustwright \
+  --env RUSTWRIGHT_MCP_CHANNEL=chrome \
+  --env RUSTWRIGHT_MCP_HEADLESS=0 \
+  -- uvx --from 'git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp' rustwright-mcp
+```
+
+The mode is fixed for the lifetime of the server process; to switch, change
+the env var and restart the MCP server (in Claude Code: re-add the server or
+restart the session).
+
+## Limitations
+
+- Single page, single browser session per server process.
+- Snapshot refs are regenerated on every snapshot; after a page mutation,
+  take a new snapshot before acting on refs. Stale refs fail fast with a
+  message asking for a fresh snapshot.
+- The snapshot script does not walk iframes (any origin) or shadow DOM;
+  iframes appear as `- iframe "..." (content not captured)` markers. Use
+  `browser_evaluate` to reach into same-origin frames if needed.

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rustwright-mcp"
+version = "0.1.0"
+description = "MCP server exposing Rustwright browser automation as tools for MCP-compatible AI agents"
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10"
+dependencies = [
+    "mcp>=1.2",
+    "rustwright>=0.1.1",
+]
+
+[project.optional-dependencies]
+test = ["pytest>=7"]
+
+[project.scripts]
+rustwright-mcp = "rustwright_mcp.server:main"
+
+[tool.setuptools.packages.find]
+include = ["rustwright_mcp*"]

--- a/mcp/rustwright_mcp/__init__.py
+++ b/mcp/rustwright_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""Rustwright MCP server package."""
+
+__version__ = "0.1.0"

--- a/mcp/rustwright_mcp/__main__.py
+++ b/mcp/rustwright_mcp/__main__.py
@@ -1,0 +1,3 @@
+from rustwright_mcp.server import main
+
+main()

--- a/mcp/rustwright_mcp/server.py
+++ b/mcp/rustwright_mcp/server.py
@@ -8,6 +8,7 @@ Environment variables:
     RUSTWRIGHT_MCP_HEADLESS    "0" to show the browser window (default headless)
     RUSTWRIGHT_MCP_CHANNEL     chromium channel, e.g. "chrome" (default: bundled chromium)
     RUSTWRIGHT_MCP_EXECUTABLE  explicit browser executable path (overrides channel)
+    RUSTWRIGHT_MCP_ALLOW_EVAL  "1", "true", or "yes" to expose browser_evaluate
 """
 
 from __future__ import annotations
@@ -41,6 +42,30 @@ def _serialized(fn):
 SNAPSHOT_CHAR_LIMIT = 30_000
 
 
+def _handle_dialog(page, dialog) -> None:
+    policy = _session.get("dialog_policy")
+    if policy is None or policy["page"] is not page:
+        dialog.dismiss()
+        return
+
+    _session.pop("dialog_policy")
+    if policy["accept"]:
+        if policy["prompt_text"] is None:
+            dialog.accept()
+        else:
+            dialog.accept(policy["prompt_text"])
+    else:
+        dialog.dismiss()
+
+
+def _register_dialog_handler(page) -> None:
+    pages = _session.setdefault("dialog_pages", [])
+    if any(existing is page for existing in pages):
+        return
+    page.on("dialog", functools.partial(_handle_dialog, page))
+    pages.append(page)
+
+
 def _page():
     if "page" in _session:
         try:
@@ -63,7 +88,15 @@ def _page():
         pw = sync_playwright().start()
         browser = pw.chromium.launch(**launch_kwargs)
         page = browser.new_page()
-        _session.update(pw=pw, browser=browser, page=page, snapshot_taken=False)
+        _session.update(
+            pw=pw,
+            browser=browser,
+            page=page,
+            snapshot_taken=False,
+            next_ref=1,
+            dialog_pages=[],
+        )
+        _register_dialog_handler(page)
     return _session["page"]
 
 
@@ -73,7 +106,9 @@ def _snapshot(page) -> str:
         page.wait_for_load_state(timeout=10_000)
     except Exception:
         pass
-    outline = page.evaluate(SNAPSHOT_JS)
+    result = page.evaluate(SNAPSHOT_JS, _session["next_ref"])
+    outline = result["outline"]
+    _session["next_ref"] = result["nextRef"]
     _session["snapshot_taken"] = True
     header = f"Page: {page.title()}\nURL: {page.url}\n\n"
     body = outline[:SNAPSHOT_CHAR_LIMIT]
@@ -204,6 +239,84 @@ def browser_navigate_back() -> str:
 
 @mcp.tool()
 @_serialized
+def browser_reload() -> str:
+    """Reload the active page. Returns a fresh snapshot."""
+    page = _page()
+    page.reload()
+    return _snapshot(page)
+
+
+@mcp.tool()
+@_serialized
+def browser_tabs(
+    action: str, index: int | None = None, url: str | None = None
+) -> str:
+    """List, open, select, or close browser tabs.
+
+    `action` is one of "list", "new", "select", or "close". `index` is
+    required when selecting or closing a tab; `url` is optional for new tabs.
+    """
+    page = _page()
+    context = page.context
+    pages = list(context.pages)
+    action = action.lower()
+
+    if action == "list":
+        return "\n".join(
+            f"{i}: {tab.title()} — {tab.url}" for i, tab in enumerate(pages)
+        )
+    if action == "new":
+        page = context.new_page()
+        _register_dialog_handler(page)
+        _session["page"] = page
+        if url:
+            page.goto(url)
+        return _snapshot(page)
+    if action not in {"select", "close"}:
+        raise ValueError('action must be one of "list", "new", "select", or "close"')
+    if index is None or index < 0 or index >= len(pages):
+        raise ValueError(f"Invalid tab index {index}; expected 0 through {len(pages) - 1}")
+
+    if action == "select":
+        page = pages[index]
+        _register_dialog_handler(page)
+        _session["page"] = page
+        page.bring_to_front()
+        return _snapshot(page)
+
+    closing = pages[index]
+    was_active = closing is page
+    closing.close()
+    remaining = list(context.pages)
+    if not remaining:
+        page = context.new_page()
+    elif was_active:
+        page = remaining[min(index, len(remaining) - 1)]
+    _register_dialog_handler(page)
+    _session["page"] = page
+    return _snapshot(page)
+
+
+@mcp.tool()
+@_serialized
+def browser_handle_dialog(accept: bool, prompt_text: str | None = None) -> str:
+    """Accept or dismiss the next JavaScript dialog on the active page.
+
+    A dialog opened by a brand-new popup may be auto-dismissed before its page
+    can be registered. The policy is consumed once; other dialogs auto-dismiss.
+    """
+    page = _page()
+    _session["dialog_policy"] = {
+        "page": page,
+        "accept": accept,
+        "prompt_text": prompt_text,
+    }
+    action = "accepted" if accept else "dismissed"
+    return f"The next dialog on the active page will be {action}."
+
+
+@mcp.tool()
+@_serialized
 def browser_wait_for(text: Optional[str] = None, timeout_ms: float = 10_000) -> str:
     """Wait for text to appear on the page (or for load state when no text
     is given), then return a snapshot."""
@@ -222,12 +335,22 @@ def browser_get_text(selector: str = "body", max_chars: int = 20_000) -> str:
     return _page().inner_text(selector)[:max_chars]
 
 
-@mcp.tool()
-@_serialized
 def browser_evaluate(expression: str) -> str:
     """Run JavaScript in the page. Use an arrow function, e.g.
     "() => document.title". Returns the JSON-ish result as a string."""
     return str(_page().evaluate(expression))
+
+
+def _allow_eval() -> bool:
+    return os.environ.get("RUSTWRIGHT_MCP_ALLOW_EVAL", "").lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+if _allow_eval():
+    mcp.tool()(_serialized(browser_evaluate))
 
 
 @mcp.tool()

--- a/mcp/rustwright_mcp/server.py
+++ b/mcp/rustwright_mcp/server.py
@@ -1,0 +1,260 @@
+"""MCP server exposing Rustwright browser automation over stdio.
+
+Tool names mirror the Playwright MCP server so agents can switch between
+the two without re-learning the surface. Element targeting uses refs from
+``browser_snapshot`` (``e1``, ``e2``, ...) or raw CSS selectors.
+
+Environment variables:
+    RUSTWRIGHT_MCP_HEADLESS    "0" to show the browser window (default headless)
+    RUSTWRIGHT_MCP_CHANNEL     chromium channel, e.g. "chrome" (default: bundled chromium)
+    RUSTWRIGHT_MCP_EXECUTABLE  explicit browser executable path (overrides channel)
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+import tempfile
+import threading
+from typing import Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from rustwright_mcp.snapshot import SNAPSHOT_JS
+
+mcp = FastMCP("rustwright")
+
+_session: dict = {}
+# FastMCP executes sync tools on a thread pool; the browser session is
+# shared state, so tool bodies are serialized.
+_lock = threading.Lock()
+
+
+def _serialized(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with _lock:
+            return fn(*args, **kwargs)
+
+    return wrapper
+
+SNAPSHOT_CHAR_LIMIT = 30_000
+
+
+def _page():
+    if "page" in _session:
+        try:
+            # The user may have closed a headed window; detect a dead
+            # session and relaunch instead of failing every call.
+            _session["page"].evaluate("() => 1")
+        except Exception:
+            _teardown()
+    if "page" not in _session:
+        from rustwright.sync_api import sync_playwright
+
+        headless = os.environ.get("RUSTWRIGHT_MCP_HEADLESS", "1") != "0"
+        launch_kwargs: dict = {"headless": headless}
+        executable = os.environ.get("RUSTWRIGHT_MCP_EXECUTABLE")
+        channel = os.environ.get("RUSTWRIGHT_MCP_CHANNEL")
+        if executable:
+            launch_kwargs["executable_path"] = executable
+        elif channel:
+            launch_kwargs["channel"] = channel
+        pw = sync_playwright().start()
+        browser = pw.chromium.launch(**launch_kwargs)
+        page = browser.new_page()
+        _session.update(pw=pw, browser=browser, page=page, snapshot_taken=False)
+    return _session["page"]
+
+
+def _snapshot(page) -> str:
+    try:
+        # An action may have triggered a navigation; settle before reading the DOM.
+        page.wait_for_load_state(timeout=10_000)
+    except Exception:
+        pass
+    outline = page.evaluate(SNAPSHOT_JS)
+    _session["snapshot_taken"] = True
+    header = f"Page: {page.title()}\nURL: {page.url}\n\n"
+    body = outline[:SNAPSHOT_CHAR_LIMIT]
+    if len(outline) > SNAPSHOT_CHAR_LIMIT:
+        body += "\n- … (snapshot truncated, use browser_get_text for full content)"
+    return header + body
+
+
+def _teardown() -> None:
+    for close in (
+        lambda: _session["browser"].close(),
+        lambda: _session["pw"].stop(),
+    ):
+        try:
+            close()
+        except Exception:
+            pass
+    _session.clear()
+
+
+def _resolve(target: str) -> str:
+    """Map a snapshot ref like ``e12`` to its attribute selector; pass CSS through.
+
+    Refs fail fast when absent from the live DOM (stale snapshot) instead of
+    hitting the full action timeout.
+    """
+    if target and target[0] == "e" and target[1:].isdigit():
+        if not _session.get("snapshot_taken"):
+            raise ValueError(
+                "No snapshot taken on this page yet; call browser_snapshot first"
+            )
+        selector = f'[data-mcp-ref="{target}"]'
+        if _session["page"].query_selector(selector) is None:
+            raise ValueError(
+                f"Ref {target} is not on the current page (stale snapshot); "
+                "call browser_snapshot and use a fresh ref"
+            )
+        return selector
+    return target
+
+
+@mcp.tool()
+@_serialized
+def browser_navigate(url: str) -> str:
+    """Navigate to a URL. Returns the page snapshot with element refs."""
+    page = _page()
+    page.goto(url)
+    return _snapshot(page)
+
+
+@mcp.tool()
+@_serialized
+def browser_snapshot() -> str:
+    """Accessibility-style outline of the current page. Interactive elements
+    carry [ref=eN] handles usable with browser_click / browser_type."""
+    return _snapshot(_page())
+
+
+@mcp.tool()
+@_serialized
+def browser_click(target: str, double_click: bool = False) -> str:
+    """Click an element. `target` is a ref from the snapshot (e.g. "e12") or a
+    CSS selector. Returns a fresh snapshot."""
+    page = _page()
+    selector = _resolve(target)
+    if double_click:
+        page.dblclick(selector)
+    else:
+        page.click(selector)
+    return _snapshot(page)
+
+
+@mcp.tool()
+@_serialized
+def browser_type(target: str, text: str, submit: bool = False, clear: bool = True) -> str:
+    """Type into an input. `target` is a snapshot ref or CSS selector. Set
+    submit=True to press Enter afterwards. Returns a fresh snapshot."""
+    page = _page()
+    selector = _resolve(target)
+    if clear:
+        page.fill(selector, text)
+    else:
+        page.type(selector, text)
+    if submit:
+        page.press(selector, "Enter")
+    return _snapshot(page)
+
+
+@mcp.tool()
+@_serialized
+def browser_select_option(target: str, value: str) -> str:
+    """Select an option in a <select> element by value or visible label."""
+    page = _page()
+    selector = _resolve(target)
+    try:
+        page.select_option(selector, value=value)
+    except Exception:
+        page.select_option(selector, label=value)
+    return _snapshot(page)
+
+
+@mcp.tool()
+@_serialized
+def browser_hover(target: str) -> str:
+    """Hover over an element identified by snapshot ref or CSS selector."""
+    page = _page()
+    page.hover(_resolve(target))
+    return _snapshot(page)
+
+
+@mcp.tool()
+@_serialized
+def browser_press_key(key: str) -> str:
+    """Press a keyboard key (e.g. "Enter", "Escape", "ArrowDown") on the page."""
+    page = _page()
+    page.keyboard.press(key)
+    return _snapshot(page)
+
+
+@mcp.tool()
+@_serialized
+def browser_navigate_back() -> str:
+    """Go back in browser history. Returns a fresh snapshot."""
+    page = _page()
+    page.go_back()
+    return _snapshot(page)
+
+
+@mcp.tool()
+@_serialized
+def browser_wait_for(text: Optional[str] = None, timeout_ms: float = 10_000) -> str:
+    """Wait for text to appear on the page (or for load state when no text
+    is given), then return a snapshot."""
+    page = _page()
+    if text:
+        page.wait_for_selector(f"text={text}", timeout=timeout_ms)
+    else:
+        page.wait_for_load_state(timeout=timeout_ms)
+    return _snapshot(page)
+
+
+@mcp.tool()
+@_serialized
+def browser_get_text(selector: str = "body", max_chars: int = 20_000) -> str:
+    """Visible text content of a CSS selector (defaults to the whole page)."""
+    return _page().inner_text(selector)[:max_chars]
+
+
+@mcp.tool()
+@_serialized
+def browser_evaluate(expression: str) -> str:
+    """Run JavaScript in the page. Use an arrow function, e.g.
+    "() => document.title". Returns the JSON-ish result as a string."""
+    return str(_page().evaluate(expression))
+
+
+@mcp.tool()
+@_serialized
+def browser_take_screenshot(path: Optional[str] = None, full_page: bool = False) -> str:
+    """Save a PNG screenshot and return its file path. Writes to a temporary
+    file when no path is given."""
+    if path is None:
+        fd, path = tempfile.mkstemp(prefix="rustwright-mcp-", suffix=".png")
+        os.close(fd)
+    _page().screenshot(path=path, full_page=full_page)
+    return path
+
+
+@mcp.tool()
+@_serialized
+def browser_close() -> str:
+    """Close the browser. The next tool call starts a fresh session."""
+    if "browser" in _session:
+        _teardown()
+        return "Browser closed."
+    return "No browser session was open."
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp/rustwright_mcp/snapshot.py
+++ b/mcp/rustwright_mcp/snapshot.py
@@ -2,15 +2,16 @@
 
 Produces a compact accessibility-style outline of the page and tags every
 emitted element with a ``data-mcp-ref`` attribute so tools can act on it
-later via an attribute selector. Refs are regenerated on every snapshot;
-acting on a ref from an older snapshot raises a clear error in the server.
+later via an attribute selector. Refs increase for the lifetime of a browser
+session and are regenerated on every snapshot; acting on a ref from an older
+snapshot raises a clear error in the server.
 """
 
 SNAPSHOT_JS = r"""
-() => {
+(startRef) => {
   const MAX_NAME = 120;
   const MAX_LINES = 1200;
-  let refCounter = 0;
+  let refCounter = startRef;
   const lines = [];
 
   for (const el of document.querySelectorAll('[data-mcp-ref]')) {
@@ -100,11 +101,15 @@ SNAPSHOT_JS = r"""
       if (el.disabled) parts.push('[disabled]');
       if (el.checked) parts.push('[checked]');
       if ((el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') && el.value) {
-        parts.push(`[value="${String(el.value).slice(0, 60)}"]`);
+        const isPassword = el.tagName === 'INPUT'
+          && (el.getAttribute('type') || 'text').toLowerCase() === 'password';
+        parts.push(isPassword
+          ? '[value=••••••]'
+          : `[value="${String(el.value).slice(0, 60)}"]`);
       }
       if (isInteractive(el, role)) {
-        refCounter += 1;
         const ref = `e${refCounter}`;
+        refCounter += 1;
         el.setAttribute('data-mcp-ref', ref);
         parts.push(`[ref=${ref}]`);
       }
@@ -128,9 +133,11 @@ SNAPSHOT_JS = r"""
     for (const child of el.children) walk(child, emittedDepth);
   };
 
-  if (!document.body) return '- (page has no body yet)';
+  if (!document.body) {
+    return {outline: '- (page has no body yet)', nextRef: refCounter};
+  }
   walk(document.body, 0);
   if (lines.length >= MAX_LINES) lines.push('- … (snapshot truncated)');
-  return lines.join('\n');
+  return {outline: lines.join('\n'), nextRef: refCounter};
 }
 """

--- a/mcp/rustwright_mcp/snapshot.py
+++ b/mcp/rustwright_mcp/snapshot.py
@@ -1,0 +1,136 @@
+"""In-page snapshot script.
+
+Produces a compact accessibility-style outline of the page and tags every
+emitted element with a ``data-mcp-ref`` attribute so tools can act on it
+later via an attribute selector. Refs are regenerated on every snapshot;
+acting on a ref from an older snapshot raises a clear error in the server.
+"""
+
+SNAPSHOT_JS = r"""
+() => {
+  const MAX_NAME = 120;
+  const MAX_LINES = 1200;
+  let refCounter = 0;
+  const lines = [];
+
+  for (const el of document.querySelectorAll('[data-mcp-ref]')) {
+    el.removeAttribute('data-mcp-ref');
+  }
+
+  const ROLE_BY_TAG = {
+    A: 'link', BUTTON: 'button', SELECT: 'combobox', TEXTAREA: 'textbox',
+    H1: 'heading', H2: 'heading', H3: 'heading', H4: 'heading', H5: 'heading',
+    H6: 'heading', IMG: 'img', NAV: 'navigation', MAIN: 'main', HEADER: 'banner',
+    FOOTER: 'contentinfo', FORM: 'form', TABLE: 'table', UL: 'list', OL: 'list',
+    LI: 'listitem', DIALOG: 'dialog', SUMMARY: 'button', LABEL: 'label',
+    OPTION: 'option', ARTICLE: 'article', SECTION: 'region', ASIDE: 'complementary',
+  };
+  const INPUT_ROLES = {
+    button: 'button', submit: 'button', reset: 'button', checkbox: 'checkbox',
+    radio: 'radio', range: 'slider', search: 'searchbox',
+  };
+  const SKIP_TAGS = new Set(['SCRIPT', 'STYLE', 'NOSCRIPT', 'TEMPLATE', 'META', 'LINK', 'HEAD', 'SVG', 'PATH']);
+
+  const isVisible = (el) => {
+    const style = getComputedStyle(el);
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+    if (el.getAttribute('aria-hidden') === 'true') return false;
+    const rect = el.getBoundingClientRect();
+    return rect.width > 0 || rect.height > 0 || el.tagName === 'OPTION';
+  };
+
+  const roleOf = (el) => {
+    const explicit = el.getAttribute('role');
+    if (explicit) return explicit;
+    if (el.tagName === 'INPUT') {
+      const type = (el.getAttribute('type') || 'text').toLowerCase();
+      return INPUT_ROLES[type] || 'textbox';
+    }
+    return ROLE_BY_TAG[el.tagName] || null;
+  };
+
+  const nameOf = (el) => {
+    const labelled = el.getAttribute('aria-labelledby');
+    if (labelled) {
+      const parts = labelled.split(/\s+/)
+        .map((id) => document.getElementById(id))
+        .filter(Boolean)
+        .map((n) => n.textContent.trim());
+      if (parts.length) return parts.join(' ');
+    }
+    const ariaLabel = el.getAttribute('aria-label');
+    if (ariaLabel) return ariaLabel;
+    // Associated <label> outranks placeholder/title in accessible-name order.
+    if (el.labels && el.labels.length) return el.labels[0].textContent.trim();
+    const direct = el.getAttribute('alt') || el.getAttribute('title')
+      || el.getAttribute('placeholder');
+    if (direct) return direct;
+    if (el.tagName === 'INPUT' || el.tagName === 'SELECT' || el.tagName === 'TEXTAREA') {
+      return el.getAttribute('name') || '';
+    }
+    return (el.textContent || '').trim().replace(/\s+/g, ' ');
+  };
+
+  const isInteractive = (el, role) =>
+    ['link', 'button', 'textbox', 'searchbox', 'combobox', 'checkbox', 'radio',
+     'slider', 'option', 'tab', 'menuitem', 'switch'].includes(role)
+    || el.hasAttribute('onclick') || el.tabIndex >= 0;
+
+  const walk = (el, depth) => {
+    if (lines.length >= MAX_LINES) return;
+    // SVG element tagNames are not uppercased; normalize before lookups.
+    const tag = String(el.tagName || '').toUpperCase();
+    if (SKIP_TAGS.has(tag) || el.namespaceURI === 'http://www.w3.org/2000/svg') return;
+    if (!isVisible(el)) return;
+    if (tag === 'IFRAME' || tag === 'FRAME') {
+      const label = el.getAttribute('title') || el.getAttribute('name') || el.getAttribute('src') || '';
+      lines.push(`${'  '.repeat(depth)}- iframe "${label.slice(0, MAX_NAME)}" (content not captured)`);
+      return;
+    }
+
+    const role = roleOf(el);
+    let emittedDepth = depth;
+    if (role) {
+      let name = nameOf(el);
+      if (name.length > MAX_NAME) name = name.slice(0, MAX_NAME) + '…';
+      const parts = [`${'  '.repeat(depth)}- ${role}`];
+      if (name) parts.push(`"${name}"`);
+      if (/^H[1-6]$/.test(el.tagName)) parts.push(`[level=${el.tagName[1]}]`);
+      if (el.tagName === 'A' && el.href) parts.push(`[href=${el.getAttribute('href')}]`);
+      if (el.disabled) parts.push('[disabled]');
+      if (el.checked) parts.push('[checked]');
+      if ((el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') && el.value) {
+        parts.push(`[value="${String(el.value).slice(0, 60)}"]`);
+      }
+      if (isInteractive(el, role)) {
+        refCounter += 1;
+        const ref = `e${refCounter}`;
+        el.setAttribute('data-mcp-ref', ref);
+        parts.push(`[ref=${ref}]`);
+      }
+      lines.push(parts.join(' '));
+      emittedDepth = depth + 1;
+      // Named leaf: children's text is already in the name, skip descent.
+      const hasElementChildren = el.children.length > 0;
+      if (!hasElementChildren || ['link', 'button', 'heading', 'option', 'label'].includes(role)) {
+        return;
+      }
+    } else {
+      // Text-bearing node with no element children becomes a text line.
+      if (el.children.length === 0) {
+        const text = (el.textContent || '').trim().replace(/\s+/g, ' ');
+        if (text) {
+          lines.push(`${'  '.repeat(depth)}- text: ${text.slice(0, MAX_NAME)}`);
+        }
+        return;
+      }
+    }
+    for (const child of el.children) walk(child, emittedDepth);
+  };
+
+  if (!document.body) return '- (page has no body yet)';
+  walk(document.body, 0);
+  if (lines.length >= MAX_LINES) lines.push('- … (snapshot truncated)');
+  return lines.join('\n');
+}
+"""

--- a/mcp/tests/fixtures/form.html
+++ b/mcp/tests/fixtures/form.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head><title>Form Test</title></head>
+<body>
+  <h1>Order form</h1>
+  <form id="f" onsubmit="event.preventDefault();
+      document.getElementById('out').textContent =
+        'name=' + document.getElementById('name').value +
+        ';size=' + document.getElementById('size').value;">
+    <label for="name">Customer name</label>
+    <input id="name" name="name" type="text" placeholder="Your name" />
+    <label for="size">Size</label>
+    <select id="size" name="size">
+      <option value="s">Small</option>
+      <option value="m">Medium</option>
+      <option value="l">Large</option>
+    </select>
+    <button type="submit">Place order</button>
+  </form>
+  <p id="out"></p>
+</body>
+</html>

--- a/mcp/tests/fixtures/hardening.html
+++ b/mcp/tests/fixtures/hardening.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head><title>Hardening Test</title></head>
+<body>
+  <label for="password">Password</label>
+  <input id="password" name="password" type="password" value="SECRET_PW" />
+  <button type="button">Continue</button>
+  <button id="prompt" type="button"
+    onclick="document.getElementById('out').textContent = prompt('Name?')">
+    Prompt
+  </button>
+  <p id="out"></p>
+</body>
+</html>

--- a/mcp/tests/test_hardening.py
+++ b/mcp/tests/test_hardening.py
@@ -1,0 +1,91 @@
+"""Focused stdio tests for MCP server hardening."""
+
+import asyncio
+import re
+from pathlib import Path
+
+from test_smoke import _call, _run_session
+
+FIXTURE = Path(__file__).parent / "fixtures" / "hardening.html"
+
+
+def test_password_value_is_masked():
+    async def checks(session):
+        snap = await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+        assert "SECRET_PW" not in snap
+        assert "[value=••••••]" in snap
+        await _call(session, "browser_close")
+
+    asyncio.run(_run_session(checks))
+
+
+def test_snapshot_refs_are_never_reused():
+    async def checks(session):
+        first = await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+        old_ref = re.search(r'button "Continue" \[ref=(e\d+)\]', first).group(1)
+
+        second = await _call(session, "browser_snapshot")
+        new_ref = re.search(r'button "Continue" \[ref=(e\d+)\]', second).group(1)
+        assert int(new_ref[1:]) > int(old_ref[1:])
+
+        result = await session.call_tool("browser_click", {"target": old_ref})
+        text = "\n".join(c.text for c in result.content if c.type == "text")
+        assert result.isError
+        assert "stale snapshot" in text
+        await _call(session, "browser_close")
+
+    asyncio.run(_run_session(checks))
+
+
+def test_browser_evaluate_registration_is_opt_in():
+    async def check_default(session):
+        tools = {t.name for t in (await session.list_tools()).tools}
+        assert "browser_evaluate" not in tools
+
+    async def check_enabled(session):
+        tools = {t.name for t in (await session.list_tools()).tools}
+        assert "browser_evaluate" in tools
+
+    asyncio.run(_run_session(check_default))
+    asyncio.run(
+        _run_session(check_enabled, {"RUSTWRIGHT_MCP_ALLOW_EVAL": "1"})
+    )
+
+
+def test_browser_reload_returns_snapshot():
+    async def checks(session):
+        await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+        snap = await _call(session, "browser_reload")
+        assert snap.startswith("Page: Hardening Test")
+        assert "SECRET_PW" not in snap
+        await _call(session, "browser_close")
+
+    asyncio.run(_run_session(checks))
+
+
+def test_browser_tabs_and_dialog_policy():
+    async def checks(session):
+        await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+
+        tabs = await _call(session, "browser_tabs", action="list")
+        assert "0: Hardening Test" in tabs
+        snap = await _call(
+            session, "browser_tabs", action="new", url=FIXTURE.as_uri()
+        )
+        assert snap.startswith("Page: Hardening Test")
+        tabs = await _call(session, "browser_tabs", action="list")
+        assert "1: Hardening Test" in tabs
+        await _call(session, "browser_tabs", action="close", index=1)
+
+        confirmation = await _call(
+            session,
+            "browser_handle_dialog",
+            accept=True,
+            prompt_text="Rustwright",
+        )
+        assert confirmation == "The next dialog on the active page will be accepted."
+        await _call(session, "browser_click", target="#prompt")
+        assert await _call(session, "browser_get_text", selector="#out") == "Rustwright"
+        await _call(session, "browser_close")
+
+    asyncio.run(_run_session(checks))

--- a/mcp/tests/test_smoke.py
+++ b/mcp/tests/test_smoke.py
@@ -1,0 +1,75 @@
+"""Smoke test for the Rustwright MCP server.
+
+Speaks the real MCP stdio protocol against a local HTML fixture, so no
+network access is required. Skips when no Chromium is available; set
+RUSTWRIGHT_MCP_CHANNEL=chrome to use an installed Chrome.
+"""
+
+import asyncio
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+FIXTURE = Path(__file__).parent / "fixtures" / "form.html"
+
+
+def _server_command() -> list[str]:
+    exe = shutil.which("rustwright-mcp")
+    if exe:
+        return [exe]
+    return [sys.executable, "-m", "rustwright_mcp"]
+
+
+async def _run_session(checks) -> None:
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    command = _server_command()
+    params = StdioServerParameters(
+        command=command[0], args=command[1:], env=dict(os.environ)
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            await checks(session)
+
+
+async def _call(session, name, **kwargs) -> str:
+    result = await session.call_tool(name, kwargs)
+    text = "\n".join(c.text for c in result.content if c.type == "text")
+    if result.isError:
+        if "Failed to launch chromium" in text:
+            pytest.skip("no Chromium available for MCP smoke test")
+        raise AssertionError(f"{name} failed: {text}")
+    return text
+
+
+def test_stdio_form_flow():
+    async def checks(session):
+        tools = {t.name for t in (await session.list_tools()).tools}
+        assert {"browser_navigate", "browser_snapshot", "browser_click",
+                "browser_type", "browser_close"} <= tools
+
+        snap = await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+        assert snap.startswith("Page: Form Test")
+        name_ref = re.search(r'textbox "Customer name"[^\[]*\[ref=(e\d+)\]', snap).group(1)
+        size_ref = re.search(r'combobox "Size" \[ref=(e\d+)\]', snap).group(1)
+        btn_ref = re.search(r'button "Place order"[^\[]*\[ref=(e\d+)\]', snap).group(1)
+
+        await _call(session, "browser_type", target=name_ref, text="Rustwright Test")
+        await _call(session, "browser_select_option", target=size_ref, value="Large")
+        await _call(session, "browser_click", target=btn_ref)
+
+        out = await _call(session, "browser_get_text", selector="#out")
+        assert out == "name=Rustwright Test;size=l"
+
+        title = await _call(session, "browser_evaluate", expression="() => document.title")
+        assert title == "Form Test"
+
+        assert await _call(session, "browser_close") == "Browser closed."
+
+    asyncio.run(_run_session(checks))

--- a/mcp/tests/test_smoke.py
+++ b/mcp/tests/test_smoke.py
@@ -24,13 +24,17 @@ def _server_command() -> list[str]:
     return [sys.executable, "-m", "rustwright_mcp"]
 
 
-async def _run_session(checks) -> None:
+async def _run_session(checks, env_overrides=None) -> None:
     from mcp import ClientSession, StdioServerParameters
     from mcp.client.stdio import stdio_client
 
     command = _server_command()
+    env = dict(os.environ)
+    env.pop("RUSTWRIGHT_MCP_ALLOW_EVAL", None)
+    if env_overrides:
+        env.update(env_overrides)
     params = StdioServerParameters(
-        command=command[0], args=command[1:], env=dict(os.environ)
+        command=command[0], args=command[1:], env=env
     )
     async with stdio_client(params) as (read, write):
         async with ClientSession(read, write) as session:
@@ -57,19 +61,38 @@ def test_stdio_form_flow():
         snap = await _call(session, "browser_navigate", url=FIXTURE.as_uri())
         assert snap.startswith("Page: Form Test")
         name_ref = re.search(r'textbox "Customer name"[^\[]*\[ref=(e\d+)\]', snap).group(1)
-        size_ref = re.search(r'combobox "Size" \[ref=(e\d+)\]', snap).group(1)
-        btn_ref = re.search(r'button "Place order"[^\[]*\[ref=(e\d+)\]', snap).group(1)
 
-        await _call(session, "browser_type", target=name_ref, text="Rustwright Test")
-        await _call(session, "browser_select_option", target=size_ref, value="Large")
+        snap = await _call(
+            session, "browser_type", target=name_ref, text="Rustwright Test"
+        )
+        size_ref = re.search(r'combobox "Size" \[ref=(e\d+)\]', snap).group(1)
+        snap = await _call(
+            session, "browser_select_option", target=size_ref, value="Large"
+        )
+        btn_ref = re.search(
+            r'button "Place order"[^\[]*\[ref=(e\d+)\]', snap
+        ).group(1)
         await _call(session, "browser_click", target=btn_ref)
 
         out = await _call(session, "browser_get_text", selector="#out")
         assert out == "name=Rustwright Test;size=l"
 
+        assert await _call(session, "browser_close") == "Browser closed."
+
+    asyncio.run(_run_session(checks))
+
+
+def test_stdio_evaluate_opt_in():
+    async def checks(session):
+        tools = {t.name for t in (await session.list_tools()).tools}
+        assert "browser_evaluate" in tools
+
+        await _call(session, "browser_navigate", url=FIXTURE.as_uri())
         title = await _call(session, "browser_evaluate", expression="() => document.title")
         assert title == "Form Test"
 
         assert await _call(session, "browser_close") == "Browser closed."
 
-    asyncio.run(_run_session(checks))
+    asyncio.run(
+        _run_session(checks, {"RUSTWRIGHT_MCP_ALLOW_EVAL": "1"})
+    )


### PR DESCRIPTION
Implements the roadmap item **Rustwright MCP server** as a self-contained `mcp/` subpackage — no changes to the engine, bindings, or existing packaging.

## What

- `rustwright-mcp` console script: a FastMCP stdio server with 13 `browser_*` tools whose names and semantics mirror the Playwright MCP server (`browser_navigate`, `browser_snapshot`, `browser_click`, `browser_type`, `browser_select_option`, `browser_hover`, `browser_press_key`, `browser_navigate_back`, `browser_wait_for`, `browser_get_text`, `browser_evaluate`, `browser_take_screenshot`, `browser_close`), so agents can swap between the two servers without prompt changes
- `browser_snapshot` returns an accessibility-style outline where interactive elements carry `[ref=eN]` handles; action tools accept a ref or a raw CSS selector
- No-clone usage: `uvx --from 'git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp' rustwright-mcp` (documented in `mcp/README.md` along with Claude Code / generic MCP client config, headed vs headless modes, and env vars)

## Design notes

- **Ref resolution.** `Page.aria_snapshot(mode="ai")` emits `[ref=eN]` labels but exposes no API to resolve a ref back to an element. The server ships its own snapshot script that tags emitted interactive elements with `data-mcp-ref` attributes; actions resolve refs via attribute selectors, staying on the real input pipeline (`page.click` etc.). If/when the engine grows first-class ref resolution (as Playwright's `aria-ref=` selector engine does), the server can drop its script and delegate
- **Stale refs fail fast**: acting on a ref absent from the live DOM raises immediately with a re-snapshot hint instead of consuming the full action timeout
- **Session robustness**: if the user closes a headed window, the next call detects the dead session and relaunches instead of failing until restart
- **Concurrency**: FastMCP runs sync tools on a thread pool; tool bodies are serialized behind a lock since the browser session is shared state
- Browser selection via `RUSTWRIGHT_MCP_CHANNEL` / `RUSTWRIGHT_MCP_EXECUTABLE`, headed mode via `RUSTWRIGHT_MCP_HEADLESS=0`

## Testing

- `mcp/tests/test_smoke.py` speaks the real MCP stdio protocol against a local HTML fixture (no network): initialize, tools/list, navigate, snapshot, ref extraction, type, select, click, get_text, evaluate, close. Skips cleanly when no Chromium is available; `pip install -e '.[test]'` brings pytest
- Manually verified end to end from Claude Code against live pages, including a ref click across a cross-site navigation, form fills, and screenshots

## Known limitations (documented in mcp/README.md)

- Single page / single session per server process (no tabs, dialogs, file upload, or network inspection yet)
- The snapshot walker does not descend into iframes (any origin) or shadow DOM; iframes appear as explicit `(content not captured)` markers
- The install URLs in `mcp/README.md` reference this repository and resolve once merged

Also checks the corresponding roadmap box in the root README.