### PR TITLE
Name sync PRs after the originating change

### DIFF
--- a/.github/workflows/sync-rustwright-cloud.yml
+++ b/.github/workflows/sync-rustwright-cloud.yml
@@ -37,7 +37,9 @@ jobs:
           PR_LABELS: sync
           BRANCH_NAME: repo-sync/rustwright-${{ github.event.pull_request.number || github.run_id }}
           PR_BODY: ${{ github.event.pull_request.html_url || 'Manual sync from rustwright' }}
-          PR_TITLE: "Sync rustwright changes to rustwright-cloud (#${{ github.event.pull_request.number || github.run_id }})"
+          # The sync PR title (and its squash commit on the target main) should
+          # carry the originating change's title; dispatch runs have no PR context.
+          PR_TITLE: ${{ github.event.pull_request.title || format('Sync rustwright changes to rustwright-cloud (run {0})', github.run_id) }}
 
       - name: Link the rustwright-cloud PR
         if: github.event_name == 'pull_request_target' && steps.file-sync.outputs.pull_request_urls


### PR DESCRIPTION
## What

Name sync PRs after the change they carry: `PR_TITLE` for the file-sync action now passes through the merged pull request's own title instead of a hardcoded generic sync label. Manual `workflow_dispatch` runs (no pull-request context) fall back to a generic title tagged with the run id.

## Why

The sync PR on the target repository — and, since sync PRs are squash-merged with `PR_TITLE` squash commits, the resulting commit on the target `main` — currently reads as a generic sync label, so history says nothing about what actually changed. The source PR link stays in the sync PR body (unchanged), preserving traceability.

## Testing

- [x] `actionlint` — clean
- [x] Expression walk: `pull_request_target closed` events carry a non-empty `github.event.pull_request.title`; `workflow_dispatch` selects the `format(...)` fallback. The value flows into an action input, never a shell line
- [ ] Exercised on the next merged contribution that touches synced paths

## Checklist

- [x] I kept this change focused.
- [x] I added or updated tests for behavior changes. (No testable surface beyond lint — one-line CI expression change.)
- [x] I did not include private credentials, tokens, or internal-only artifacts.
