### PR TITLE
Give remote-CDP actionability probes the full remaining action budget

### DIFF
--- a/python/rustwright/sync_api.py
+++ b/python/rustwright/sync_api.py
@@ -4607,6 +4607,19 @@ def _sleep_until_next_poll(deadline: float, interval: float = 0.02) -> None:
         time.sleep(min(interval, remaining))
 
 
+def _actionability_probe_timeout(remaining_ms: float, timeout_disabled: bool = False) -> float:
+    # Budget a single actionability/state probe with the full remaining action time rather
+    # than a small fixed cap. A cap shorter than one remote-CDP round trip made every probe
+    # time out and abort the action while the outer deadline was still far away (observed on
+    # click/select_option over connect_over_cdp attach). Polling cadence is driven by
+    # _sleep_until_next_poll, not this bound, so widening it does not busy-loop. For an
+    # infinite wait (timeout<=0) keep a bounded cadence so owner-availability and locator
+    # handlers are still re-checked periodically.
+    if timeout_disabled:
+        return min(remaining_ms, 1_000.0)
+    return max(remaining_ms, 1.0)
+
+
 def _handle_event_wait_timeout(owner: Any, event: str, timeout_display: str, deadline: Optional[float]) -> None:
     if owner is not None:
         _raise_if_owner_unavailable(owner, use_close_reason=True)
