### PR TITLE
mcp: attach to a remote browser over CDP

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -137,7 +137,35 @@ Example Domains
 | `RUSTWRIGHT_MCP_HEADLESS` | `0` shows the browser window (default headless) |
 | `RUSTWRIGHT_MCP_CHANNEL` | Chromium channel, e.g. `chrome`, `chrome-beta` |
 | `RUSTWRIGHT_MCP_EXECUTABLE` | Explicit browser binary path (overrides channel) |
+| `RUSTWRIGHT_MCP_CDP_ENDPOINT` | Remote browser CDP endpoint; enables remote mode when set |
+| `RUSTWRIGHT_MCP_CDP_HEADERS` | Optional JSON object of extra CDP connection headers |
+| `RUSTWRIGHT_MCP_CDP_TIMEOUT_MS` | Remote connection timeout in milliseconds (default `60000`) |
 | `RUSTWRIGHT_MCP_ALLOW_EVAL` | `1`, `true`, or `yes` exposes `browser_evaluate` (default off) |
+
+### Remote browsers over CDP
+
+Set `RUSTWRIGHT_MCP_CDP_ENDPOINT` to attach to an existing Chromium browser
+over CDP. `RUSTWRIGHT_MCP_CDP_HEADERS` accepts a JSON object of extra connection
+headers, and `RUSTWRIGHT_MCP_CDP_TIMEOUT_MS` controls the connection timeout.
+The server adopts the remote browser's default context and an existing page,
+creating a page only when the context has none.
+
+```bash
+RUSTWRIGHT_MCP_CDP_ENDPOINT='wss://browser.example.com/devtools/browser/<session-id>' \
+RUSTWRIGHT_MCP_CDP_HEADERS='{"Authorization":"Bearer <token>"}' \
+RUSTWRIGHT_MCP_CDP_TIMEOUT_MS=60000 \
+rustwright-mcp
+```
+
+In CDP mode, `RUSTWRIGHT_MCP_HEADLESS`, `RUSTWRIGHT_MCP_CHANNEL`, and
+`RUSTWRIGHT_MCP_EXECUTABLE` are ignored. If the initial connection fails or a
+remote session stops responding, the tool fails loudly; it never silently
+launches a local browser. `browser_close` detaches from the remote browser
+without terminating the remotely owned process.
+
+For example, a hosted browser provider such as Skyvern Browser Sessions exposes
+a CDP address plus an `x-api-key` header; configure the header with
+`RUSTWRIGHT_MCP_CDP_HEADERS='{"x-api-key":"<key>"}'`.
 
 ### Headless vs headed
 
@@ -166,12 +194,12 @@ restart the session).
   are masked in snapshot output; other field values are included as-is.
 - Snapshot refs are best-effort handles for cooperative pages, not a security
   boundary. Refs increase for the browser session and stale refs fail fast.
-- Each server process controls a single local browser session, which may have
-  multiple tabs.
+- Each server process controls a single local or remote browser session, which
+  may have multiple tabs.
 
 ## Limitations
 
-- Single local browser session per server process.
+- Single browser session per server process.
 - Snapshot refs are regenerated on every snapshot; after a page mutation,
   take a new snapshot before acting on refs. Stale refs fail fast with a
   message asking for a fresh snapshot.

--- a/mcp/rustwright_mcp/server.py
+++ b/mcp/rustwright_mcp/server.py
@@ -8,12 +8,19 @@ Environment variables:
     RUSTWRIGHT_MCP_HEADLESS    "0" to show the browser window (default headless)
     RUSTWRIGHT_MCP_CHANNEL     chromium channel, e.g. "chrome" (default: bundled chromium)
     RUSTWRIGHT_MCP_EXECUTABLE  explicit browser executable path (overrides channel)
+    RUSTWRIGHT_MCP_CDP_ENDPOINT remote browser CDP endpoint (uses remote mode when set)
+    RUSTWRIGHT_MCP_CDP_HEADERS optional JSON object of CDP connection headers
+    RUSTWRIGHT_MCP_CDP_TIMEOUT_MS remote connection timeout in milliseconds (default: 60000)
     RUSTWRIGHT_MCP_ALLOW_EVAL  "1", "true", or "yes" to expose browser_evaluate
