### PR TITLE
Keep selector waits alive across a mid-wait navigation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,6 +185,7 @@ impl Drop for SpawnedTaskAbortGuard {
 const CDP_EVENT_LOG_LIMIT: usize = 8192;
 const FRAME_UTILITY_WORLD_NAME: &str = "__utility_world__";
 const MAX_FRAME_TREE_DEPTH: usize = 256;
+const NAVIGATION_RETRY_INTERVAL: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Error)]
 pub enum RwError {
@@ -202,6 +203,20 @@ pub enum RwError {
     Reqwest(#[from] reqwest::Error),
     #[error(transparent)]
     WebSocket(#[from] tokio_tungstenite::tungstenite::Error),
+}
+
+/// True for the CDP errors Chromium reports when the execution context an
+/// evaluation was running in goes away because the frame navigated. Callers that
+/// poll the page can re-resolve the frame and retry instead of failing.
+fn is_execution_context_destroyed_error(error: &RwError) -> bool {
+    let RwError::Cdp { message, .. } = error else {
+        return false;
+    };
+    let message = message.to_ascii_lowercase();
+    message.contains("inspected target navigated or closed")
+        || message.contains("execution context was destroyed")
+        || message.contains("cannot find context with specified id")
+        || message.contains("execution context with given id not found")
 }
 
 #[cfg(feature = "python")]
@@ -908,6 +923,37 @@ mod tests {
         assert!(
             remote_debugging_port_from_args(&["--remote-debugging-port=bad".to_string()]).is_err()
         );
+    }
+
+    #[test]
+    fn execution_context_destroyed_errors_are_detected_for_navigation_retry() {
+        for message in [
+            "Inspected target navigated or closed",
+            "Execution context was destroyed.",
+            "Cannot find context with specified id",
+            "Execution context with given id not found",
+        ] {
+            let error = RwError::Cdp {
+                method: "Runtime.evaluate".to_string(),
+                message: message.to_string(),
+            };
+            assert!(
+                is_execution_context_destroyed_error(&error),
+                "expected {message:?} to be retryable"
+            );
+        }
+    }
+
+    #[test]
+    fn unrelated_errors_are_not_treated_as_execution_context_destroyed() {
+        assert!(!is_execution_context_destroyed_error(&RwError::Cdp {
+            method: "Runtime.evaluate".to_string(),
+            message: "Uncaught ReferenceError: spec is not defined".to_string(),
+        }));
+        assert!(!is_execution_context_destroyed_error(&RwError::Timeout(120)));
+        assert!(!is_execution_context_destroyed_error(&RwError::Message(
+            "Inspected target navigated or closed".to_string()
+        )));
     }
 
     #[test]
@@ -6463,23 +6509,52 @@ async fn page_wait_for_selector_async(
     timeout: Duration,
     strict: bool,
 ) -> RwResult<bool> {
-    let body = wait_for_selector_body(&state, strict, timeout);
-    let eval_timeout = Duration::from_millis(timeout.as_millis().saturating_add(1_000) as u64);
-    let json = evaluate_locator_for_page(page, locator_json, index, body, eval_timeout).await?;
-    let value = serde_json::from_str::<Value>(&json).unwrap_or(Value::Null);
-    if value.as_str() == Some("__rustwright_timeout__") {
-        return Err(RwError::Timeout(timeout.as_millis() as u64));
+    let reported_timeout = timeout.as_millis().min(u128::from(u64::MAX)) as u64;
+    let deadline = OperationDeadline::new(timeout);
+    loop {
+        // The poll runs inside the page, so a navigation destroys it along with
+        // its execution context. Re-arm it against whatever document is live now
+        // and keep waiting, budgeting each attempt to the time the caller has
+        // left so retries cannot extend the overall wait.
+        let Ok(remaining) = deadline.remaining() else {
+            return Err(RwError::Timeout(reported_timeout));
+        };
+        let body = wait_for_selector_body(&state, strict, remaining);
+        let eval_timeout = remaining.saturating_add(Duration::from_secs(1));
+        let json = match evaluate_locator_for_page(
+            Arc::clone(&page),
+            locator_json.clone(),
+            index,
+            body,
+            eval_timeout,
+        )
+        .await
+        {
+            Ok(json) => json,
+            Err(error) if is_execution_context_destroyed_error(&error) => {
+                let Ok(remaining) = deadline.remaining() else {
+                    return Err(RwError::Timeout(reported_timeout));
+                };
+                tokio::time::sleep(remaining.min(NAVIGATION_RETRY_INTERVAL)).await;
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+        let value = serde_json::from_str::<Value>(&json).unwrap_or(Value::Null);
+        if value.as_str() == Some("__rustwright_timeout__") {
+            return Err(RwError::Timeout(reported_timeout));
+        }
+        if let Some(count) = value
+            .as_str()
+            .and_then(|text| text.strip_prefix("__rustwright_strict_violation__:"))
+            .and_then(|text| text.parse::<u64>().ok())
+        {
+            return Err(RwError::Message(format!(
+                "strict mode violation: locator resolved to {count} elements while trying to wait_for_selector"
+            )));
+        }
+        return Ok(value.as_bool().unwrap_or(false));
     }
-    if let Some(count) = value
-        .as_str()
-        .and_then(|text| text.strip_prefix("__rustwright_strict_violation__:"))
-        .and_then(|text| text.parse::<u64>().ok())
-    {
-        return Err(RwError::Message(format!(
-            "strict mode violation: locator resolved to {count} elements while trying to wait_for_selector"
-        )));
-    }
-    Ok(value.as_bool().unwrap_or(false))
 }
 
 fn locator_action_body(action: &str, strict: bool, timeout: Duration) -> String {
@@ -8937,76 +9012,14 @@ return true;
         let state = state.unwrap_or("visible").to_string();
         let strict = strict.unwrap_or(false);
         let timeout = BrowserInner::command_timeout(timeout_ms);
-        let state_json =
-            serde_json::to_string(&state).unwrap_or_else(|_| "\"visible\"".to_string());
-        let strict_json = if strict { "true" } else { "false" };
-        let timeout_millis = timeout.as_millis().max(1);
-        let eval_timeout = timeout_millis.saturating_add(1_000) as f64;
-        let body = format!(
-            r#"
-const targetState = {state_json};
-const strict = {strict_json};
-const timeoutMs = {timeout_millis};
-const snapshot = () => {{
-  const matches = all(spec);
-  if (strict && matches.length > 1) return {{ strict: true, count: matches.length }};
-  const current = matches[index] || null;
-  const attached = !!current;
-  const isVisible = !!current && visible(current);
-  const matched = targetState === 'attached'
-    ? attached
-    : targetState === 'detached'
-      ? !attached
-      : targetState === 'hidden'
-        ? (!attached || !isVisible)
-        : isVisible;
-  return {{ attached, matched }};
-}};
-const first = snapshot();
-if (first.strict) return `__rustwright_strict_violation__:${{first.count}}`;
-if (first.matched) return first.attached;
-return new Promise(resolve => {{
-  let settled = false;
-  let observer = null;
-  let interval = null;
-  let timer = null;
-  const finish = value => {{
-    if (settled) return;
-    settled = true;
-    if (observer) observer.disconnect();
-    if (interval) clearInterval(interval);
-    if (timer) clearTimeout(timer);
-    resolve(value);
-  }};
-  const check = () => {{
-    const next = snapshot();
-    if (next.strict) finish(`__rustwright_strict_violation__:${{next.count}}`);
-    if (next.matched) finish(next.attached);
-  }};
-  observer = new MutationObserver(check);
-  observer.observe(document, {{ subtree: true, childList: true, attributes: true, characterData: true }});
-  interval = setInterval(check, 5);
-  timer = setTimeout(() => finish('__rustwright_timeout__'), timeoutMs);
-}});
-"#
-        );
-        let json = self
-            .evaluate_locator(locator_json, index, &body, Some(eval_timeout))
-            .map_err(py_err)?;
-        let value = serde_json::from_str::<Value>(&json).unwrap_or(Value::Null);
-        if value.as_str() == Some("__rustwright_timeout__") {
-            return Err(py_err(RwError::Timeout(timeout.as_millis() as u64)));
-        }
-        if let Some(count) = value
-            .as_str()
-            .and_then(|text| text.strip_prefix("__rustwright_strict_violation__:"))
-            .and_then(|text| text.parse::<u64>().ok())
-        {
-            return Err(py_err(RwError::Message(format!(
-                "strict mode violation: locator resolved to {count} elements while trying to wait_for_selector"
-            ))));
-        }
-        Ok(value.as_bool().unwrap_or(false))
+        let page = Arc::clone(&self.inner);
+        let locator_json = locator_json.to_string();
+        let browser = Arc::clone(&page.browser);
+        browser
+            .block_on(async move {
+                page_wait_for_selector_async(page, locator_json, index, state, timeout, strict).await
+            })
+            .map_err(py_err)
     }
 
     #[pyo3(signature = (path=None, full_page=None, clip_json=None, timeout_ms=None, image_type=None, quality=None, omit_background=None))]

--- a/tests/test_rustwright_sync_api.py
+++ b/tests/test_rustwright_sync_api.py
@@ -740,6 +740,26 @@ def http_server():
                 self.end_headers()
                 self.wfile.write(body)
                 return
+            if self.path == "/navigate-away-mid-wait":
+                body = (
+                    b"<!doctype html>"
+                    b"<script>setTimeout(function(){location.href='/navigate-away-target'},200)</script>"
+                    b"<div id='before-navigation'>A</div>"
+                )
+                self.send_response(200, "OK")
+                self.send_header("Content-Type", "text/html")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            if self.path == "/navigate-away-target":
+                body = b"<!doctype html><div id='after-navigation'>Loaded</div>"
+                self.send_response(200, "OK")
+                self.send_header("Content-Type", "text/html")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
             body = b"missing"
             self.send_response(404, "Missing")
             self.send_header("Content-Length", str(len(body)))
@@ -19157,6 +19177,40 @@ def test_wait_for_selector(page):
         root.wait_for_selector("#hidden", state="enabled", timeout=500)
     with pytest.raises(Error, match="Frame\\.wait_for_selector: state: expected one of"):
         frame.wait_for_selector("#frame-hidden", state="enabled", timeout=500)
+
+
+def test_wait_for_selector_survives_navigation_committed_mid_wait(page, http_server):
+    # The target only exists in the document we redirect to, so the wait has to
+    # poll across the navigation before it can ever match. Playwright keeps
+    # polling in the new document instead of surfacing the CDP error raised when
+    # the original execution context is torn down.
+    page.goto(f"{http_server}/navigate-away-mid-wait")
+
+    handle = page.wait_for_selector("#after-navigation", timeout=10_000)
+
+    assert handle is not None
+    assert handle.text_content() == "Loaded"
+    assert page.url == f"{http_server}/navigate-away-target"
+
+
+def test_locator_wait_for_survives_navigation_committed_mid_wait(page, http_server):
+    page.goto(f"{http_server}/navigate-away-mid-wait")
+
+    assert page.locator("#after-navigation").wait_for(state="visible", timeout=10_000) is None
+    assert page.locator("#after-navigation").text_content() == "Loaded"
+
+
+def test_wait_for_selector_still_times_out_when_navigation_never_reveals_element(page, http_server):
+    # The navigation retry must not extend the caller's deadline.
+    page.goto(f"{http_server}/navigate-away-mid-wait")
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError) as exc_info:
+        page.wait_for_selector("#never-appears", timeout=1_000)
+    elapsed_ms = (time.monotonic() - started) * 1000
+
+    assert str(exc_info.value).splitlines()[0] == "Page.wait_for_selector: Timeout 1000ms exceeded."
+    assert elapsed_ms < 5_000
 
 
 def test_wait_for_selector_timeout_messages_match_playwright(page):


### PR DESCRIPTION
`wait_for_selector` runs its whole poll inside the page, held open by a single `Runtime.evaluate`. A navigation that commits while the poll is pending destroys that execution context, so CDP rejects the evaluate and the raw "Inspected target navigated or closed" surfaced to callers. Playwright keeps polling across the navigation and resolves once the element appears in the new document.

Retry the evaluate when it fails because the context went away, re-resolving the frame so the poll re-arms against the live document. Each attempt is budgeted to the time left on the caller's deadline, so a retry cannot extend the overall wait and an element that never appears still reports the original timeout. A closed target reports a different CDP message and keeps failing fast as `TargetClosedError`.

The sync binding duplicated the same poll script inline and had the same defect; it now delegates to the shared async path.

Fixes #79

## What

- `page_wait_for_selector_async` now retries its evaluate when the execution context is torn down by a navigation, re-resolving the frame each attempt so the poll re-arms against the live document.
- Added `is_execution_context_destroyed_error`, which matches only the CDP messages Chromium reports when a context goes away (`Inspected target navigated or closed`, `Execution context was destroyed`, `Cannot find context with specified id`, `Execution context with given id not found`).
- The sync `wait_for_selector` binding, which carried its own inline copy of the poll script, now delegates to the shared async path (−74 lines of duplicated JS).

## Why

The poll lives inside the page, so its execution context dies with the document. Nothing in the selector-wait path treated that as recoverable, so the raw CDP error reached callers. This breaks any flow where an element only renders after a redirect (e.g. post-login), which is exactly the case Playwright handles by re-arming across the navigation.

Worth noting for anyone reproducing #79: the async repro there is timing-dependent. `AsyncLocator.wait_for` goes through `_run_sync_wait_sliced`, which slices the wait into 50ms evaluates and retries on `TimeoutError`. That accidentally survives most navigations — but a CDP error is not a `TimeoutError`, so it escapes whenever a navigation lands inside an evaluate window. On Ubuntu 24.04 / Python 3.12 / Chromium 1223 the async repro passed 8/8 for me, while the sync API (one long evaluate, no slicing) failed 3/3 with the exact reported error. Same root cause either way, and the fix sits below both paths.

Not included deliberately: `locator_action_body` (click/fill) has the same in-page-poll structure and the same fragility, but actions are not idempotent — retrying a click that may already have run risks double-firing. That needs at-most-once handling and belongs in its own change.

## Testing

- [x] `cargo check --locked`
- [x] Targeted pytest, using the focused `-k` subset from `CONTRIBUTING.md`

Evidence, against the deterministic sync repro:

```
[sync] FAILED -> Error: Protocol error (Runtime.evaluate): Inspected target navigated or closed   # 3/3 before
[sync] SUCCEEDED after 224ms                                                                      # 5/5 after
```

- 3 new Python regression tests, verified non-vacuous: all 3 fail on unmodified 0.1.1 with the exact reported error, and pass on this branch. One asserts the retry does not extend the deadline — an element that never appears still reports `Page.wait_for_selector: Timeout 1000ms exceeded.`
- 2 new Rust unit tests for the error classifier, including that it does not match unrelated errors.
- `cargo test --lib`: 39 passed. Existing `wait_for_selector` suite: 6/6. Broader `-k "wait or locator or navigat or frame or click or strict"`: 246 passed, 1 failed — `test_forced_isolation_oopif_locator_pointer_actions_wait_for_handlers` fails identically on unmodified 0.1.1 in my environment, so it looks pre-existing/environmental rather than related to this change.
- Checked the "or closed" half of the CDP message: closing a page mid-wait reports `Session with given id not found` and still fails fast as `TargetClosedError` at ~1400ms, identical before and after. The retry does not swallow it.

One note on the first box: `Cargo.toml` lists `members = ["node", "capi", "rust-native"]`, but `capi/` and `rust-native/` are not present in the repository, so `cargo check --locked` and the `maturin develop --release` flow in `CONTRIBUTING.md` both fail out of the box with `failed to read capi/Cargo.toml`. I emptied the workspace members locally to build and test; that workaround is not part of this PR. Happy to file it separately if it is not already known.

## Checklist

- [x] I kept this change focused.
- [x] I added or updated tests for behavior changes.
- [x] I did not include private credentials, tokens, or internal-only artifacts.
