### PR TITLE
Mirror the form-fill cloud benchmark workflow in the repo sync

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -11,6 +11,16 @@ Skyvern-AI/rustwright-cloud:
   - source: benchmarks/
     dest: benchmarks/
     deleteOrphaned: true
+  # capi/ and rust-native/ are Cargo workspace members referenced by the synced
+  # root Cargo.toml; they must mirror together or the target repo's workspace
+  # breaks (as happened when Cargo.toml gained these members before the dirs
+  # were mapped here).
+  - source: capi/
+    dest: capi/
+    deleteOrphaned: true
+  - source: rust-native/
+    dest: rust-native/
+    deleteOrphaned: true
   - source: docs/
     dest: docs/
     deleteOrphaned: true

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,7 +1,13 @@
 # Shared Rustwright files mirrored from rustwright to rustwright-cloud.
-# Repository-specific GitHub workflows and metadata are intentionally excluded.
+# Repository-specific GitHub workflows and metadata are intentionally excluded,
+# with one deliberate exception: the form-fill cloud benchmark workflow is part
+# of the shared benchmark suite and is mirrored so hardening fixes stay in
+# lockstep. Note: syncing it requires RUSTWRIGHT_SYNC_GH_PAT to carry the
+# `workflow` scope; while the two copies are identical the entry is inert.
 # Cloud-only additions must live outside the mirrored paths below.
 Skyvern-AI/rustwright-cloud:
+  - source: .github/workflows/form-fill-cloud-benchmark.yml
+    dest: .github/workflows/form-fill-cloud-benchmark.yml
   - source: benchmarks/
     dest: benchmarks/
     deleteOrphaned: true


### PR DESCRIPTION
## What
Adds `.github/workflows/form-fill-cloud-benchmark.yml` to the repo file-sync list — a deliberate single-file exception to the intentional workflows exclusion, matching the identical entry landing on rustwright-cloud ([cloud#73](https://github.com/Skyvern-AI/rustwright-cloud/pull/73)). The benchmark workflow is part of the shared benchmark suite; mirroring it keeps hardening fixes in lockstep instead of requiring manual backports.

## Safety
- Both copies are **byte-identical today** (cloud#73 backports the reviewed hardening from #82), so this entry is inert until the next divergence — identical files produce no sync changeset.
- The first divergent sync requires `RUSTWRIGHT_SYNC_GH_PAT` to carry the `workflow` scope. If it doesn't, that sync run fails visibly (it cannot silently drop the file); the fix is adding the scope to the PAT.
- The general exclusion for repository-specific workflows stays in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