+
+When RUSTWRIGHT_MCP_CDP_ENDPOINT is set, the local headless, channel, and
+executable options are ignored.
 """
 
 from __future__ import annotations
 
 import functools
+import json
 import os
 import tempfile
 import threading
@@ -67,15 +74,98 @@ def _register_dialog_handler(page) -> None:
 
 
 def _page():
+    """Return the active page, launching locally or attaching over remote CDP.
+
+    In remote CDP mode, local launch options (headless, channel, and executable)
+    are ignored.
+    """
     if "page" in _session:
         try:
             # The user may have closed a headed window; detect a dead
             # session and relaunch instead of failing every call.
             _session["page"].evaluate("() => 1")
         except Exception:
+            if _session.get("remote"):
+                _teardown()
+                raise RuntimeError(
+                    "Remote CDP session is no longer reachable — "
+                    "reconnect/restart the MCP server."
+                ) from None
             _teardown()
     if "page" not in _session:
         from rustwright.sync_api import sync_playwright
+
+        endpoint = os.environ.get("RUSTWRIGHT_MCP_CDP_ENDPOINT")
+        if endpoint:
+            raw_headers = os.environ.get("RUSTWRIGHT_MCP_CDP_HEADERS", "")
+            headers: dict[str, str] = {}
+            if raw_headers:
+                try:
+                    parsed_headers = json.loads(raw_headers)
+                except json.JSONDecodeError:
+                    raise ValueError(
+                        "RUSTWRIGHT_MCP_CDP_HEADERS must contain a valid JSON object"
+                    ) from None
+                if not isinstance(parsed_headers, dict) or not all(
+                    isinstance(name, str) and isinstance(value, str)
+                    for name, value in parsed_headers.items()
+                ):
+                    raise ValueError(
+                        "RUSTWRIGHT_MCP_CDP_HEADERS must be a JSON object with "
+                        "string keys and values"
+                    )
+                headers = parsed_headers
+
+            try:
+                timeout_ms = int(
+                    os.environ.get("RUSTWRIGHT_MCP_CDP_TIMEOUT_MS", "60000")
+                )
+            except ValueError:
+                raise ValueError(
+                    "RUSTWRIGHT_MCP_CDP_TIMEOUT_MS must be a non-negative integer"
+                ) from None
+            if timeout_ms < 0:
+                raise ValueError(
+                    "RUSTWRIGHT_MCP_CDP_TIMEOUT_MS must be a non-negative integer"
+                )
+
+            pw = None
+            browser = None
+            try:
+                pw = sync_playwright().start()
+                browser = pw.chromium.connect_over_cdp(
+                    endpoint,
+                    headers=headers,
+                    timeout=timeout_ms,
+                )
+                context = browser.contexts[0]
+                pages = context.pages
+                page = pages[0] if pages else context.new_page()
+                _session.update(
+                    pw=pw,
+                    browser=browser,
+                    page=page,
+                    remote=True,
+                    snapshot_taken=False,
+                    next_ref=1,
+                    dialog_pages=[],
+                )
+                _register_dialog_handler(page)
+            except Exception:
+                for close in (
+                    lambda: browser.close() if browser is not None else None,
+                    lambda: pw.stop() if pw is not None else None,
+                ):
+                    try:
+                        close()
+                    except Exception:
+                        pass
+                _session.clear()
+                raise RuntimeError(
+                    "Remote CDP browser is unreachable; check the connection "
+                    "settings and try again."
+                ) from None
+            return _session["page"]
 
         headless = os.environ.get("RUSTWRIGHT_MCP_HEADLESS", "1") != "0"
         launch_kwargs: dict = {"headless": headless}
@@ -92,6 +182,7 @@ def _page():
             pw=pw,
             browser=browser,
             page=page,
+            remote=False,
             snapshot_taken=False,
             next_ref=1,
             dialog_pages=[],
@@ -118,6 +209,8 @@ def _snapshot(page) -> str:
 
 
 def _teardown() -> None:
+    # For remote sessions, closing the connected Browser detaches this client;
+    # Rustwright leaves the remotely owned browser running.
     for close in (
         lambda: _session["browser"].close(),
         lambda: _session["pw"].stop(),

--- a/mcp/tests/test_cdp.py
+++ b/mcp/tests/test_cdp.py
@@ -1,0 +1,75 @@
+"""Real stdio tests for remote CDP browser sessions."""
+
+import asyncio
+from pathlib import Path
+
+from rustwright.sync_api import sync_playwright
+
+from test_smoke import _call, _run_session
+
+FIXTURE = Path(__file__).parent / "fixtures" / "form.html"
+
+
+def test_stdio_connects_over_cdp():
+    with sync_playwright() as playwright:
+        remote_browser = playwright.chromium.launch(
+            headless=True,
+            args=["--remote-debugging-port=0"],
+        )
+        endpoint = remote_browser._ws_endpoint
+
+        async def checks(session):
+            snap = await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+            assert snap.startswith("Page: Form Test")
+            assert "Customer name" in snap
+
+            snap = await _call(session, "browser_snapshot")
+            assert snap.startswith("Page: Form Test")
+            assert "Place order" in snap
+
+            assert await _call(session, "browser_close") == "Browser closed."
+
+        try:
+            asyncio.run(
+                _run_session(
+                    checks,
+                    {
+                        "RUSTWRIGHT_MCP_CDP_ENDPOINT": endpoint,
+                        "RUSTWRIGHT_MCP_CDP_HEADERS": '{"x-test":"rustwright-mcp"}',
+                        "RUSTWRIGHT_MCP_CDP_TIMEOUT_MS": "10000",
+                    },
+                )
+            )
+            assert remote_browser.is_connected()
+        finally:
+            remote_browser.close()
+
+
+def test_dead_cdp_endpoint_fails_without_local_fallback():
+    endpoint = "ws://127.0.0.1:1/devtools/browser/nope"
+    header_value = "not-a-real-secret"
+
+    async def checks(session):
+        result = await session.call_tool("browser_snapshot", {})
+        text = "\n".join(c.text for c in result.content if c.type == "text")
+
+        assert result.isError
+        assert "Remote CDP browser is unreachable" in text
+        assert "Failed to launch chromium" not in text
+        assert "Page:" not in text
+        assert endpoint not in text
+        assert header_value not in text
+
+    asyncio.run(
+        _run_session(
+            checks,
+            {
+                "RUSTWRIGHT_MCP_CDP_ENDPOINT": endpoint,
+                "RUSTWRIGHT_MCP_CDP_HEADERS": (
+                    '{"Authorization":"' + header_value + '"}'
+                ),
+                "RUSTWRIGHT_MCP_CDP_TIMEOUT_MS": "1000",
+                "RUSTWRIGHT_MCP_EXECUTABLE": "/not/a/browser",
+            },
+        )
+    )

--- a/mcp/tests/test_smoke.py
+++ b/mcp/tests/test_smoke.py
@@ -30,7 +30,13 @@ async def _run_session(checks, env_overrides=None) -> None:
 
     command = _server_command()
     env = dict(os.environ)
-    env.pop("RUSTWRIGHT_MCP_ALLOW_EVAL", None)
+    for name in (
+        "RUSTWRIGHT_MCP_ALLOW_EVAL",
+        "RUSTWRIGHT_MCP_CDP_ENDPOINT",
+        "RUSTWRIGHT_MCP_CDP_HEADERS",
+        "RUSTWRIGHT_MCP_CDP_TIMEOUT_MS",
+    ):
+        env.pop(name, None)
     if env_overrides:
         env.update(env_overrides)
     params = StdioServerParameters(


### PR DESCRIPTION
Fast-follow to the MCP server (#84): a vendor-neutral option to drive a **remote** browser over CDP instead of launching a local Chromium.

- `RUSTWRIGHT_MCP_CDP_ENDPOINT` — attach to this CDP endpoint (remote mode). Local launch options (headless/channel/executable) are ignored.
- `RUSTWRIGHT_MCP_CDP_HEADERS` — optional JSON object of connect headers (e.g. an auth header); never printed or logged.
- `RUSTWRIGHT_MCP_CDP_TIMEOUT_MS` — connect timeout (default 60000).

**Fails loudly on a dead/unreachable remote** — it never silently falls back to a local browser — and teardown detaches without terminating the remotely-owned browser.

Vendor-neutral: no SDK dependency. Docs use a hosted provider (Skyvern Browser Sessions, which exposes a CDP address + `x-api-key` header) purely as an example. Tests exercise a live remote (a second local browser over `--remote-debugging-port`) and a dead-endpoint failure — 9 passing.