### PR TITLE
ci(gem): add RubyGems release workflow (platform-native gems)

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -1,0 +1,239 @@
+name: Release Ruby gem
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build and upload artifacts without publishing"
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-gem-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  metadata:
+    name: validate package versions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
+        with:
+          ruby-version: "3.2"
+
+      - name: Validate release metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruby <<'RUBY'
+          cargo_version = File.read('Cargo.toml')[/^version = "([^"]+)"$/, 1]
+          gemspec = Gem::Specification.load('ruby/rustwright.gemspec')
+          abort 'Unable to load ruby/rustwright.gemspec' unless gemspec
+
+          versions = {
+            'Cargo.toml' => cargo_version,
+            'ruby/rustwright.gemspec' => gemspec.version.to_s
+          }
+          expected = versions.values.first
+          abort "Package versions do not match: #{versions}" unless versions.values.all? { |value| value == expected }
+
+          if ENV['GITHUB_REF_TYPE'] == 'tag'
+            tag_version = ENV.fetch('GITHUB_REF_NAME').sub(/^v/, '')
+            abort "Tag version #{tag_version.inspect} does not match package version #{expected.inspect}" unless tag_version == expected
+          end
+          puts "Validated package version #{expected}"
+          RUBY
+
+  native:
+    name: native library - ${{ matrix.platform.gem }}
+    needs: metadata
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - runner: macos-latest
+            target: aarch64-apple-darwin
+            gem: arm64-darwin
+            library: librustwright_capi.dylib
+            zig_target: ""
+          - runner: macos-latest
+            target: x86_64-apple-darwin
+            gem: x86_64-darwin
+            library: librustwright_capi.dylib
+            zig_target: ""
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            gem: x86_64-linux
+            library: librustwright_capi.so
+            zig_target: x86_64-linux-gnu.2.17
+          - runner: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            gem: aarch64-linux
+            library: librustwright_capi.so
+            zig_target: aarch64-linux-gnu.2.17
+
+    env:
+      CARGO_BUILD_TARGET: ${{ matrix.platform.target }}
+      MACOSX_DEPLOYMENT_TARGET: "10.13"
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.platform.target }}
+
+      - name: Set up Zig
+        if: ${{ matrix.platform.zig_target != '' }}
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.14.1
+
+      - name: Configure Linux linker
+        if: ${{ matrix.platform.zig_target != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          linker="$RUNNER_TEMP/zig-cc"
+          cat > "$linker" <<'SH'
+          #!/bin/sh
+          exec zig cc -target "${ZIG_TARGET}" "$@"
+          SH
+          chmod +x "$linker"
+          target_env="$(printf '%s' "$CARGO_BUILD_TARGET" | tr '[:lower:]-' '[:upper:]_')"
+          cc_env="$(printf '%s' "$CARGO_BUILD_TARGET" | tr '-' '_')"
+          echo "ZIG_TARGET=${{ matrix.platform.zig_target }}" >> "$GITHUB_ENV"
+          echo "CARGO_TARGET_${target_env}_LINKER=$linker" >> "$GITHUB_ENV"
+          echo "CC_${cc_env}=$linker" >> "$GITHUB_ENV"
+
+      - name: Build native library
+        run: cargo build -p rustwright-capi --release --locked
+
+      - name: Upload native library
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gem-native-${{ matrix.platform.gem }}
+          path: target/${{ matrix.platform.target }}/release/${{ matrix.platform.library }}
+          if-no-files-found: error
+
+  package:
+    name: assemble platform gems
+    needs: native
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
+        with:
+          ruby-version: "3.2"
+
+      - name: Download native libraries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: gem-native-*
+          path: gem-native
+
+      - name: Build platform gems
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS='|' read -r platform library; do
+            source="gem-native/gem-native-${platform}/${library}"
+            test -f "$source"
+            ruby ruby/package.rb "$platform" "$source"
+          done <<'PLATFORMS'
+          arm64-darwin|librustwright_capi.dylib
+          x86_64-darwin|librustwright_capi.dylib
+          aarch64-linux|librustwright_capi.so
+          x86_64-linux|librustwright_capi.so
+          PLATFORMS
+          count="$(find ruby/pkg -maxdepth 1 -type f -name '*.gem' | wc -l | tr -d ' ')"
+          test "$count" -eq 4
+
+      - name: Smoke-test packaged Linux native
+        shell: bash
+        run: |
+          set -euo pipefail
+          gem_home="$RUNNER_TEMP/rustwright-gems"
+          gem install --local ruby/pkg/rustwright-*-x86_64-linux.gem --install-dir "$gem_home" --ignore-dependencies --no-document
+          cd "$RUNNER_TEMP"
+          GEM_HOME="$gem_home" GEM_PATH="$gem_home" ruby -e \
+            "require 'rustwright'; abort 'bundled native was not selected' unless Rustwright.bundled_library_path; Rustwright.chromium"
+
+      - name: Upload Ruby gems
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: gem-package
+          path: ruby/pkg/*.gem
+          if-no-files-found: error
+
+  publish:
+    name: publish to RubyGems
+    needs: package
+    if: >-
+      ${{
+        github.repository == 'Skyvern-AI/rustwright' &&
+        github.ref_type == 'tag' &&
+        (
+          github.event_name == 'push' ||
+          (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
+        )
+      }}
+    runs-on: ubuntu-latest
+    environment:
+      name: rubygems
+      url: https://rubygems.org/gems/rustwright
+
+    steps:
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@003a5c4d8d6321bd302e38f6f0ec593f77f06600 # v1.319.0
+        with:
+          ruby-version: "3.2"
+
+      - name: Download Ruby gems
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: gem-package
+          path: gem-dist
+
+      - name: Require a prerelease version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#v}"
+          case "$version" in
+            *-*) ;;
+            *)
+              echo "The experimental Ruby gem requires a prerelease version such as 0.2.0-alpha.1" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Publish experimental platform gems
+        shell: bash
+        run: |
+          set -euo pipefail
+          for package in gem-dist/*.gem; do
+            gem push "$package"
+          done
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}


### PR DESCRIPTION
Sibling of `release-npm.yml`/`release-pypi.yml`/`release-nuget.yml` — release workflows execute on this repository. Per-platform gem publish (bundled `librustwright_capi`) guarded by `v*` tag / dispatch with `dry_run` default true; uses the org-level `RUBYGEMS_API_KEY`. Identical to the copy merged on the development repo (its review passed with the `ruby/setup-ruby` action SHA-pinned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)