@@ -21785,16 +21798,26 @@ return new Promise(resolve => {
         while True:
             _raise_if_owner_unavailable(self._page, method=method)
             remaining_ms = max((deadline - time.monotonic()) * 1000, 1.0)
-            command_timeout = min(1_000.0 if timeout_disabled else max(timeout_ms, 1.0), remaining_ms, 1_000.0)
+            command_timeout = _actionability_probe_timeout(remaining_ms, timeout_disabled)
             self._page._run_locator_handlers(deadline)
-            last_info = self._target_state(
-                command_timeout,
-                scroll=scroll or state in {"actionable", "scrollable"},
-                stable=requires_stable,
-                receives_events=state == "actionable",
-                stable_position_required=stable_position_required,
-                action_position=action_position,
-            )
+            try:
+                last_info = self._target_state(
+                    command_timeout,
+                    scroll=scroll or state in {"actionable", "scrollable"},
+                    stable=requires_stable,
+                    receives_events=state == "actionable",
+                    stable_position_required=stable_position_required,
+                    action_position=action_position,
+                )
+            except TimeoutError:
+                # A single actionability probe that exceeds its own budget is transient,
+                # not fatal: over a high-latency remote-CDP transport one probe's round
+                # trips can outlast a small fixed cap. Keep polling until the outer
+                # deadline instead of aborting the whole action (matches Playwright).
+                if time.monotonic() >= deadline:
+                    break
+                _sleep_until_next_poll(deadline)
+                continue
             if self._strict and not self._explicit_index:
                 self._raise_frame_strict_violation(last_info.get("frame_strict_violation"))
             count = int(last_info.get("count") or 0)
@@ -21857,9 +21880,17 @@ return new Promise(resolve => {
         while True:
             _raise_if_owner_unavailable(self._page, method=method)
             remaining_ms = max((deadline - time.monotonic()) * 1000, 1.0)
-            command_timeout = min(max(timeout_ms, 1.0), remaining_ms, 1_000.0)
+            command_timeout = _actionability_probe_timeout(remaining_ms)
             self._page._run_locator_handlers(deadline)
-            last_info = self._target_state(command_timeout)
+            try:
+                last_info = self._target_state(command_timeout)
+            except TimeoutError:
+                # A single fill-readiness probe timing out is transient over a slow
+                # remote-CDP transport: keep polling until the outer deadline.
+                if time.monotonic() >= deadline:
+                    break
+                _sleep_until_next_poll(deadline)
+                continue
             if self._strict and not self._explicit_index:
                 self._raise_frame_strict_violation(last_info.get("frame_strict_violation"))
             count = int(last_info.get("count") or 0)
@@ -23614,7 +23645,7 @@ return {{ ok: true, info }};
         last_info: dict[str, Any] = {}
         while True:
             remaining_ms = max((deadline - time.monotonic()) * 1000, 1.0)
-            command_timeout = min(max(timeout_ms, 1.0), remaining_ms, 1_000.0)
+            command_timeout = _actionability_probe_timeout(remaining_ms)
             self._page._run_locator_handlers(deadline)
             try:
                 result = self._eval(fill_script, command_timeout)
@@ -24397,7 +24428,7 @@ return {{ ok: true, selected: Array.from(el.selectedOptions).map(option => optio
         deadline = started + max(timeout_ms, 0.0) / 1000
         while True:
             remaining_ms = max((deadline - time.monotonic()) * 1000, 1.0)
-            command_timeout = min(max(timeout_ms, 1.0), remaining_ms, 1_000.0)
+            command_timeout = _actionability_probe_timeout(remaining_ms)
             try:
                 result = self._eval(select_script, command_timeout, method=method)
             except TimeoutError:

--- a/python/rustwright/sync_api.py
+++ b/python/rustwright/sync_api.py
@@ -21812,8 +21812,13 @@ return new Promise(resolve => {
             except TimeoutError:
                 # A single actionability probe that exceeds its own budget is transient,
                 # not fatal: over a high-latency remote-CDP transport one probe's round
-                # trips can outlast a small fixed cap. Keep polling until the outer
-                # deadline instead of aborting the whole action (matches Playwright).
+                # trips can outlast a small fixed cap. Surface owner unavailability
+                # immediately, otherwise keep polling until the outer deadline instead of
+                # aborting the whole action (matches Playwright and the fill/select-apply
+                # loops). Doing this before the deadline check means a page/context/browser
+                # that closed mid-probe raises the precise owner error rather than a
+                # generic timeout when the deadline coincides.
+                _raise_if_owner_unavailable(self._page, method=method)
                 if time.monotonic() >= deadline:
                     break
                 _sleep_until_next_poll(deadline)
@@ -21886,7 +21891,12 @@ return new Promise(resolve => {
                 last_info = self._target_state(command_timeout)
             except TimeoutError:
                 # A single fill-readiness probe timing out is transient over a slow
-                # remote-CDP transport: keep polling until the outer deadline.
+                # remote-CDP transport: surface owner unavailability immediately, otherwise
+                # keep polling until the outer deadline (matches the fill/select-apply
+                # loops). Checking the owner before the deadline break means a closed
+                # page/context/browser raises the precise owner error rather than a generic
+                # timeout when the deadline coincides.
+                _raise_if_owner_unavailable(self._page, method=method)
                 if time.monotonic() >= deadline:
                     break
                 _sleep_until_next_poll(deadline)

--- a/python/rustwright/sync_api.py
+++ b/python/rustwright/sync_api.py
@@ -23649,6 +23649,18 @@ return {{ ok: true, info }};
             self._page._run_locator_handlers(deadline)
             try:
                 result = self._eval(fill_script, command_timeout)
+            except TimeoutError:
+                # A single fill-apply probe timing out is transient over a slow remote-CDP
+                # transport: one probe's CDP round trips can outlast the per-probe budget.
+                # Surface owner unavailability immediately, otherwise keep polling until the
+                # outer deadline instead of aborting the whole action (matches Playwright and
+                # the sibling wait/select loops). TimeoutError subclasses Error, so this must
+                # precede the generic Error handler below.
+                _raise_if_owner_unavailable(self._page, method=_locator_method_for_action(action))
+                if time.monotonic() >= deadline:
+                    break
+                _sleep_until_next_poll(deadline)
+                continue
             except Error as exc:
                 if "No element matches locator" not in str(exc):
                     raise
@@ -24432,6 +24444,9 @@ return {{ ok: true, selected: Array.from(el.selectedOptions).map(option => optio
             try:
                 result = self._eval(select_script, command_timeout, method=method)
             except TimeoutError:
+                # A transient select-apply probe timeout is retried until the outer deadline
+                # (see the fill-apply loop), but owner unavailability is surfaced immediately.
+                _raise_if_owner_unavailable(self._page, method=method)
                 if time.monotonic() >= deadline:
                     break
                 _sleep_until_next_poll(deadline)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9046,12 +9046,18 @@ return true;
     #[pyo3(signature = (locator_json, index, body, timeout_ms=None))]
     fn locator_eval(
         &self,
+        py: Python<'_>,
         locator_json: &str,
         index: usize,
         body: &str,
         timeout_ms: Option<f64>,
     ) -> PyResult<String> {
-        self.evaluate_locator(locator_json, index, body, timeout_ms)
+        // Release the GIL for the duration of the blocking CDP round-trip, matching
+        // `click` and `locator_eval_handle`. `evaluate_locator` already detaches inside
+        // `block_on`, but keeping the detach explicit at the binding layer keeps the
+        // three locator bindings consistent and guards against a future refactor that
+        // adds GIL-holding work before `block_on` or changes the transport.
+        py.detach(|| self.evaluate_locator(locator_json, index, body, timeout_ms))
             .map_err(py_err)
     }
 

--- a/tests/test_rustwright_sync_api.py
+++ b/tests/test_rustwright_sync_api.py
@@ -10312,6 +10312,32 @@ def test_fill_apply_loop_propagates_owner_crash_on_probe_timeout(page, monkeypat
         page._crashed = False
 
 
+def test_wait_for_single_propagates_owner_crash_when_probe_times_out_at_deadline(page, monkeypatch):
+    # Owner unavailability must win over a probe timeout even when the timeout coincides
+    # with the outer deadline. The top-of-loop owner check already covers the retry path,
+    # but a probe that both crashes the owner and outlasts the deadline would otherwise
+    # take the deadline-break path and raise a generic actionability timeout. The except
+    # block now surfaces the crash first, matching the fill/select-apply loops.
+    from rustwright.sync_api import Locator
+
+    page.set_content("<button id='go'>go</button>")
+
+    def crashing_probe(self, timeout=None, **kwargs):
+        # Crash the owner and sleep past the tiny outer deadline before timing out, so the
+        # loop reaches the deadline break rather than re-polling on the next iteration.
+        self._page._crashed = True
+        time.sleep(0.05)
+        raise TimeoutError(f"timed out after {int(timeout)} ms")
+
+    monkeypatch.setattr(Locator, "_target_state", crashing_probe)
+
+    try:
+        with pytest.raises(Error, match="Page crashed"):
+            page.click("#go", timeout=10)
+    finally:
+        page._crashed = False
+
+
 def test_locator_fill_waits_for_delayed_editable(page):
     page.set_content(
         """
@@ -24095,6 +24121,62 @@ def test_async_cancelled_create_target_response_closes_orphan_and_normal_page_su
             await browser.close()
 
     asyncio.run(run())
+
+
+def test_locator_eval_does_not_monopolize_gil_while_blocking(page):
+    # Invariant guard for the PR #95 GIL finding: while native ``locator_eval`` blocks
+    # on a slow in-page evaluate, it must not hold the Python GIL, so other Python
+    # threads keep running. This holds because ``locator_eval`` runs the CDP round-trip
+    # under ``py.detach`` (matching ``click`` / ``locator_eval_handle``); ``block_on``
+    # also detaches internally, so the property predates and survives the binding-layer
+    # change -- this test locks it in against future refactors that could hold the GIL.
+    #
+    # The probe is a pure-Python busy-increment thread (no I/O -- ``time.sleep`` would
+    # release the GIL regardless). If ``locator_eval`` ever held the GIL for the whole
+    # blocking window, the busy thread would be starved to ~0 iterations, because native
+    # Rust code never reaches a bytecode boundary where CPython could rotate threads.
+    # Absolute iteration counts are very noisy (10-20x run-to-run), so the assertion
+    # only checks "not frozen" with a wide margin rather than a tight rate.
+    page.set_content("<div id='target'>hi</div>")
+
+    stop = threading.Event()
+    progress = {"count": 0}
+
+    def spin() -> None:
+        while not stop.is_set():
+            progress["count"] += 1
+
+    worker = threading.Thread(target=spin, daemon=True)
+    worker.start()
+    try:
+        # Let the busy thread reach steady state before measuring.
+        time.sleep(0.05)
+        before = progress["count"]
+        started = time.monotonic()
+        # ``_eval`` routes straight through the native ``locator_eval`` binding. The JS
+        # body busy-waits ~750ms so the native call blocks for a measurable window.
+        page.locator("#target")._eval(
+            "const end = Date.now() + 750; while (Date.now() < end) {} return true;"
+        )
+        elapsed = time.monotonic() - started
+        advanced = progress["count"] - before
+    finally:
+        stop.set()
+        worker.join(timeout=2)
+
+    # Confirm the in-page busy loop actually blocked the native call (~0.75s), so the
+    # measurement window is real rather than a fast return.
+    assert elapsed >= 0.4, (
+        f"native locator_eval returned too fast to prove blocking: {elapsed:.3f}s"
+    )
+    # A frozen GIL would starve the busy thread to ~0 iterations. A released GIL lets it
+    # accumulate hundreds of thousands to millions; 50k is far above 0 yet far below the
+    # smallest observed released count, so it discriminates "frozen" from "released"
+    # without depending on the machine's exact throughput.
+    assert advanced > 50_000, (
+        f"busy thread only advanced {advanced} iterations during a {elapsed:.3f}s "
+        "native locator_eval; the GIL appears to be held for the blocking call"
+    )
 
 
 def test_connect_over_cdp_cancelled_creations_cleanup_after_last_browser_owner_drops():

--- a/tests/test_rustwright_sync_api.py
+++ b/tests/test_rustwright_sync_api.py
@@ -10177,39 +10177,139 @@ def test_locator_click_waits_for_delayed_element(page):
     assert page.evaluate("document.body.dataset.clicked") == "yes"
 
 
-def test_actionability_probe_tolerates_slow_remote_cdp_round_trips(page, monkeypatch):
-    # Regression for remote-CDP interaction timeouts (connect_over_cdp attach): over a
-    # high-latency transport a single actionability probe's CDP round-trips can outlast the
-    # per-probe budget. The action must keep polling until the outer deadline instead of
-    # aborting on that transient probe timeout. Before the fix, click()/select_option()
-    # failed in ~1s with a raw "timed out after 1000 ms" (the old fixed per-probe cap) even
-    # though the outer timeout was 30s, so 13/60 remote-CDP interactions timed out.
+def test_wait_for_single_retries_transient_actionability_probe_timeout(page, monkeypatch):
+    # A single actionability probe can exceed its own budget over a high-latency remote-CDP
+    # transport (connect_over_cdp attach): its several CDP round trips outlast the per-probe
+    # budget even though the outer action deadline is still far off. The wait loop must treat
+    # that probe TimeoutError as transient and keep polling, not abort the whole action.
+    from rustwright.sync_api import Locator
+
+    page.set_content("<button id='go' onclick=\"document.body.dataset.clicked='yes'\">go</button>")
+
+    real_target_state = Locator._target_state
+    probe = {"calls": 0, "timed_out": 0}
+
+    def flaky_target_state(self, timeout=None, **kwargs):
+        probe["calls"] += 1
+        # Time out only the first probe regardless of how large its budget is, so the retry
+        # path itself is exercised rather than merely the enlarged per-probe budget.
+        if probe["timed_out"] == 0:
+            probe["timed_out"] += 1
+            raise TimeoutError(f"timed out after {int(timeout)} ms")
+        return real_target_state(self, timeout, **kwargs)
+
+    monkeypatch.setattr(Locator, "_target_state", flaky_target_state)
+
+    page.click("#go", timeout=30_000)
+
+    assert page.evaluate("document.body.dataset.clicked") == "yes"
+    assert probe["timed_out"] == 1
+    assert probe["calls"] >= 2  # retried after the transient probe timeout
+
+
+def test_fill_apply_loop_retries_transient_probe_timeout(page, monkeypatch):
+    # The fill-apply loop performs the actual fill via _eval. A first probe whose CDP round
+    # trips outlast the per-probe budget raises TimeoutError; the loop must retry until the
+    # outer deadline instead of re-raising that transient timeout as a fatal error.
+    from rustwright.sync_api import Locator
+
+    page.set_content("<input id='name'>")
+
+    real_eval = Locator._eval
+    probe = {"calls": 0, "timed_out": 0}
+
+    def flaky_eval(self, body, timeout=None, *, method=None):
+        if "nonFillableInputTypes" in body:
+            probe["calls"] += 1
+            if probe["timed_out"] == 0:
+                probe["timed_out"] += 1
+                raise TimeoutError(f"timed out after {int(timeout)} ms")
+        return real_eval(self, body, timeout, method=method)
+
+    monkeypatch.setattr(Locator, "_eval", flaky_eval)
+
+    page.fill("#name", "Ada", timeout=30_000)
+
+    assert page.locator("#name").input_value() == "Ada"
+    assert probe["timed_out"] == 1
+    assert probe["calls"] >= 2  # retried after the transient probe timeout
+
+
+def test_select_apply_loop_retries_transient_probe_timeout(page, monkeypatch):
+    # The select-apply loop performs the final selection via _eval. A first transient probe
+    # timeout must be retried until the outer deadline rather than aborting select_option.
     from rustwright.sync_api import Locator
 
     page.set_content(
         "<select id='sel'><option value='a'>A</option><option value='b'>B</option></select>"
-        "<button id='mutate' onclick=\"document.getElementById('state').textContent='after'\">go</button>"
-        "<span id='state'>before</span>"
     )
 
-    real_target_state = Locator._target_state
-    probe_calls = {"count": 0}
+    real_eval = Locator._eval
+    probe = {"calls": 0, "timed_out": 0}
 
-    def slow_probe_target_state(self, timeout=None, **kwargs):
-        probe_calls["count"] += 1
-        # Model a probe whose round-trips need more than the old 1000ms cap to complete.
-        if timeout is not None and timeout < 1_500.0:
-            raise TimeoutError(f"timed out after {int(timeout)} ms")
-        return real_target_state(self, timeout, **kwargs)
+    def flaky_eval(self, body, timeout=None, *, method=None):
+        if "foundValues" in body:
+            probe["calls"] += 1
+            if probe["timed_out"] == 0:
+                probe["timed_out"] += 1
+                raise TimeoutError(f"timed out after {int(timeout)} ms")
+        return real_eval(self, body, timeout, method=method)
 
-    monkeypatch.setattr(Locator, "_target_state", slow_probe_target_state)
+    monkeypatch.setattr(Locator, "_eval", flaky_eval)
 
-    # With the outer timeout at 30s, each probe must be granted well over 1500ms, so the
-    # interaction completes rather than dying on the first under-budgeted probe.
-    page.click("#mutate", timeout=30_000)
-    assert page.locator("#state").text_content() == "after"
     assert page.select_option("#sel", "b", timeout=30_000) == ["b"]
-    assert probe_calls["count"] > 0
+    assert probe["timed_out"] == 1
+    assert probe["calls"] >= 2  # retried after the transient probe timeout
+
+
+def test_fill_apply_loop_surfaces_outer_deadline_on_persistent_probe_timeout(page, monkeypatch):
+    # When every fill-apply probe keeps timing out, the loop must still end at the outer
+    # deadline with its own editable-timeout message (not the raw per-probe timeout) and
+    # without busy-looping past the deadline.
+    from rustwright.sync_api import Locator
+
+    page.set_content("<input id='name'>")
+
+    real_eval = Locator._eval
+
+    def always_timeout_eval(self, body, timeout=None, *, method=None):
+        if "nonFillableInputTypes" in body:
+            raise TimeoutError(f"timed out after {int(timeout)} ms")
+        return real_eval(self, body, timeout, method=method)
+
+    monkeypatch.setattr(Locator, "_eval", always_timeout_eval)
+
+    started = time.monotonic()
+    with pytest.raises(TimeoutError, match="editable"):
+        page.fill("#name", "Ada", timeout=300)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 5  # honored the ~300ms outer deadline; no runaway busy-loop
+
+
+def test_fill_apply_loop_propagates_owner_crash_on_probe_timeout(page, monkeypatch):
+    # A probe timeout must not mask owner unavailability: if the page crashes while a fill
+    # probe is timing out, the loop surfaces the crash immediately instead of polling until
+    # the outer deadline.
+    from rustwright.sync_api import Locator
+
+    page.set_content("<input id='name'>")
+
+    real_eval = Locator._eval
+
+    def crashing_probe_eval(self, body, timeout=None, *, method=None):
+        if "nonFillableInputTypes" in body:
+            self._page._crashed = True
+            raise TimeoutError(f"timed out after {int(timeout)} ms")
+        return real_eval(self, body, timeout, method=method)
+
+    monkeypatch.setattr(Locator, "_eval", crashing_probe_eval)
+
+    try:
+        with pytest.raises(Error, match="Page crashed"):
+            page.fill("#name", "Ada", timeout=30_000)
+    finally:
+        page._crashed = False
 
 
 def test_locator_fill_waits_for_delayed_editable(page):

--- a/tests/test_rustwright_sync_api.py
+++ b/tests/test_rustwright_sync_api.py
@@ -10177,6 +10177,41 @@ def test_locator_click_waits_for_delayed_element(page):
     assert page.evaluate("document.body.dataset.clicked") == "yes"
 
 
+def test_actionability_probe_tolerates_slow_remote_cdp_round_trips(page, monkeypatch):
+    # Regression for remote-CDP interaction timeouts (connect_over_cdp attach): over a
+    # high-latency transport a single actionability probe's CDP round-trips can outlast the
+    # per-probe budget. The action must keep polling until the outer deadline instead of
+    # aborting on that transient probe timeout. Before the fix, click()/select_option()
+    # failed in ~1s with a raw "timed out after 1000 ms" (the old fixed per-probe cap) even
+    # though the outer timeout was 30s, so 13/60 remote-CDP interactions timed out.
+    from rustwright.sync_api import Locator
+
+    page.set_content(
+        "<select id='sel'><option value='a'>A</option><option value='b'>B</option></select>"
+        "<button id='mutate' onclick=\"document.getElementById('state').textContent='after'\">go</button>"
+        "<span id='state'>before</span>"
+    )
+
+    real_target_state = Locator._target_state
+    probe_calls = {"count": 0}
+
+    def slow_probe_target_state(self, timeout=None, **kwargs):
+        probe_calls["count"] += 1
+        # Model a probe whose round-trips need more than the old 1000ms cap to complete.
+        if timeout is not None and timeout < 1_500.0:
+            raise TimeoutError(f"timed out after {int(timeout)} ms")
+        return real_target_state(self, timeout, **kwargs)
+
+    monkeypatch.setattr(Locator, "_target_state", slow_probe_target_state)
+
+    # With the outer timeout at 30s, each probe must be granted well over 1500ms, so the
+    # interaction completes rather than dying on the first under-budgeted probe.
+    page.click("#mutate", timeout=30_000)
+    assert page.locator("#state").text_content() == "after"
+    assert page.select_option("#sel", "b", timeout=30_000) == ["b"]
+    assert probe_calls["count"] > 0
+
+
 def test_locator_fill_waits_for_delayed_editable(page):
     page.set_content(
         """


### PR DESCRIPTION
## Problem

On the `connect_over_cdp()` remote-attach path, `click()`, `select_option()`, and
`fill()` could time out prematurely — aborting after roughly 0.3–0.4 s even though the
caller's action deadline (default 30 s) was still far off.

The Locator actionability/state polling loops capped each individual CDP probe at a fixed
1000 ms. A single probe issues several CDP round trips; over a high-latency remote
transport those round trips can exceed 1000 ms, so every probe hit its per-probe cap and
raised `TimeoutError`. The `_wait_for_single` and `_wait_for_fill_ready` loops did not
catch that error at all; the fill-apply loop caught only the generic `Error` and re-raised
the `TimeoutError` (since `TimeoutError` subclasses `Error`). Either way the probe timeout
propagated out and aborted the whole action long before the real deadline.

## Fix

- Budget each probe with the **full remaining action time** instead of a small fixed cap,
  via the `_actionability_probe_timeout` helper.
- Treat a per-probe `TimeoutError` as **transient** — keep polling until the outer action
  deadline rather than aborting (matching Playwright's behavior).
- Applied uniformly to the four sibling loops: `_wait_for_single`, `_wait_for_fill_ready`,
  the **fill-apply** loop, and the **select-apply** loop. The fill-apply loop now catches
  `TimeoutError` **before** the generic `Error` handler; the select-apply loop already
  caught it.
- All four loops surface **owner unavailability** (page/context/browser closed or crashed)
  immediately on a probe timeout instead of masking it: the two wait loops re-check the
  owner at the top of each iteration, and the fill/select-apply loops call
  `_raise_if_owner_unavailable` in their `TimeoutError` handlers.

Polling cadence is still driven by `_sleep_until_next_poll`, so widening the per-probe
bound does not busy-loop. For an infinite wait (`timeout<=0`) the probe keeps a bounded
1000 ms cadence so owner-availability and locator handlers are still re-checked
periodically.

The change is **pure Python** — no Rust/native changes, no timeout inflation of the outer
deadline, no vendor-specific behavior, no retries that bypass semantics, and no fallback
engine.

## Tests

Call-count-driven regressions that force a **first-probe `TimeoutError`** on the real
affected loop paths (rather than only asserting the enlarged per-probe budget):

- `test_fill_apply_loop_retries_transient_probe_timeout` — the fill-apply `_eval` probe
  times out once, then the fill completes (RED before this commit: the transient timeout
  was re-raised).
- `test_select_apply_loop_retries_transient_probe_timeout` — the select-apply `_eval`
  probe times out once, then `select_option()` completes.
- `test_wait_for_single_retries_transient_actionability_probe_timeout` — the actionability
  `_target_state` probe times out once, then `click()` completes.
- `test_fill_apply_loop_surfaces_outer_deadline_on_persistent_probe_timeout` — a probe
  that always times out ends at the outer deadline with the loop's own editable-timeout
  message, bounded (no runaway busy-loop) (RED before: raw per-probe timeout surfaced).
- `test_fill_apply_loop_propagates_owner_crash_on_probe_timeout` — a page crash during a
  probe timeout raises `Page crashed` immediately instead of polling to the deadline
  (RED before: the raw probe timeout surfaced).

## Validation status

Local browser-backed execution runs against the Playwright `chrome-headless-shell` build
(the full Chromium build does not expose its CDP endpoint on this host); under that build
all five regressions plus the surrounding fill/select/click/actionability suite pass, and
the RED→GREEN behavior was verified at head `72a5dbb`. **External reliability validation
over a real high-latency remote transport is stale after this commit and will be rerun by
Hermes**; this stays **Draft** until that validation completes.


---

## Update — head `6ecb956` (GIL-release + owner-consistency hardening)

Follow-up addressing the automated Critical GIL finding on this PR.

**Supersedes the "pure Python — no Rust/native changes" note above:** this commit includes
a **one-line native change** in `src/lib.rs`.

- **`locator_eval` binding now releases the GIL explicitly** via `py.detach`, matching its
  siblings `click` and `locator_eval_handle`. Note the GIL was already released for the
  blocking CDP round-trip one layer deeper — `evaluate_locator` → `block_on` →
  `run_blocking_detached` → `run_detached` wraps the work in
  `Python::try_attach(|py| py.detach(..))` — so `locator_eval` did **not** actually
  monopolize the GIL in practice (verified: a pure-Python busy thread advances ~9M
  iterations while a ~0.75 s native `locator_eval` blocks). The change closes the
  binding-layer inconsistency and guards against future refactors. No 3–5 s probe cap was
  added.
- **Guard test** `test_locator_eval_does_not_monopolize_gil_while_blocking` locks in the
  GIL-release invariant.
- **Owner-unavailability refinement:** `_wait_for_single` and `_wait_for_fill_ready` now
  also call `_raise_if_owner_unavailable` **inside** their `except TimeoutError` block
  (before the deadline break), so a close that coincides with a probe timeout at the outer
  deadline raises the precise owner error instead of a generic actionability timeout —
  matching the fill/select-apply loops. New RED→GREEN test
  `test_wait_for_single_propagates_owner_crash_when_probe_times_out_at_deadline`.
  (`_wait_for_fill_ready` is currently unreferenced, so its mirrored edit is
  consistency-only.)

No transport or outer/probe timeout semantics changed.

**Validation now stale at `6ecb956`:** the latest-head external actionability gate (20/20)
and the Codex rereview PASS predate this commit and must be re-run against the new head.
Stays **Draft**.
