### PR TITLE
MCP server: default-toolset compatibility (foundations, canonical schemas, full default tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,42 +94,15 @@ Already have a Chromium/Chrome binary? Point Rustwright at it with `RUSTWRIGHT_C
 
 ## Browser automation for AI agents
 
-Two agent-facing surfaces drive Chromium from a compact accessibility snapshot
-with stable element refs (`e1`, `e2`, …) instead of raw HTML or screenshots:
-take a snapshot, then act on an element by its ref. Refs are session-scoped and
-never reused; resolution is best-effort for cooperative pages (not a security
-boundary), and snapshots reflect page values with password fields masked.
+Give an agent or shell script a browser through compact accessibility snapshots with element refs (`e1`, `e2`, …), instead of raw HTML or screenshots. Refs are session-scoped, never reused, and best-effort rather than a security boundary; snapshots include page values but mask password fields.
 
-### CLI — drive a browser from your shell
+### MCP server — give your agent a browser
 
-Ships with the `rustwright` package (pure Python, no extra runtime dependency).
-Named sessions keep one browser alive across commands:
+`rustwright-mcp` gives any MCP client `browser_*` tools over stdio.
 
-```bash
-pip install rustwright
-python -m rustwright install chromium   # one-time browser download
+#### Fastest path
 
-rustwright open example.com       # launch + navigate; prints a snapshot
-rustwright snapshot               # accessibility tree with refs (e1, e2, …)
-rustwright click e3               # act on an element by its ref
-rustwright fill e2 "hi@example.com"
-rustwright --json snapshot        # one JSON object, for scripting
-rustwright close
-```
-
-The CLI verbs and the MCP server's tools are the same surface.
-
-Full verbs, flags, session model, and threat model:
-[docs/agent-interfaces.md](docs/agent-interfaces.md).
-
-### MCP server — `rustwright-mcp`
-
-A [Model Context Protocol](https://modelcontextprotocol.io) server (a separate,
-opt-in package under [`mcp/`](mcp/)) exposing browser tools — `browser_navigate`,
-`browser_snapshot`, `browser_click`, `browser_type`, … — over stdio, so
-MCP-compatible agents (Claude Code, Claude Desktop, and others) can browse with
-Rustwright. After installing both packages, start the stdio server with `rustwright mcp`.
-Register it with Claude Code, no clone required:
+##### Claude Code
 
 ```bash
 claude mcp add rustwright \
@@ -137,25 +110,81 @@ claude mcp add rustwright \
   -- uvx --from 'git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp' rustwright-mcp
 ```
 
-…or point any MCP client at it:
+Uses the Chrome you already have — no browser download.
+
+##### Claude Desktop
+
+Open `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows, then use:
 
 ```json
 {
   "mcpServers": {
     "rustwright": {
       "command": "uvx",
-      "args": ["--from", "git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp", "rustwright-mcp"],
-      "env": { "RUSTWRIGHT_MCP_CHANNEL": "chrome" }
+      "args": [
+        "--from",
+        "git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp",
+        "rustwright-mcp"
+      ],
+      "env": {
+        "RUSTWRIGHT_MCP_CHANNEL": "chrome"
+      }
     }
   }
 }
 ```
 
-Key environment variables: `RUSTWRIGHT_MCP_HEADLESS` (`0` runs headed),
-`RUSTWRIGHT_MCP_CHANNEL` (Chromium channel, e.g. `chrome`), and
-`RUSTWRIGHT_MCP_ALLOW_EVAL` (`browser_evaluate` is available by default; `0`
-disables it). See the [MCP security note](mcp/README.md#security--scope). Full
-setup, tool list, and configuration: [mcp/README.md](mcp/README.md).
+##### Any MCP client
+
+```json
+{
+  "mcpServers": {
+    "rustwright": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp",
+        "rustwright-mcp"
+      ],
+      "env": {
+        "RUSTWRIGHT_MCP_CHANNEL": "chrome"
+      }
+    }
+  }
+}
+```
+
+| If... | Do this |
+|---|---|
+| You do not have Chrome installed | Drop `RUSTWRIGHT_MCP_CHANNEL`, then run `uvx --from 'git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp' python -m rustwright install chromium`. |
+| You want a visible browser | Set `RUSTWRIGHT_MCP_HEADLESS=0`. |
+| You want to disable page evaluation | Set `RUSTWRIGHT_MCP_ALLOW_EVAL=0`; see [Security & scope](mcp/README.md#security--scope). |
+
+PyPI package coming soon — the command shrinks to `uvx rustwright-mcp`.
+
+See [the MCP guide](mcp/README.md) for the full tool list and configuration.
+
+### CLI — drive a browser from your shell
+
+Drive one persistent Chromium session straight from the `rustwright` command, with no application code.
+
+#### Try it in 60 seconds
+
+```bash
+pip install rustwright
+python -m rustwright install chromium
+
+rustwright open example.com
+rustwright snapshot
+rustwright click e1001
+rustwright close
+```
+
+- `snapshot` shows refs; act by ref, then use the fresh snapshot returned after the action.
+- Add `--json` for one JSON object per command when scripting.
+- Use `--session NAME` for named browser sessions.
+
+See [the agent interface guide](docs/agent-interfaces.md) for every verb, flag, and security detail.
 
 ## Remote browsers (Skyvern)
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ claude mcp add rustwright \
 
 Key environment variables: `RUSTWRIGHT_MCP_HEADLESS` (`0` runs headed),
 `RUSTWRIGHT_MCP_CHANNEL` (Chromium channel, e.g. `chrome`), and
-`RUSTWRIGHT_MCP_ALLOW_EVAL` (`1` exposes the `browser_evaluate` tool, off by
-default). Full setup, tool list, and configuration: [mcp/README.md](mcp/README.md).
+`RUSTWRIGHT_MCP_ALLOW_EVAL` (`browser_evaluate` is available by default; `0`
+disables it). See the [MCP security note](mcp/README.md#security--scope). Full
+setup, tool list, and configuration: [mcp/README.md](mcp/README.md).
 
 ## Remote browsers (Skyvern)
 

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -2,3 +2,4 @@
 *.egg-info/
 __pycache__/
 .pytest_cache/
+tests/output/

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -100,7 +100,7 @@ Ask your agent to “take a browser snapshot of example.com”.
 | `RUSTWRIGHT_MCP_CDP_ENDPOINT` | Remote browser CDP endpoint; enables remote mode when set |
 | `RUSTWRIGHT_MCP_CDP_HEADERS` | Optional JSON object of extra CDP connection headers |
 | `RUSTWRIGHT_MCP_CDP_TIMEOUT_MS` | Remote connection timeout in milliseconds (default `60000`) |
-| `RUSTWRIGHT_MCP_ALLOW_EVAL` | Page-world evaluation is on by default; an explicit `0`, `false`, `no`, or `off` disables it |
+| `RUSTWRIGHT_MCP_ALLOW_EVAL` | Page-world evaluation is on by default; accepts `1`, `true`, `yes`, `on` or `0`, `false`, `no`, `off`; any other value stops startup |
 | `RUSTWRIGHT_MCP_CAPS` | Comma-separated capability groups; unavailable groups warn and are ignored |
 | `RUSTWRIGHT_MCP_TOOLSET` | `mirror` (all 25 tools, default) or `lean` (core interaction loop, resize, and evaluate) |
 | `RUSTWRIGHT_MCP_OUTPUT_DIR` | Root for files written by tools |
@@ -113,7 +113,9 @@ Ask your agent to “take a browser snapshot of example.com”.
 All tool-written files are confined to `RUSTWRIGHT_MCP_OUTPUT_DIR`. If that
 variable is unset, each server process creates a private session directory at
 `${XDG_CACHE_HOME:-~/.cache}/rustwright-mcp/output/<session-uuid>/`. Output
-directories use mode `0700`; files are created exclusively with mode `0600`.
+directories created by the server use mode `0700`; files are created exclusively
+with mode `0600`. A pre-existing configured directory keeps its permissions, and
+only files reserved by the current server process are eligible for eviction.
 Artifact paths returned by tools are relative to the output root.
 
 Each output is limited to 20 MiB by default, and all retained outputs together

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -70,6 +70,7 @@ Ask your agent to “take a browser snapshot of example.com”.
 | `browser_find(text?, regex?)` | Search one refreshed outline with paths, refs, and sibling context |
 | `browser_click(target, element?, doubleClick?, button?, modifiers?)` | Click a ref or unique CSS selector |
 | `browser_drag(startTarget, endTarget, startElement?, endElement?)` | Strict element-to-element drag with a fresh snapshot |
+| `browser_drop(target, element?, paths?, data?)` | Best-effort synthetic DataTransfer drop with files and/or MIME strings |
 | `browser_type(target, text, element?, submit?, slowly?, clear?)` | Fill or character-type into an input; `clear` is an extension |
 | `browser_select_option(target, values, element?)` | Select one or more dropdown options; legacy `value` is accepted |
 | `browser_fill_form(fields)` | Sequential, non-transactional typed form fill with one final snapshot |
@@ -101,11 +102,11 @@ Ask your agent to “take a browser snapshot of example.com”.
 | `RUSTWRIGHT_MCP_CDP_TIMEOUT_MS` | Remote connection timeout in milliseconds (default `60000`) |
 | `RUSTWRIGHT_MCP_ALLOW_EVAL` | Page-world evaluation is on by default; an explicit `0`, `false`, `no`, or `off` disables it |
 | `RUSTWRIGHT_MCP_CAPS` | Comma-separated capability groups; unavailable groups warn and are ignored |
-| `RUSTWRIGHT_MCP_TOOLSET` | `mirror` (all 24 tools, default) or `lean` (core interaction loop, resize, and evaluate) |
+| `RUSTWRIGHT_MCP_TOOLSET` | `mirror` (all 25 tools, default) or `lean` (core interaction loop, resize, and evaluate) |
 | `RUSTWRIGHT_MCP_OUTPUT_DIR` | Root for files written by tools |
-| `RUSTWRIGHT_MCP_OUTPUT_MAX_FILE_BYTES` | Per-file output cap (default `20971520`, or 20 MiB) |
-| `RUSTWRIGHT_MCP_OUTPUT_MAX_TOTAL_BYTES` | Total output cap (default `209715200`, or 200 MiB) |
-| `RUSTWRIGHT_MCP_WORKSPACE` | Allowed absolute input root for file uploads |
+| `RUSTWRIGHT_MCP_OUTPUT_MAX_FILE_BYTES` | Shared per-file output and drop-input cap (default `20971520`, or 20 MiB) |
+| `RUSTWRIGHT_MCP_OUTPUT_MAX_TOTAL_BYTES` | Shared total output and per-drop input cap (default `209715200`, or 200 MiB) |
+| `RUSTWRIGHT_MCP_WORKSPACE` | Allowed absolute input root for file uploads and drops |
 
 ### File outputs
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -65,16 +65,24 @@ Ask your agent to “take a browser snapshot of example.com”.
 | Tool | Purpose |
 |---|---|
 | `browser_navigate(url)` | Open a URL, returns snapshot |
+| `browser_resize(width, height)` | Change the page viewport and return a responsive snapshot |
 | `browser_snapshot(target?, filename?, depth?, boxes?)` | Full or targeted outline with `[ref=eN]` handles |
+| `browser_find(text?, regex?)` | Search one refreshed outline with paths, refs, and sibling context |
 | `browser_click(target, element?, doubleClick?, button?, modifiers?)` | Click a ref or unique CSS selector |
+| `browser_drag(startTarget, endTarget, startElement?, endElement?)` | Strict element-to-element drag with a fresh snapshot |
 | `browser_type(target, text, element?, submit?, slowly?, clear?)` | Fill or character-type into an input; `clear` is an extension |
 | `browser_select_option(target, values, element?)` | Select one or more dropdown options; legacy `value` is accepted |
+| `browser_fill_form(fields)` | Sequential, non-transactional typed form fill with one final snapshot |
 | `browser_hover(target)` | Hover an element |
 | `browser_press_key(key)` | Press a keyboard key |
 | `browser_navigate_back()` | History back |
 | `browser_reload()` | Reload the active page, returns snapshot |
 | `browser_tabs(action, index?, url?)` | List, open, select, or close tabs |
-| `browser_handle_dialog(accept, promptText?)` | Set a one-shot policy for the next dialog |
+| `browser_handle_dialog(accept, promptText?)` | Resolve the JavaScript dialog that is currently pending |
+| `browser_file_upload(paths?)` | Resolve or cancel the currently pending file chooser |
+| `browser_console_messages(level?, all?, filename?)` | Read thresholded console records inline or as an artifact |
+| `browser_network_requests(static?, filter?, filename?)` | List current-navigation requests by stable index |
+| `browser_network_request(index, part?, filename?)` | Read request/response details and lazy response bodies |
 | `browser_wait_for(time?, text?, textGone?, timeout_ms?)` | Wait up to 30 seconds and/or for visible/hidden text |
 | `browser_get_text(selector?)` | Visible text of a selector |
 | `browser_evaluate(function, element?, target?, filename?)` | Run page-world JavaScript and return JSON plus a fresh snapshot |
@@ -93,11 +101,11 @@ Ask your agent to “take a browser snapshot of example.com”.
 | `RUSTWRIGHT_MCP_CDP_TIMEOUT_MS` | Remote connection timeout in milliseconds (default `60000`) |
 | `RUSTWRIGHT_MCP_ALLOW_EVAL` | Page-world evaluation is on by default; an explicit `0`, `false`, `no`, or `off` disables it |
 | `RUSTWRIGHT_MCP_CAPS` | Comma-separated capability groups; unavailable groups warn and are ignored |
-| `RUSTWRIGHT_MCP_TOOLSET` | `mirror` (all 16 tools, default) or `lean` (core interaction loop plus evaluate) |
+| `RUSTWRIGHT_MCP_TOOLSET` | `mirror` (all 24 tools, default) or `lean` (core interaction loop, resize, and evaluate) |
 | `RUSTWRIGHT_MCP_OUTPUT_DIR` | Root for files written by tools |
 | `RUSTWRIGHT_MCP_OUTPUT_MAX_FILE_BYTES` | Per-file output cap (default `20971520`, or 20 MiB) |
 | `RUSTWRIGHT_MCP_OUTPUT_MAX_TOTAL_BYTES` | Total output cap (default `209715200`, or 200 MiB) |
-| `RUSTWRIGHT_MCP_WORKSPACE` | Allowed input root for future file-upload tools |
+| `RUSTWRIGHT_MCP_WORKSPACE` | Allowed absolute input root for file uploads |
 
 ### File outputs
 
@@ -171,6 +179,10 @@ restart the session).
   boundary. Refs increase for the browser session and stale refs fail fast.
 - Each server process controls a single local or remote browser session, which
   may have multiple tabs.
+- JavaScript dialogs and file choosers are pending modal state. Responses show
+  a `### Modal` section; use `browser_handle_dialog` or `browser_file_upload`
+  before another DOM-evaluating tool. Downloads are confined automatically and
+  reported once in `### Downloads`.
 
 ## Limitations
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -137,7 +137,35 @@ Example Domains
 | `RUSTWRIGHT_MCP_HEADLESS` | `0` shows the browser window (default headless) |
 | `RUSTWRIGHT_MCP_CHANNEL` | Chromium channel, e.g. `chrome`, `chrome-beta` |
 | `RUSTWRIGHT_MCP_EXECUTABLE` | Explicit browser binary path (overrides channel) |
+| `RUSTWRIGHT_MCP_CDP_ENDPOINT` | Remote browser CDP endpoint; enables remote mode when set |
+| `RUSTWRIGHT_MCP_CDP_HEADERS` | Optional JSON object of extra CDP connection headers |
+| `RUSTWRIGHT_MCP_CDP_TIMEOUT_MS` | Remote connection timeout in milliseconds (default `60000`) |
 | `RUSTWRIGHT_MCP_ALLOW_EVAL` | `1`, `true`, or `yes` exposes `browser_evaluate` (default off) |
+
+### Remote browsers over CDP
+
+Set `RUSTWRIGHT_MCP_CDP_ENDPOINT` to attach to an existing Chromium browser
+over CDP. `RUSTWRIGHT_MCP_CDP_HEADERS` accepts a JSON object of extra connection
+headers, and `RUSTWRIGHT_MCP_CDP_TIMEOUT_MS` controls the connection timeout.
+The server adopts the remote browser's default context and an existing page,
+creating a page only when the context has none.
+
+```bash
+RUSTWRIGHT_MCP_CDP_ENDPOINT='wss://browser.example.com/devtools/browser/<session-id>' \
+RUSTWRIGHT_MCP_CDP_HEADERS='{"Authorization":"Bearer <token>"}' \
+RUSTWRIGHT_MCP_CDP_TIMEOUT_MS=60000 \
+rustwright-mcp
+```
+
+In CDP mode, `RUSTWRIGHT_MCP_HEADLESS`, `RUSTWRIGHT_MCP_CHANNEL`, and
+`RUSTWRIGHT_MCP_EXECUTABLE` are ignored. If the initial connection fails or a
+remote session stops responding, the tool fails loudly; it never silently
+launches a local browser. `browser_close` detaches from the remote browser
+without terminating the remotely owned process.
+
+For example, a hosted browser provider such as Skyvern Browser Sessions exposes
+a CDP address plus an `x-api-key` header; configure the header with
+`RUSTWRIGHT_MCP_CDP_HEADERS='{"x-api-key":"<key>"}'`.
 
 ### Headless vs headed
 
@@ -166,12 +194,12 @@ restart the session).
   are masked in snapshot output; other field values are included as-is.
 - Snapshot refs are best-effort handles for cooperative pages, not a security
   boundary. Refs increase for the browser session and stale refs fail fast.
-- Each server process controls a single local browser session, which may have
-  multiple tabs.
+- Each server process controls a single local or remote browser session, which
+  may have multiple tabs.
 
 ## Limitations
 
-- Single local browser session per server process.
+- Single browser session per server process.
 - Snapshot refs are regenerated on every snapshot; after a page mutation,
   take a new snapshot before acting on refs. Stale refs fail fast with a
   message asking for a fresh snapshot.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,18 +1,10 @@
 # Rustwright MCP server
 
-Exposes Rustwright browser automation as [Model Context Protocol](https://modelcontextprotocol.io)
-tools, so MCP-compatible agents can browse through the Rustwright backend.
+Give any MCP client `browser_*` tools over stdio with no clone or browser download.
 
-Tool names mirror the de-facto standard `browser_*` toolset
-(`browser_navigate`, `browser_snapshot`, `browser_click`, ...) so agents can
-switch without re-learning the surface. `browser_snapshot` returns an accessibility-style
-outline where interactive elements carry `[ref=eN]` handles; pass a ref (or a
-raw CSS selector) to the action tools.
+## Install
 
-## Quick start (no clone needed)
-
-With [uv](https://docs.astral.sh/uv/) installed, register the server with
-Claude Code in one command — `uvx` fetches and runs it straight from GitHub:
+### Claude Code
 
 ```bash
 claude mcp add rustwright \
@@ -20,11 +12,11 @@ claude mcp add rustwright \
   -- uvx --from 'git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp' rustwright-mcp
 ```
 
-Note the `--` before the command: `--env` is variadic, so without the
-separator it swallows the command and `claude mcp add` fails with
-`missing required argument 'commandOrUrl'`.
+Uses the Chrome you already have — no browser download.
 
-Or add to any MCP client config (Claude Desktop, Cursor, etc.):
+### Claude Desktop
+
+Open `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS or `%APPDATA%\Claude\claude_desktop_config.json` on Windows, then use:
 
 ```json
 {
@@ -36,77 +28,37 @@ Or add to any MCP client config (Claude Desktop, Cursor, etc.):
         "git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp",
         "rustwright-mcp"
       ],
-      "env": { "RUSTWRIGHT_MCP_CHANNEL": "chrome" }
+      "env": {
+        "RUSTWRIGHT_MCP_CHANNEL": "chrome"
+      }
     }
   }
 }
 ```
 
-`RUSTWRIGHT_MCP_CHANNEL=chrome` uses your installed Google Chrome. Drop it
-to use rustwright's bundled Chromium instead (install once with
-`uvx --from 'git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp' python -m rustwright install chromium`).
+### Any MCP client
 
-Without uv, install into a plain venv from git:
-
-```bash
-python3 -m venv ~/.rustwright-mcp
-~/.rustwright-mcp/bin/pip install 'rustwright-mcp @ git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp'
+```json
+{
+  "mcpServers": {
+    "rustwright": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/Skyvern-AI/rustwright#subdirectory=mcp",
+        "rustwright-mcp"
+      ],
+      "env": {
+        "RUSTWRIGHT_MCP_CHANNEL": "chrome"
+      }
+    }
+  }
+}
 ```
 
-## Install from a source checkout
+## Verify it works
 
-```bash
-cd mcp
-python3 -m venv .venv && .venv/bin/pip install -e .
-```
-
-Then either install the bundled Chromium
-(`.venv/bin/python -m rustwright install chromium`) or use
-`RUSTWRIGHT_MCP_CHANNEL=chrome`.
-
-## Register with Claude Code (installed binary)
-
-Use the **absolute path** to the `rustwright-mcp` binary — the server is
-spawned from arbitrary working directories, so relative paths break:
-
-```bash
-claude mcp add rustwright \
-  --env RUSTWRIGHT_MCP_CHANNEL=chrome \
-  -- "$HOME/.rustwright-mcp/bin/rustwright-mcp"
-```
-
-Example with a source checkout at `~/code/rustwright`:
-
-```bash
-claude mcp add rustwright \
-  --env RUSTWRIGHT_MCP_CHANNEL=chrome \
-  -- "$HOME/code/rustwright/mcp/.venv/bin/rustwright-mcp"
-```
-
-Verify with `claude mcp list` — the entry should show `✔ Connected`.
-
-## Example session
-
-What an agent sees. `browser_navigate` returns a snapshot; interactive
-elements carry `[ref=eN]` handles that later calls act on:
-
-```
-> browser_navigate(url="https://example.com")
-Page: Example Domain
-URL: https://example.com/
-
-- heading "Example Domain" [level=1]
-- text: This domain is for use in documentation examples...
-- link "Learn more" [href=https://iana.org/domains/example] [ref=e1]
-
-> browser_click(target="e1")
-Page: Example Domains
-URL: https://www.iana.org/help/example-domains
-...
-
-> browser_get_text(selector="h1")
-Example Domains
-```
+Ask your agent to “take a browser snapshot of example.com”.
 
 ## Tools
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -127,7 +127,7 @@ Example Domains
 | `browser_wait_for(text?, timeout_ms?)` | Wait for text or load state |
 | `browser_get_text(selector?)` | Visible text of a selector |
 | `browser_evaluate(expression)` | Run JavaScript in the page (opt-in) |
-| `browser_take_screenshot(path?)` | Save a PNG, returns the path |
+| `browser_take_screenshot(path?)` | Save a confined PNG artifact, returns its output-root-relative path |
 | `browser_close()` | End the browser session |
 
 ## Configuration
@@ -141,6 +141,28 @@ Example Domains
 | `RUSTWRIGHT_MCP_CDP_HEADERS` | Optional JSON object of extra CDP connection headers |
 | `RUSTWRIGHT_MCP_CDP_TIMEOUT_MS` | Remote connection timeout in milliseconds (default `60000`) |
 | `RUSTWRIGHT_MCP_ALLOW_EVAL` | `1`, `true`, or `yes` exposes `browser_evaluate` (default off) |
+| `RUSTWRIGHT_MCP_OUTPUT_DIR` | Root for files written by tools |
+| `RUSTWRIGHT_MCP_OUTPUT_MAX_FILE_BYTES` | Per-file output cap (default `20971520`, or 20 MiB) |
+| `RUSTWRIGHT_MCP_OUTPUT_MAX_TOTAL_BYTES` | Total output cap (default `209715200`, or 200 MiB) |
+| `RUSTWRIGHT_MCP_WORKSPACE` | Allowed input root for future file-upload tools |
+
+### File outputs
+
+All tool-written files are confined to `RUSTWRIGHT_MCP_OUTPUT_DIR`. If that
+variable is unset, each server process creates a private session directory at
+`${XDG_CACHE_HOME:-~/.cache}/rustwright-mcp/output/<session-uuid>/`. Output
+directories use mode `0700`; files are created exclusively with mode `0600`.
+Artifact paths returned by tools are relative to the output root.
+
+Each output is limited to 20 MiB by default, and all retained outputs together
+are limited to 200 MiB. The byte-cap variables in the table above can override
+those values. When the total cap is crossed, the oldest files are evicted first.
+
+**Migration note:** screenshot `path` values are now interpreted inside the
+output root. An absolute path is accepted only when it is beneath that root.
+Paths outside it fail with `screenshot paths are confined to
+RUSTWRIGHT_MCP_OUTPUT_DIR (<root>); got <path>` instead of being written.
+Omitting `path` still creates a temporary PNG, now inside the output root.
 
 ### Remote browsers over CDP
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,12 +1,11 @@
 # Rustwright MCP server
 
 Exposes Rustwright browser automation as [Model Context Protocol](https://modelcontextprotocol.io)
-tools, so MCP-compatible agents (Claude Code, Claude Desktop, others) can browse
-with Rustwright instead of Playwright.
+tools, so MCP-compatible agents can browse through the Rustwright backend.
 
-Tool names mirror the Playwright MCP server (`browser_navigate`,
-`browser_snapshot`, `browser_click`, ...) so agents can switch without
-re-learning the surface. `browser_snapshot` returns an accessibility-style
+Tool names mirror the de-facto standard `browser_*` toolset
+(`browser_navigate`, `browser_snapshot`, `browser_click`, ...) so agents can
+switch without re-learning the surface. `browser_snapshot` returns an accessibility-style
 outline where interactive elements carry `[ref=eN]` handles; pass a ref (or a
 raw CSS selector) to the action tools.
 
@@ -114,20 +113,20 @@ Example Domains
 | Tool | Purpose |
 |---|---|
 | `browser_navigate(url)` | Open a URL, returns snapshot |
-| `browser_snapshot()` | Outline of the page with `[ref=eN]` handles |
-| `browser_click(target)` | Click a ref or CSS selector |
-| `browser_type(target, text, submit?)` | Fill or type into an input |
-| `browser_select_option(target, value)` | Select a dropdown option |
+| `browser_snapshot(target?, filename?, depth?, boxes?)` | Full or targeted outline with `[ref=eN]` handles |
+| `browser_click(target, element?, doubleClick?, button?, modifiers?)` | Click a ref or unique CSS selector |
+| `browser_type(target, text, element?, submit?, slowly?, clear?)` | Fill or character-type into an input; `clear` is an extension |
+| `browser_select_option(target, values, element?)` | Select one or more dropdown options; legacy `value` is accepted |
 | `browser_hover(target)` | Hover an element |
 | `browser_press_key(key)` | Press a keyboard key |
 | `browser_navigate_back()` | History back |
 | `browser_reload()` | Reload the active page, returns snapshot |
 | `browser_tabs(action, index?, url?)` | List, open, select, or close tabs |
-| `browser_handle_dialog(accept, prompt_text?)` | Set a one-shot policy for the next dialog |
-| `browser_wait_for(text?, timeout_ms?)` | Wait for text or load state |
+| `browser_handle_dialog(accept, promptText?)` | Set a one-shot policy for the next dialog |
+| `browser_wait_for(time?, text?, textGone?, timeout_ms?)` | Wait up to 30 seconds and/or for visible/hidden text |
 | `browser_get_text(selector?)` | Visible text of a selector |
-| `browser_evaluate(expression)` | Run JavaScript in the page (opt-in) |
-| `browser_take_screenshot(path?)` | Save a confined PNG artifact, returns its output-root-relative path |
+| `browser_evaluate(function, element?, target?, filename?)` | Run page-world JavaScript and return JSON plus a fresh snapshot |
+| `browser_take_screenshot(element?, target?, type?, filename?, fullPage?, scale?)` | Save a confined page or element image |
 | `browser_close()` | End the browser session |
 
 ## Configuration
@@ -140,7 +139,9 @@ Example Domains
 | `RUSTWRIGHT_MCP_CDP_ENDPOINT` | Remote browser CDP endpoint; enables remote mode when set |
 | `RUSTWRIGHT_MCP_CDP_HEADERS` | Optional JSON object of extra CDP connection headers |
 | `RUSTWRIGHT_MCP_CDP_TIMEOUT_MS` | Remote connection timeout in milliseconds (default `60000`) |
-| `RUSTWRIGHT_MCP_ALLOW_EVAL` | `1`, `true`, or `yes` exposes `browser_evaluate` (default off) |
+| `RUSTWRIGHT_MCP_ALLOW_EVAL` | Page-world evaluation is on by default; an explicit `0`, `false`, `no`, or `off` disables it |
+| `RUSTWRIGHT_MCP_CAPS` | Comma-separated capability groups; unavailable groups warn and are ignored |
+| `RUSTWRIGHT_MCP_TOOLSET` | `mirror` (all 16 tools, default) or `lean` (core interaction loop plus evaluate) |
 | `RUSTWRIGHT_MCP_OUTPUT_DIR` | Root for files written by tools |
 | `RUSTWRIGHT_MCP_OUTPUT_MAX_FILE_BYTES` | Per-file output cap (default `20971520`, or 20 MiB) |
 | `RUSTWRIGHT_MCP_OUTPUT_MAX_TOTAL_BYTES` | Total output cap (default `209715200`, or 200 MiB) |
@@ -158,11 +159,11 @@ Each output is limited to 20 MiB by default, and all retained outputs together
 are limited to 200 MiB. The byte-cap variables in the table above can override
 those values. When the total cap is crossed, the oldest files are evicted first.
 
-**Migration note:** screenshot `path` values are now interpreted inside the
+**Migration note:** screenshot `filename` values (and the legacy `path` alias) are interpreted inside the
 output root. An absolute path is accepted only when it is beneath that root.
 Paths outside it fail with `screenshot paths are confined to
 RUSTWRIGHT_MCP_OUTPUT_DIR (<root>); got <path>` instead of being written.
-Omitting `path` still creates a temporary PNG, now inside the output root.
+Omitting `filename` still creates an image inside the output root.
 
 ### Remote browsers over CDP
 
@@ -209,9 +210,9 @@ restart the session).
 
 ## Security & scope
 
-- `browser_evaluate` is off by default because it runs arbitrary JavaScript
-  in the page. Set `RUSTWRIGHT_MCP_ALLOW_EVAL=1` and restart the server to
-  expose it.
+- **SECURITY:** `browser_evaluate` performs page-world evaluation and is on by
+  default for compatibility. Set `RUSTWRIGHT_MCP_ALLOW_EVAL=0` and restart the
+  server to disable and remove the tool from `tools/list`.
 - Snapshots reflect page state, including field values. Password input values
   are masked in snapshot output; other field values are included as-is.
 - Snapshot refs are best-effort handles for cooperative pages, not a security

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
     "mcp>=1.2",
     "rustwright>=0.1.1",
+    "typing-extensions>=4.0",
 ]
 
 [project.optional-dependencies]

--- a/mcp/rustwright_mcp/filepolicy.py
+++ b/mcp/rustwright_mcp/filepolicy.py
@@ -87,9 +87,11 @@ class FilePolicy:
             root = Path(output_root).expanduser()
         if not root.is_absolute():
             root = Path.cwd() / root
+        root_existed = root.exists()
         root.mkdir(mode=0o700, parents=True, exist_ok=True)
         self.output_root = root.resolve(strict=True)
-        os.chmod(self.output_root, 0o700)
+        if not root_existed:
+            os.chmod(self.output_root, 0o700)
         self.roots_provider = roots_provider or EnvRootsProvider()
         self.max_file_bytes = (
             max_file_bytes
@@ -108,6 +110,7 @@ class FilePolicy:
         if self.max_file_bytes <= 0 or self.max_total_bytes <= 0:
             raise FilePolicyError("output byte caps must be positive")
         self._lock = threading.RLock()
+        self._created_outputs: set[Path] = set()
 
     def _confined_output_path(
         self,
@@ -165,6 +168,7 @@ class FilePolicy:
                 os.fchmod(descriptor, 0o600)
             finally:
                 os.close(descriptor)
+            self._created_outputs.add(path)
             return path
 
     def discard_output(self, path: Path) -> None:
@@ -173,6 +177,7 @@ class FilePolicy:
                 path.unlink()
             except FileNotFoundError:
                 pass
+            self._created_outputs.discard(path)
 
     @staticmethod
     def _remove_entry(path: Path) -> None:
@@ -195,13 +200,20 @@ class FilePolicy:
         resolved: Path | None,
         is_link: bool,
     ) -> None:
-        if (
-            is_link
-            and resolved is not None
-            and not _is_within(resolved, self.output_root)
-        ):
-            self._remove_entry(resolved)
-        self._remove_entry(path)
+        lexical_path = Path(os.path.abspath(path))
+        if not _is_within(lexical_path, self.output_root):
+            return
+        if is_link:
+            # Unlink the confined directory entry, never its resolved target.
+            try:
+                os.unlink(lexical_path)
+            except FileNotFoundError:
+                pass
+            self._created_outputs.discard(lexical_path)
+            return
+        if resolved is not None and _is_within(resolved, self.output_root):
+            self._remove_entry(lexical_path)
+            self._created_outputs.discard(lexical_path)
 
     def _artifact_link(self, path: Path) -> str:
         for root in self.roots_provider.roots():
@@ -237,6 +249,7 @@ class FilePolicy:
             os.chmod(resolved, 0o600)
             if info.st_size > self.max_file_bytes:
                 resolved.unlink()
+                self._created_outputs.discard(resolved)
                 raise FilePolicyError(
                     f"output file exceeds the {self.max_file_bytes}-byte per-file cap"
                 )
@@ -245,10 +258,11 @@ class FilePolicy:
 
     def _artifact_files(self) -> list[tuple[int, Path, int]]:
         artifacts: list[tuple[int, Path, int]] = []
-        for path in self.output_root.rglob("*"):
+        for path in tuple(self._created_outputs):
             try:
                 info = path.lstat()
             except FileNotFoundError:
+                self._created_outputs.discard(path)
                 continue
             if stat.S_ISREG(info.st_mode) and not stat.S_ISLNK(info.st_mode):
                 artifacts.append((info.st_mtime_ns, path, info.st_size))
@@ -267,6 +281,7 @@ class FilePolicy:
                 path.unlink()
             except FileNotFoundError:
                 continue
+            self._created_outputs.discard(path)
             total -= size
             if total <= self.max_total_bytes:
                 return
@@ -275,6 +290,7 @@ class FilePolicy:
                 protected.unlink()
             except FileNotFoundError:
                 pass
+            self._created_outputs.discard(protected)
             raise FilePolicyError(
                 f"output file cannot fit within the {self.max_total_bytes}-byte total cap"
             )

--- a/mcp/rustwright_mcp/filepolicy.py
+++ b/mcp/rustwright_mcp/filepolicy.py
@@ -1,0 +1,334 @@
+"""Filesystem policy for MCP-produced artifacts and future upload inputs."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import os
+from pathlib import Path
+import stat
+import threading
+from typing import BinaryIO, Iterator, Protocol, Sequence
+import uuid
+
+
+DEFAULT_MAX_FILE_BYTES = 20 * 1024 * 1024
+DEFAULT_MAX_TOTAL_BYTES = 200 * 1024 * 1024
+
+
+class FilePolicyError(ValueError):
+    """A file path or size violated the configured policy."""
+
+
+class RootsProvider(Protocol):
+    """Supplies roots from which input files may be read."""
+
+    def roots(self) -> Sequence[Path]:
+        ...
+
+
+class EnvRootsProvider:
+    """Read the current input root from ``RUSTWRIGHT_MCP_WORKSPACE``."""
+
+    def roots(self) -> Sequence[Path]:
+        raw_root = os.environ.get("RUSTWRIGHT_MCP_WORKSPACE")
+        if not raw_root:
+            return ()
+        root = Path(raw_root).expanduser()
+        if not root.is_absolute():
+            raise FilePolicyError("RUSTWRIGHT_MCP_WORKSPACE must be an absolute path")
+        return (root.resolve(strict=True),)
+
+
+def _configured_limit(name: str, default: int) -> int:
+    raw_value = os.environ.get(name)
+    if raw_value is None:
+        return default
+    try:
+        value = int(raw_value)
+    except ValueError:
+        raise FilePolicyError(f"{name} must be a positive integer") from None
+    if value <= 0:
+        raise FilePolicyError(f"{name} must be a positive integer")
+    return value
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+class FilePolicy:
+    """Confine outputs and validate input paths against explicit roots."""
+
+    def __init__(
+        self,
+        *,
+        output_root: Path | str | None = None,
+        roots_provider: RootsProvider | None = None,
+        max_file_bytes: int | None = None,
+        max_total_bytes: int | None = None,
+    ) -> None:
+        if output_root is None:
+            configured_root = os.environ.get("RUSTWRIGHT_MCP_OUTPUT_DIR")
+            if configured_root:
+                root = Path(configured_root).expanduser()
+            else:
+                configured_cache = os.environ.get("XDG_CACHE_HOME")
+                cache_home = (
+                    Path(configured_cache).expanduser()
+                    if configured_cache
+                    else Path.home() / ".cache"
+                )
+                root = cache_home / "rustwright-mcp" / "output" / str(uuid.uuid4())
+        else:
+            root = Path(output_root).expanduser()
+        if not root.is_absolute():
+            root = Path.cwd() / root
+        root.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self.output_root = root.resolve(strict=True)
+        os.chmod(self.output_root, 0o700)
+        self.roots_provider = roots_provider or EnvRootsProvider()
+        self.max_file_bytes = (
+            max_file_bytes
+            if max_file_bytes is not None
+            else _configured_limit(
+                "RUSTWRIGHT_MCP_OUTPUT_MAX_FILE_BYTES", DEFAULT_MAX_FILE_BYTES
+            )
+        )
+        self.max_total_bytes = (
+            max_total_bytes
+            if max_total_bytes is not None
+            else _configured_limit(
+                "RUSTWRIGHT_MCP_OUTPUT_MAX_TOTAL_BYTES", DEFAULT_MAX_TOTAL_BYTES
+            )
+        )
+        if self.max_file_bytes <= 0 or self.max_total_bytes <= 0:
+            raise FilePolicyError("output byte caps must be positive")
+        self._lock = threading.RLock()
+
+    def _confined_output_path(self, requested: str | None, purpose: str) -> Path:
+        if requested is None:
+            candidate = self.output_root / f"{purpose}-{uuid.uuid4().hex}.png"
+        else:
+            raw_path = Path(requested).expanduser()
+            candidate = raw_path if raw_path.is_absolute() else self.output_root / raw_path
+        resolved = candidate.resolve(strict=False)
+        if not _is_within(resolved, self.output_root):
+            shown = requested if requested is not None else str(candidate)
+            raise FilePolicyError(
+                f"{purpose} paths are confined to RUSTWRIGHT_MCP_OUTPUT_DIR "
+                f"({self.output_root}); got {shown}"
+            )
+        return resolved
+
+    def _ensure_secure_parent(self, path: Path) -> None:
+        relative_parent = path.parent.relative_to(self.output_root)
+        current = self.output_root
+        for component in relative_parent.parts:
+            current = current / component
+            try:
+                info = current.lstat()
+            except FileNotFoundError:
+                current.mkdir(mode=0o700)
+                continue
+            if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+                raise FilePolicyError(f"output path has an unsafe parent: {path}")
+
+    def reserve_output(
+        self,
+        requested: str | None = None,
+        *,
+        purpose: str = "output",
+    ) -> Path:
+        """Exclusively create a mode-0600 file beneath the output root."""
+        with self._lock:
+            path = self._confined_output_path(requested, purpose)
+            self._ensure_secure_parent(path)
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            flags |= getattr(os, "O_NOFOLLOW", 0)
+            try:
+                descriptor = os.open(path, flags, 0o600)
+            except FileExistsError:
+                raise FilePolicyError(f"output file already exists: {path}") from None
+            try:
+                os.fchmod(descriptor, 0o600)
+            finally:
+                os.close(descriptor)
+            return path
+
+    def discard_output(self, path: Path) -> None:
+        with self._lock:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+
+    @staticmethod
+    def _remove_entry(path: Path) -> None:
+        try:
+            info = path.lstat()
+        except FileNotFoundError:
+            return
+        try:
+            if stat.S_ISDIR(info.st_mode) and not stat.S_ISLNK(info.st_mode):
+                path.rmdir()
+            else:
+                path.unlink()
+        except FileNotFoundError:
+            pass
+
+    def _discard_invalid_output(
+        self,
+        path: Path,
+        *,
+        resolved: Path | None,
+        is_link: bool,
+    ) -> None:
+        if (
+            is_link
+            and resolved is not None
+            and not _is_within(resolved, self.output_root)
+        ):
+            self._remove_entry(resolved)
+        self._remove_entry(path)
+
+    def _artifact_link(self, path: Path) -> str:
+        for root in self.roots_provider.roots():
+            try:
+                workspace_root = Path(root).expanduser().resolve(strict=True)
+            except OSError:
+                continue
+            if _is_within(self.output_root, workspace_root):
+                return path.relative_to(workspace_root).as_posix()
+        return path.relative_to(self.output_root).as_posix()
+
+    def finalize_output(self, path: Path) -> str:
+        """Enforce caps, evict old artifacts, and return a relative link."""
+        with self._lock:
+            try:
+                info = os.lstat(path)
+            except OSError:
+                self._discard_invalid_output(path, resolved=None, is_link=False)
+                raise FilePolicyError(f"output file escaped the configured root: {path}")
+            is_link = os.path.islink(path)
+            resolved = Path(os.path.realpath(path))
+            if (
+                is_link
+                or not stat.S_ISREG(info.st_mode)
+                or not _is_within(resolved, self.output_root)
+            ):
+                self._discard_invalid_output(
+                    path,
+                    resolved=resolved,
+                    is_link=is_link,
+                )
+                raise FilePolicyError(f"output file escaped the configured root: {path}")
+            os.chmod(resolved, 0o600)
+            if info.st_size > self.max_file_bytes:
+                resolved.unlink()
+                raise FilePolicyError(
+                    f"output file exceeds the {self.max_file_bytes}-byte per-file cap"
+                )
+            self._evict_to_total_cap(protected=resolved)
+            return self._artifact_link(resolved)
+
+    def _artifact_files(self) -> list[tuple[int, Path, int]]:
+        artifacts: list[tuple[int, Path, int]] = []
+        for path in self.output_root.rglob("*"):
+            try:
+                info = path.lstat()
+            except FileNotFoundError:
+                continue
+            if stat.S_ISREG(info.st_mode) and not stat.S_ISLNK(info.st_mode):
+                artifacts.append((info.st_mtime_ns, path, info.st_size))
+        return artifacts
+
+    def _evict_to_total_cap(self, *, protected: Path) -> None:
+        artifacts = self._artifact_files()
+        total = sum(size for _, _, size in artifacts)
+        if total <= self.max_total_bytes:
+            return
+        candidates = sorted(
+            (item for item in artifacts if item[1] != protected), key=lambda item: item[0]
+        )
+        for _, path, size in candidates:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                continue
+            total -= size
+            if total <= self.max_total_bytes:
+                return
+        if total > self.max_total_bytes:
+            try:
+                protected.unlink()
+            except FileNotFoundError:
+                pass
+            raise FilePolicyError(
+                f"output file cannot fit within the {self.max_total_bytes}-byte total cap"
+            )
+
+    def artifact_link(self, path: Path) -> str:
+        resolved = path.resolve(strict=True)
+        if not _is_within(resolved, self.output_root):
+            raise FilePolicyError(f"artifact is outside the configured output root: {path}")
+        return self._artifact_link(resolved)
+
+    def validate_input(self, requested: str | Path) -> Path:
+        """Validate an absolute, regular, non-symlink input under an allowed root."""
+        raw_path = Path(requested).expanduser()
+        if not raw_path.is_absolute():
+            raise FilePolicyError("input files must use absolute paths")
+        try:
+            original_info = raw_path.lstat()
+        except FileNotFoundError:
+            raise FilePolicyError(f"input file does not exist: {raw_path}") from None
+        if stat.S_ISLNK(original_info.st_mode):
+            raise FilePolicyError(f"input file must not be a symlink: {raw_path}")
+        resolved = raw_path.resolve(strict=True)
+        roots = tuple(self.roots_provider.roots())
+        if not roots:
+            raise FilePolicyError("no input workspace root is configured")
+        if not any(_is_within(resolved, root.resolve(strict=True)) for root in roots):
+            raise FilePolicyError(f"input file is outside the allowed workspace: {raw_path}")
+        info = resolved.stat()
+        if not stat.S_ISREG(info.st_mode):
+            raise FilePolicyError(f"input path is not a regular file: {raw_path}")
+        return resolved
+
+    @contextmanager
+    def open_input(self, requested: str | Path) -> Iterator[BinaryIO]:
+        """Open a validated input without following a final-component symlink."""
+        path = self.validate_input(requested)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(path, flags)
+        try:
+            info = os.fstat(descriptor)
+            if not stat.S_ISREG(info.st_mode):
+                raise FilePolicyError(f"input path is not a regular file: {path}")
+            with os.fdopen(descriptor, "rb", closefd=False) as handle:
+                yield handle
+        finally:
+            os.close(descriptor)
+
+
+_policy: FilePolicy | None = None
+_policy_lock = threading.Lock()
+
+
+def get_file_policy() -> FilePolicy:
+    global _policy
+    with _policy_lock:
+        if _policy is None:
+            _policy = FilePolicy()
+        return _policy
+
+
+def _reset_file_policy() -> None:
+    """Reset the process singleton for isolated tests."""
+    global _policy
+    with _policy_lock:
+        _policy = None

--- a/mcp/rustwright_mcp/filepolicy.py
+++ b/mcp/rustwright_mcp/filepolicy.py
@@ -307,6 +307,48 @@ class FilePolicy:
             raise FilePolicyError(f"input path is not a regular file: {raw_path}")
         return resolved
 
+    def read_inputs(
+        self, requested: Sequence[str | Path]
+    ) -> list[tuple[Path, bytes]]:
+        """Validate and read inputs while enforcing the shared byte caps.
+
+        The descriptor-backed reads repeat the regular-file check performed by
+        :meth:`validate_input` and never follow a final-component symlink.  The
+        limits are shared with outputs so one policy configuration bounds every
+        file payload crossing the MCP boundary.
+        """
+        loaded: list[tuple[Path, bytes]] = []
+        total = 0
+        for entry in requested:
+            path = self.validate_input(entry)
+            with self.open_input(path) as handle:
+                initial_size = os.fstat(handle.fileno()).st_size
+                if initial_size > self.max_file_bytes:
+                    raise FilePolicyError(
+                        f"input file exceeds the {self.max_file_bytes}-byte "
+                        f"per-file cap: {path}"
+                    )
+                if total + initial_size > self.max_total_bytes:
+                    raise FilePolicyError(
+                        f"input files exceed the {self.max_total_bytes}-byte total cap"
+                    )
+
+                content = bytearray()
+                while chunk := handle.read(1024 * 1024):
+                    content.extend(chunk)
+                    if len(content) > self.max_file_bytes:
+                        raise FilePolicyError(
+                            f"input file exceeds the {self.max_file_bytes}-byte "
+                            f"per-file cap: {path}"
+                        )
+                    if total + len(content) > self.max_total_bytes:
+                        raise FilePolicyError(
+                            f"input files exceed the {self.max_total_bytes}-byte total cap"
+                        )
+                loaded.append((path, bytes(content)))
+                total += len(content)
+        return loaded
+
     @contextmanager
     def open_input(self, requested: str | Path) -> Iterator[BinaryIO]:
         """Open a validated input without following a final-component symlink."""

--- a/mcp/rustwright_mcp/filepolicy.py
+++ b/mcp/rustwright_mcp/filepolicy.py
@@ -109,9 +109,14 @@ class FilePolicy:
             raise FilePolicyError("output byte caps must be positive")
         self._lock = threading.RLock()
 
-    def _confined_output_path(self, requested: str | None, purpose: str) -> Path:
+    def _confined_output_path(
+        self,
+        requested: str | None,
+        purpose: str,
+        suffix: str,
+    ) -> Path:
         if requested is None:
-            candidate = self.output_root / f"{purpose}-{uuid.uuid4().hex}.png"
+            candidate = self.output_root / f"{purpose}-{uuid.uuid4().hex}{suffix}"
         else:
             raw_path = Path(requested).expanduser()
             candidate = raw_path if raw_path.is_absolute() else self.output_root / raw_path
@@ -142,10 +147,13 @@ class FilePolicy:
         requested: str | None = None,
         *,
         purpose: str = "output",
+        suffix: str = ".png",
     ) -> Path:
         """Exclusively create a mode-0600 file beneath the output root."""
+        if not suffix.startswith(".") or "/" in suffix or "\\" in suffix:
+            raise FilePolicyError("output suffix must be a simple file extension")
         with self._lock:
-            path = self._confined_output_path(requested, purpose)
+            path = self._confined_output_path(requested, purpose, suffix)
             self._ensure_secure_parent(path)
             flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
             flags |= getattr(os, "O_NOFOLLOW", 0)

--- a/mcp/rustwright_mcp/filepolicy.py
+++ b/mcp/rustwright_mcp/filepolicy.py
@@ -1,4 +1,4 @@
-"""Filesystem policy for MCP-produced artifacts and future upload inputs."""
+"""Filesystem policy for MCP-produced artifacts and upload inputs."""
 
 from __future__ import annotations
 

--- a/mcp/rustwright_mcp/server.py
+++ b/mcp/rustwright_mcp/server.py
@@ -12,6 +12,8 @@ Environment variables:
     RUSTWRIGHT_MCP_CDP_HEADERS optional JSON object of CDP connection headers
     RUSTWRIGHT_MCP_CDP_TIMEOUT_MS remote connection timeout in milliseconds (default: 60000)
     RUSTWRIGHT_MCP_ALLOW_EVAL  "1", "true", or "yes" to expose browser_evaluate
+    RUSTWRIGHT_MCP_OUTPUT_DIR   root for files written by tools
+    RUSTWRIGHT_MCP_WORKSPACE    allowed input root for future upload tools
 
 When RUSTWRIGHT_MCP_CDP_ENDPOINT is set, the local headless, channel, and
 executable options are ignored.
@@ -20,19 +22,27 @@ executable options are ignored.
 from __future__ import annotations
 
 import functools
+from dataclasses import dataclass
+from importlib import metadata
 import json
 import os
-import tempfile
+import re
 import threading
-from typing import Optional
+from typing import Any, Literal, Optional
 
 from mcp.server.fastmcp import FastMCP
 
+from rustwright_mcp.filepolicy import get_file_policy
+from rustwright_mcp.session import SessionState
 from rustwright_mcp.snapshot import SNAPSHOT_JS
 
-mcp = FastMCP("rustwright")
+PACKAGE_VERSION = metadata.version("rustwright-mcp")
+mcp = FastMCP("rustwright-mcp")
+# FastMCP 1.x does not expose its low-level Server's version constructor
+# argument, so set the same field that initialize reads.
+mcp._mcp_server.version = PACKAGE_VERSION
 
-_session: dict = {}
+_state = SessionState()
 # FastMCP executes sync tools on a thread pool; the browser session is
 # shared state, so tool bodies are serialized.
 _lock = threading.Lock()
@@ -47,30 +57,11 @@ def _serialized(fn):
     return wrapper
 
 SNAPSHOT_CHAR_LIMIT = 30_000
+_OUTLINE_REF_PATTERN = re.compile(r"\[ref=(e[1-9][0-9]*)\]")
 
 
-def _handle_dialog(page, dialog) -> None:
-    policy = _session.get("dialog_policy")
-    if policy is None or policy["page"] is not page:
-        dialog.dismiss()
-        return
-
-    _session.pop("dialog_policy")
-    if policy["accept"]:
-        if policy["prompt_text"] is None:
-            dialog.accept()
-        else:
-            dialog.accept(policy["prompt_text"])
-    else:
-        dialog.dismiss()
-
-
-def _register_dialog_handler(page) -> None:
-    pages = _session.setdefault("dialog_pages", [])
-    if any(existing is page for existing in pages):
-        return
-    page.on("dialog", functools.partial(_handle_dialog, page))
-    pages.append(page)
+def _register_page_handlers(page: Any) -> None:
+    _state.register_page_handlers(page)
 
 
 def _page():
@@ -79,20 +70,27 @@ def _page():
     In remote CDP mode, local launch options (headless, channel, and executable)
     are ignored.
     """
-    if "page" in _session:
+    if _state.page is not None:
         try:
             # The user may have closed a headed window; detect a dead
             # session and relaunch instead of failing every call.
-            _session["page"].evaluate("() => 1")
+            _state.page.evaluate("() => 1")
+            _register_page_handlers(_state.page)
         except Exception:
-            if _session.get("remote"):
+            if _state.remote:
                 _teardown()
                 raise RuntimeError(
                     "Remote CDP session is no longer reachable — "
                     "reconnect/restart the MCP server."
                 ) from None
             _teardown()
-    if "page" not in _session:
+    if _state.page is None and _state.browser is not None and _state.context is not None:
+        pages = list(_state.context.pages)
+        page = pages[0] if pages else _state.context.new_page()
+        _register_page_handlers(page)
+        _state.page = page
+        return page
+    if _state.page is None:
         from rustwright.sync_api import sync_playwright
 
         endpoint = os.environ.get("RUSTWRIGHT_MCP_CDP_ENDPOINT")
@@ -141,16 +139,14 @@ def _page():
                 context = browser.contexts[0]
                 pages = context.pages
                 page = pages[0] if pages else context.new_page()
-                _session.update(
+                _state.attach(
                     pw=pw,
                     browser=browser,
+                    context=context,
                     page=page,
                     remote=True,
-                    snapshot_taken=False,
-                    next_ref=1,
-                    dialog_pages=[],
                 )
-                _register_dialog_handler(page)
+                _register_page_handlers(page)
             except Exception:
                 for close in (
                     lambda: browser.close() if browser is not None else None,
@@ -160,12 +156,12 @@ def _page():
                         close()
                     except Exception:
                         pass
-                _session.clear()
+                _state.clear()
                 raise RuntimeError(
                     "Remote CDP browser is unreachable; check the connection "
                     "settings and try again."
                 ) from None
-            return _session["page"]
+            return _state.page
 
         headless = os.environ.get("RUSTWRIGHT_MCP_HEADLESS", "1") != "0"
         launch_kwargs: dict = {"headless": headless}
@@ -178,17 +174,15 @@ def _page():
         pw = sync_playwright().start()
         browser = pw.chromium.launch(**launch_kwargs)
         page = browser.new_page()
-        _session.update(
+        _state.attach(
             pw=pw,
             browser=browser,
+            context=page.context,
             page=page,
             remote=False,
-            snapshot_taken=False,
-            next_ref=1,
-            dialog_pages=[],
         )
-        _register_dialog_handler(page)
-    return _session["page"]
+        _register_page_handlers(page)
+    return _state.page
 
 
 def _snapshot(page) -> str:
@@ -197,14 +191,18 @@ def _snapshot(page) -> str:
         page.wait_for_load_state(timeout=10_000)
     except Exception:
         pass
-    result = page.evaluate(SNAPSHOT_JS, _session["next_ref"])
+    result = page.evaluate(SNAPSHOT_JS, _state.snapshot_start_ref())
     outline = result["outline"]
-    _session["next_ref"] = result["nextRef"]
-    _session["snapshot_taken"] = True
     header = f"Page: {page.title()}\nURL: {page.url}\n\n"
     body = outline[:SNAPSHOT_CHAR_LIMIT]
     if len(outline) > SNAPSHOT_CHAR_LIMIT:
         body += "\n- … (snapshot truncated, use browser_get_text for full content)"
+    delivered_refs = set(_OUTLINE_REF_PATTERN.findall(body))
+    _state.record_snapshot(
+        page,
+        [ref for ref in result["refs"] if ref in delivered_refs],
+        result["nextRef"],
+    )
     return header + body
 
 
@@ -212,35 +210,53 @@ def _teardown() -> None:
     # For remote sessions, closing the connected Browser detaches this client;
     # Rustwright leaves the remotely owned browser running.
     for close in (
-        lambda: _session["browser"].close(),
-        lambda: _session["pw"].stop(),
+        lambda: _state.browser.close(),
+        lambda: _state.pw.stop(),
     ):
         try:
             close()
         except Exception:
             pass
-    _session.clear()
+    _state.clear()
 
 
-def _resolve(target: str) -> str:
-    """Map a snapshot ref like ``e12`` to its attribute selector; pass CSS through.
+@dataclass(frozen=True)
+class ResolvedTarget:
+    locator: Any
+    display_name: str
+    source: Literal["ref", "selector"]
 
-    Refs fail fast when absent from the live DOM (stale snapshot) instead of
-    hitting the full action timeout.
-    """
-    if target and target[0] == "e" and target[1:].isdigit():
-        if not _session.get("snapshot_taken"):
+
+_REF_PATTERN = re.compile(r"^e[1-9][0-9]*$")
+
+
+def _resolve(
+    page: Any,
+    target: str,
+    element_description: str | None = None,
+) -> ResolvedTarget:
+    """Resolve a current stamped ref or exactly one selector match."""
+    display_name = target if element_description is None else element_description
+    if _REF_PATTERN.fullmatch(target):
+        snapshot_taken, snapshot_refs = _state.snapshot_status(page)
+        if not snapshot_taken:
+            raise ValueError("No current snapshot; call browser_snapshot first.")
+        if target not in snapshot_refs:
             raise ValueError(
-                "No snapshot taken on this page yet; call browser_snapshot first"
+                f"Ref {target} is not in the current page snapshot; take a fresh snapshot."
             )
-        selector = f'[data-mcp-ref="{target}"]'
-        if _session["page"].query_selector(selector) is None:
-            raise ValueError(
-                f"Ref {target} is not on the current page (stale snapshot); "
-                "call browser_snapshot and use a fresh ref"
-            )
-        return selector
-    return target
+        locator = page.locator(f'[data-mcp-ref="{target}"]')
+        return ResolvedTarget(locator, display_name, "ref")
+
+    locator = page.locator(target)
+    count = locator.count()
+    if count == 0:
+        raise ValueError(f"Target selector matched no elements: {target}")
+    if count > 1:
+        raise ValueError(
+            f"Target selector matched {count} elements; provide a unique selector: {target}"
+        )
+    return ResolvedTarget(locator, display_name, "selector")
 
 
 @mcp.tool()
@@ -266,11 +282,11 @@ def browser_click(target: str, double_click: bool = False) -> str:
     """Click an element. `target` is a ref from the snapshot (e.g. "e12") or a
     CSS selector. Returns a fresh snapshot."""
     page = _page()
-    selector = _resolve(target)
+    resolved = _resolve(page, target)
     if double_click:
-        page.dblclick(selector)
+        resolved.locator.dblclick()
     else:
-        page.click(selector)
+        resolved.locator.click()
     return _snapshot(page)
 
 
@@ -280,13 +296,13 @@ def browser_type(target: str, text: str, submit: bool = False, clear: bool = Tru
     """Type into an input. `target` is a snapshot ref or CSS selector. Set
     submit=True to press Enter afterwards. Returns a fresh snapshot."""
     page = _page()
-    selector = _resolve(target)
+    resolved = _resolve(page, target)
     if clear:
-        page.fill(selector, text)
+        resolved.locator.fill(text)
     else:
-        page.type(selector, text)
+        resolved.locator.type(text)
     if submit:
-        page.press(selector, "Enter")
+        resolved.locator.press("Enter")
     return _snapshot(page)
 
 
@@ -295,11 +311,11 @@ def browser_type(target: str, text: str, submit: bool = False, clear: bool = Tru
 def browser_select_option(target: str, value: str) -> str:
     """Select an option in a <select> element by value or visible label."""
     page = _page()
-    selector = _resolve(target)
+    resolved = _resolve(page, target)
     try:
-        page.select_option(selector, value=value)
+        resolved.locator.select_option(value=value)
     except Exception:
-        page.select_option(selector, label=value)
+        resolved.locator.select_option(label=value)
     return _snapshot(page)
 
 
@@ -308,7 +324,7 @@ def browser_select_option(target: str, value: str) -> str:
 def browser_hover(target: str) -> str:
     """Hover over an element identified by snapshot ref or CSS selector."""
     page = _page()
-    page.hover(_resolve(target))
+    _resolve(page, target).locator.hover()
     return _snapshot(page)
 
 
@@ -360,8 +376,8 @@ def browser_tabs(
         )
     if action == "new":
         page = context.new_page()
-        _register_dialog_handler(page)
-        _session["page"] = page
+        _register_page_handlers(page)
+        _state.page = page
         if url:
             page.goto(url)
         return _snapshot(page)
@@ -372,8 +388,8 @@ def browser_tabs(
 
     if action == "select":
         page = pages[index]
-        _register_dialog_handler(page)
-        _session["page"] = page
+        _register_page_handlers(page)
+        _state.page = page
         page.bring_to_front()
         return _snapshot(page)
 
@@ -385,8 +401,8 @@ def browser_tabs(
         page = context.new_page()
     elif was_active:
         page = remaining[min(index, len(remaining) - 1)]
-    _register_dialog_handler(page)
-    _session["page"] = page
+    _register_page_handlers(page)
+    _state.page = page
     return _snapshot(page)
 
 
@@ -395,15 +411,11 @@ def browser_tabs(
 def browser_handle_dialog(accept: bool, prompt_text: str | None = None) -> str:
     """Accept or dismiss the next JavaScript dialog on the active page.
 
-    A dialog opened by a brand-new popup may be auto-dismissed before its page
-    can be registered. The policy is consumed once; other dialogs auto-dismiss.
+    A dialog opened by a brand-new popup may appear before its page can be
+    registered. The policy is consumed once; unarmed dialogs remain pending.
     """
     page = _page()
-    _session["dialog_policy"] = {
-        "page": page,
-        "accept": accept,
-        "prompt_text": prompt_text,
-    }
+    _state.arm_dialog(page, accept, prompt_text)
     action = "accepted" if accept else "dismissed"
     return f"The next dialog on the active page will be {action}."
 
@@ -425,7 +437,9 @@ def browser_wait_for(text: Optional[str] = None, timeout_ms: float = 10_000) -> 
 @_serialized
 def browser_get_text(selector: str = "body", max_chars: int = 20_000) -> str:
     """Visible text content of a CSS selector (defaults to the whole page)."""
-    return _page().inner_text(selector)[:max_chars]
+    page = _page()
+    text = _resolve(page, selector).locator.inner_text() or ""
+    return text[:max_chars]
 
 
 def browser_evaluate(expression: str) -> str:
@@ -449,20 +463,22 @@ if _allow_eval():
 @mcp.tool()
 @_serialized
 def browser_take_screenshot(path: Optional[str] = None, full_page: bool = False) -> str:
-    """Save a PNG screenshot and return its file path. Writes to a temporary
-    file when no path is given."""
-    if path is None:
-        fd, path = tempfile.mkstemp(prefix="rustwright-mcp-", suffix=".png")
-        os.close(fd)
-    _page().screenshot(path=path, full_page=full_page)
-    return path
+    """Save a PNG under the configured output root and return its artifact path."""
+    policy = get_file_policy()
+    output_path = policy.reserve_output(path, purpose="screenshot")
+    try:
+        _page().screenshot(path=str(output_path), full_page=full_page)
+        return policy.finalize_output(output_path)
+    except Exception:
+        policy.discard_output(output_path)
+        raise
 
 
 @mcp.tool()
 @_serialized
 def browser_close() -> str:
     """Close the browser. The next tool call starts a fresh session."""
-    if "browser" in _session:
+    if _state.browser is not None:
         _teardown()
         return "Browser closed."
     return "No browser session was open."

--- a/mcp/rustwright_mcp/server.py
+++ b/mcp/rustwright_mcp/server.py
@@ -15,7 +15,7 @@ Environment variables:
     RUSTWRIGHT_MCP_CAPS        accepted comma-separated capability groups
     RUSTWRIGHT_MCP_TOOLSET     "mirror" (default) or the smaller "lean" profile
     RUSTWRIGHT_MCP_OUTPUT_DIR   root for files written by tools
-    RUSTWRIGHT_MCP_WORKSPACE    allowed input root for future upload tools
+    RUSTWRIGHT_MCP_WORKSPACE    allowed absolute input root for upload tools
 
 When RUSTWRIGHT_MCP_CDP_ENDPOINT is set, the local headless, channel, and
 executable options are ignored.
@@ -23,15 +23,20 @@ executable options are ignored.
 
 from __future__ import annotations
 
+import base64
 import functools
 from dataclasses import dataclass
 from importlib import metadata
 import json
+import math
 import os
 import re
 import sys
 import threading
 from typing import Annotated, Any, Literal
+import uuid
+
+from typing_extensions import NotRequired, TypedDict
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import (
@@ -62,12 +67,30 @@ def _serialized(fn):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         with _lock:
+            if (
+                fn.__name__ not in _MODAL_SAFE_TOOLS
+                and _state.page is not None
+                and _has_pending_modal()
+            ):
+                return _render_response(
+                    f"{fn.__name__} deferred until the pending modal is handled.",
+                    page=_state.page,
+                )
             return fn(*args, **kwargs)
 
     return wrapper
 
 
 _FALSE_VALUES = {"0", "false", "no", "off"}
+_MODAL_SAFE_TOOLS = {
+    "browser_handle_dialog",
+    "browser_file_upload",
+    "browser_console_messages",
+    "browser_network_requests",
+    "browser_network_request",
+    "browser_tabs",
+    "browser_close",
+}
 _LEAN_TOOLS = {
     "browser_navigate",
     "browser_navigate_back",
@@ -82,6 +105,8 @@ _LEAN_TOOLS = {
     "browser_tabs",
     "browser_take_screenshot",
     "browser_close",
+    # PR-3 intentionally adds only viewport resize to the lean profile.
+    "browser_resize",
     # Evaluation is controlled only by RUSTWRIGHT_MCP_ALLOW_EVAL. Profiles
     # must not quietly change that security setting.
     "browser_evaluate",
@@ -169,11 +194,103 @@ def _tool():
 
 
 SNAPSHOT_CHAR_LIMIT = 30_000
+NETWORK_BODY_INLINE_BYTES = 64 * 1024
+FIND_MATCH_LIMIT = 20
 _OUTLINE_REF_PATTERN = re.compile(r"\[ref=(e[1-9][0-9]*)\]")
+_CONSOLE_LEVEL_RANK = {
+    "error": 0,
+    "warning": 1,
+    "warn": 1,
+    "info": 2,
+    "log": 2,
+    "debug": 3,
+}
 
 
 def _register_page_handlers(page: Any) -> None:
+    _state.download_saver = _save_download
     _state.register_page_handlers(page)
+    _capture_page_title(page)
+
+
+def _pending_modals(page: Any) -> tuple[Any | None, Any | None]:
+    return _state.pending_modals(page)
+
+
+def _context_pages(reference_page: Any | None = None) -> list[Any]:
+    page = reference_page if reference_page is not None else _state.page
+    try:
+        pages = list(page.context.pages) if page is not None else []
+    except Exception:
+        pages = []
+    for registered_page, _, _ in _state.pending_modal_pages():
+        if not any(candidate is registered_page for candidate in pages):
+            pages.append(registered_page)
+    return pages
+
+
+def _pending_modal_entries(
+    reference_page: Any | None = None,
+) -> list[tuple[int, Any, Any | None, Any | None]]:
+    """Return every pending modal ordered by its owning tab index."""
+    pages = _context_pages(reference_page)
+    entries: list[tuple[int, Any, Any | None, Any | None]] = []
+    for owner, dialog, chooser in _state.pending_modal_pages():
+        index = next(
+            (position for position, tab in enumerate(pages) if tab is owner), -1
+        )
+        entries.append((index, owner, dialog, chooser))
+    entries.sort(key=lambda entry: (entry[0] < 0, entry[0]))
+    return entries
+
+
+def _has_pending_modal(page: Any | None = None) -> bool:
+    del page
+    return bool(_state.pending_modal_pages())
+
+
+def _capture_page_title(page: Any) -> str | None:
+    """Cache a safe title without querying a page blocked by a dialog."""
+    dialog, _ = _pending_modals(page)
+    if dialog is not None:
+        return _state.known_page_title(page)
+    try:
+        title = str(page.title())
+    except Exception:
+        return _state.known_page_title(page)
+    _state.remember_page_title(page, title)
+    return title
+
+
+def _save_download(download: Any, suggested_filename: str) -> str:
+    """Save an untrusted download name into the confined artifact root."""
+    policy = get_file_policy()
+    leaf = suggested_filename.replace("\\", "/").rsplit("/", 1)[-1]
+    leaf = re.sub(r"[^A-Za-z0-9._-]+", "_", leaf).lstrip(".")
+    if not leaf:
+        leaf = "download"
+    if len(leaf) > 180:
+        stem, suffix = os.path.splitext(leaf)
+        leaf = stem[: max(1, 180 - len(suffix))] + suffix[:20]
+
+    candidate = leaf
+    while True:
+        try:
+            output_path = policy.reserve_output(
+                candidate, purpose="download", suffix=".bin"
+            )
+            break
+        except ValueError as exc:
+            if "already exists" not in str(exc):
+                raise
+            stem, suffix = os.path.splitext(leaf)
+            candidate = f"{stem}-{uuid.uuid4().hex[:8]}{suffix}"
+    try:
+        download.save_as(str(output_path))
+        return policy.finalize_output(output_path)
+    except Exception:
+        policy.discard_output(output_path)
+        raise
 
 
 def _page():
@@ -183,6 +300,11 @@ def _page():
     are ignored.
     """
     if _state.page is not None:
+        if _has_pending_modal(_state.page):
+            # Chromium blocks evaluation while a JavaScript dialog is live.
+            # Event state is enough to service the modal tools, so never run
+            # the health-check evaluation in this state.
+            return _state.page
         try:
             # The user may have closed a headed window; detect a dead
             # session and relaunch instead of failing every call.
@@ -303,14 +425,20 @@ def _snapshot(
     target: Any | None = None,
     depth: float | None = None,
     boxes: bool = False,
-) -> str:
+) -> str | None:
     if depth is not None and depth < 0:
         raise ValueError("depth must be non-negative")
+    if _has_pending_modal():
+        # This check is deliberately before wait_for_load_state/evaluate: a live
+        # dialog blocks both in Chromium. The triggering action can therefore
+        # return its Modal section promptly without attempting a fresh snapshot.
+        return None
     try:
         # An action may have triggered a navigation; settle before reading the DOM.
         page.wait_for_load_state(timeout=10_000)
     except Exception:
         pass
+    _capture_page_title(page)
     options = {
         "startRef": _state.snapshot_start_ref(),
         "maxDepth": depth,
@@ -335,10 +463,11 @@ def _snapshot(
 
 
 def _page_details(page: Any) -> tuple[str, str, int, list[Any]]:
-    try:
-        title = str(page.title())
-    except Exception:
-        title = "(unavailable)"
+    pending_dialog, _ = _pending_modals(page)
+    if pending_dialog is not None:
+        title = _state.known_page_title(page) or "(dialog pending)"
+    else:
+        title = _capture_page_title(page) or "(unavailable)"
     try:
         url = str(page.url)
     except Exception:
@@ -354,6 +483,62 @@ def _page_details(page: Any) -> tuple[str, str, int, list[Any]]:
     return title, url, active_index, pages
 
 
+def _metadata_value(items: tuple[tuple[str, Any], ...], *names: str) -> Any:
+    values = dict(items)
+    for name in names:
+        if name in values:
+            return values[name]
+    return None
+
+
+def _console_level(message_type: str) -> str:
+    normalized = message_type.lower()
+    if normalized in {"warning", "warn"}:
+        return "warning"
+    if normalized in {"error", "debug"}:
+        return normalized
+    return "info"
+
+
+def _format_console_record(record: Any) -> str:
+    level = _console_level(record.message_type).upper()
+    url = _metadata_value(record.location, "url") or "(unknown)"
+    line = _metadata_value(record.location, "lineNumber", "line")
+    location = str(url) if line is None else f"{url}:{line}"
+    text = str(record.text).replace("\r", " ").replace("\n", " ")
+    return f"{level} {location} {text}"
+
+
+def _format_modal(page: Any) -> str | None:
+    lines: list[str] = []
+    for tab_index, _, dialog, chooser in _pending_modal_entries(page):
+        owner = f"Tab {tab_index}" if tab_index >= 0 else "Registered page"
+        if dialog is not None:
+            try:
+                dialog_type = str(dialog.type)
+            except Exception:
+                dialog_type = "dialog"
+            try:
+                message = str(dialog.message)
+            except Exception:
+                message = "(message unavailable)"
+            lines.append(
+                f"- {owner}: Dialog pending: type={dialog_type}; "
+                f"message={message!r}. Call browser_handle_dialog."
+            )
+        if chooser is not None:
+            try:
+                multiple = bool(chooser.is_multiple())
+            except Exception:
+                multiple = False
+            hint = "multiple files allowed" if multiple else "single file only"
+            lines.append(
+                f"- {owner}: File chooser pending: {hint}. "
+                "Call browser_file_upload."
+            )
+    return "\n".join(lines) if lines else None
+
+
 def _render_response(
     result: str | None = None,
     *,
@@ -361,7 +546,7 @@ def _render_response(
     snapshot: str | None = None,
     include_tabs: bool = False,
 ) -> str:
-    """Render every successful tool result with deterministic section order."""
+    """Render an E2 envelope with deterministic, cursor-aware section order."""
     sections: list[str] = []
     details: tuple[str, str, int, list[Any]] | None = None
     if page is not None:
@@ -383,10 +568,49 @@ def _render_response(
         lines = []
         for index, tab in enumerate(pages):
             marker = " (active)" if index == active_index else ""
-            lines.append(f"- {index}: {tab.title()} — {tab.url}{marker}")
+            pending_dialog, _ = _pending_modals(tab)
+            if pending_dialog is not None:
+                tab_title = _state.known_page_title(tab) or "(dialog pending)"
+            else:
+                tab_title = _state.known_page_title(tab)
+                if tab_title is None:
+                    tab_title = _capture_page_title(tab) or "(unavailable)"
+            lines.append(f"- {index}: {tab_title} — {tab.url}{marker}")
         sections.append("### Tabs\n" + ("\n".join(lines) or "- (none)"))
     if snapshot is not None:
         sections.append(f"### Snapshot\n{snapshot}")
+
+    console_records, _, downloads = _state.response_events()
+    terse_console = [
+        record
+        for record in console_records
+        if _CONSOLE_LEVEL_RANK[_console_level(record.message_type)] <= 1
+    ]
+    if terse_console:
+        visible = terse_console[:5]
+        lines = [_format_console_record(record) for record in visible]
+        overflow = len(terse_console) - len(visible)
+        if overflow:
+            lines.append(f"(and {overflow} more)")
+        sections.append("### Console\n" + "\n".join(lines))
+
+    if page is not None:
+        modal = _format_modal(page)
+        if modal is not None:
+            sections.append(f"### Modal\n{modal}")
+
+    if downloads:
+        download_lines = []
+        for record in downloads:
+            if record.artifact is not None:
+                download_lines.append(
+                    f"- {record.suggested_filename}: `{record.artifact}`"
+                )
+            else:
+                download_lines.append(
+                    f"- {record.suggested_filename}: save failed ({record.error})"
+                )
+        sections.append("### Downloads\n" + "\n".join(download_lines))
     return "\n\n".join(sections)
 
 
@@ -426,6 +650,7 @@ class ResolvedTarget:
     locator: Any
     display_name: str
     source: Literal["ref", "selector"]
+    selector: str
 
 
 _REF_PATTERN = re.compile(r"^e[1-9][0-9]*$")
@@ -437,6 +662,11 @@ def _resolve(
     element_description: str | None = None,
 ) -> ResolvedTarget:
     """Resolve a current stamped ref or exactly one selector match."""
+    if _has_pending_modal():
+        raise ValueError(
+            "A modal is pending; handle the dialog or file chooser before "
+            "resolving page targets."
+        )
     display_name = target if element_description is None else element_description
     if _REF_PATTERN.fullmatch(target):
         snapshot_taken, snapshot_refs = _state.snapshot_status(page)
@@ -447,7 +677,8 @@ def _resolve(
                 f"Ref {target} is not in the current page snapshot; take a fresh snapshot."
             )
         locator = page.locator(f'[data-mcp-ref="{target}"]')
-        return ResolvedTarget(locator, display_name, "ref")
+        selector = f'[data-mcp-ref="{target}"]'
+        return ResolvedTarget(locator, display_name, "ref", selector)
 
     locator = page.locator(target)
     count = locator.count()
@@ -457,7 +688,7 @@ def _resolve(
         raise ValueError(
             f"Target selector matched {count} elements; provide a unique selector: {target}"
         )
-    return ResolvedTarget(locator, display_name, "selector")
+    return ResolvedTarget(locator, display_name, "selector", target)
 
 
 def _scalar_to_array(value: Any) -> Any:
@@ -499,6 +730,248 @@ Function = Annotated[
     str,
     Field(validation_alias=AliasChoices("function", "expression")),
 ]
+PositiveDimension = Annotated[float, Field(gt=0, allow_inf_nan=False)]
+NetworkIndex = Annotated[int, Field(ge=1)]
+UploadPaths = Annotated[list[str], Field(max_length=50)]
+
+
+class FillField(TypedDict):
+    """One strictly validated browser_fill_form operation."""
+
+    __pydantic_config__ = ConfigDict(extra="forbid")
+
+    element: NotRequired[str]
+    target: str
+    name: str
+    type: Literal["textbox", "checkbox", "radio", "combobox", "slider"]
+    value: str
+
+
+FillFields = Annotated[list[FillField], Field(min_length=1, max_length=50)]
+
+
+def _round_half_away_from_zero(value: float) -> int:
+    """Round a finite dimension to the nearest integer device pixel."""
+    return int(math.copysign(math.floor(abs(value) + 0.5), value))
+
+
+def _run_action_with_pending_dialog(page: Any, action: Any) -> None:
+    """Treat a dialog-stalled action as complete once the modal is recorded."""
+    try:
+        action()
+    except Exception:
+        dialog, _ = _pending_modals(page)
+        if dialog is None:
+            raise
+
+
+def _compile_find_regex(expression: str) -> re.Pattern[str]:
+    pattern = expression
+    flags = 0
+    if expression.startswith("/"):
+        closing = expression.rfind("/")
+        if closing == 0:
+            raise ValueError(
+                "regex slash form must be /pattern/flags (flags: i, m, s)"
+            )
+        pattern = expression[1:closing]
+        raw_flags = expression[closing + 1 :]
+        invalid = sorted(set(raw_flags) - {"i", "m", "s"})
+        if invalid:
+            raise ValueError(
+                "invalid regex flags: " + ", ".join(invalid) + "; supported: i, m, s"
+            )
+        if len(set(raw_flags)) != len(raw_flags):
+            raise ValueError("regex flags must not be repeated")
+        for flag in raw_flags:
+            flags |= {"i": re.IGNORECASE, "m": re.MULTILINE, "s": re.DOTALL}[flag]
+    try:
+        return re.compile(pattern, flags)
+    except re.error as exc:
+        raise ValueError(f"invalid regex: {exc}") from None
+
+
+def _outline_indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _find_outline_matches(
+    outline: str,
+    matcher: Any,
+    *,
+    limit: int = FIND_MATCH_LIMIT,
+) -> tuple[list[str], int]:
+    """Return path-qualified matches with one same-parent sibling each side."""
+    lines = outline.splitlines()
+    matching_indices = [index for index, line in enumerate(lines) if matcher(line)]
+    rendered: list[str] = []
+    for match_number, index in enumerate(matching_indices[:limit], start=1):
+        indent = _outline_indent(lines[index])
+        ancestors: list[str] = []
+        wanted_indent = indent - 2
+        for candidate in range(index - 1, -1, -1):
+            candidate_indent = _outline_indent(lines[candidate])
+            if candidate_indent == wanted_indent:
+                ancestors.append(lines[candidate].strip())
+                wanted_indent -= 2
+                if wanted_indent < 0:
+                    break
+        path = " > ".join(reversed(ancestors)) or "(root)"
+
+        siblings: list[int] = []
+        for direction in (-1, 1):
+            candidate = index + direction
+            while 0 <= candidate < len(lines):
+                candidate_indent = _outline_indent(lines[candidate])
+                if candidate_indent < indent:
+                    break
+                if candidate_indent == indent:
+                    siblings.append(candidate)
+                    break
+                candidate += direction
+        context = sorted({*siblings, index})
+        snippets = [
+            ("> " if candidate == index else "  ") + lines[candidate]
+            for candidate in context
+        ]
+        rendered.append(
+            f"Match {match_number}\nPath: {path}\n" + "\n".join(snippets)
+        )
+    return rendered, max(0, len(matching_indices) - limit)
+
+
+# Successful image/media/font/stylesheet requests are the chosen static set.
+# Scripts are intentionally visible because they often carry application logic.
+_STATIC_RESOURCE_TYPES = {"image", "media", "font", "stylesheet"}
+
+
+def _filter_network_records(
+    records: list[Any],
+    *,
+    include_static: bool,
+    pattern: re.Pattern[str] | None,
+) -> list[Any]:
+    visible = []
+    for record in records:
+        successful_static = (
+            record.resource_type.lower() in _STATIC_RESOURCE_TYPES
+            and record.response_status is not None
+            and 200 <= record.response_status < 400
+        )
+        if not include_static and successful_static:
+            continue
+        if pattern is not None and pattern.search(record.url) is None:
+            continue
+        visible.append(record)
+    return visible
+
+
+def _thaw_metadata(value: Any) -> Any:
+    if isinstance(value, tuple):
+        if all(
+            isinstance(item, tuple) and len(item) == 2 and isinstance(item[0], str)
+            for item in value
+        ):
+            return {name: _thaw_metadata(item) for name, item in value}
+        return [_thaw_metadata(item) for item in value]
+    return value
+
+
+def _header_content_type(headers: tuple[tuple[str, Any], ...]) -> str:
+    for name, value in headers:
+        if name.lower() == "content-type":
+            return str(value).split(";", 1)[0].strip().lower()
+    return ""
+
+
+def _is_text_content_type(content_type: str) -> bool:
+    return (
+        content_type.startswith("text/")
+        or content_type.endswith("+json")
+        or content_type.endswith("+xml")
+        or content_type
+        in {
+            "application/json",
+            "application/xml",
+            "application/javascript",
+            "application/x-javascript",
+            "application/x-www-form-urlencoded",
+        }
+    )
+
+
+def _response_body_text(record: Any, *, byte_limit: int | None) -> str:
+    if record.response is None:
+        return "(response not received)"
+    try:
+        raw = record.response.body()
+    except Exception as exc:
+        return f"(body unavailable: {exc})"
+    if isinstance(raw, str):
+        body = raw.encode("utf-8")
+    else:
+        body = bytes(raw)
+    if not body:
+        return "(empty response body)"
+
+    truncated = byte_limit is not None and len(body) > byte_limit
+    delivered = body[:byte_limit] if truncated and byte_limit is not None else body
+    content_type = _header_content_type(record.response_headers)
+    if _is_text_content_type(content_type):
+        rendered = delivered.decode("utf-8", errors="replace")
+        note = ""
+    else:
+        rendered = base64.b64encode(delivered).decode("ascii")
+        note = "\n(base64-encoded non-text response body)"
+    if truncated:
+        note += (
+            f"\n(response body truncated to {byte_limit} bytes inline; "
+            "use filename for the full body)"
+        )
+    return rendered + note
+
+
+def _network_record_text(
+    record: Any,
+    part: Literal[
+        "request-headers", "request-body", "response-headers", "response-body"
+    ]
+    | None,
+    *,
+    body_limit: int | None,
+) -> str:
+    parts = (
+        [part]
+        if part is not None
+        else [
+            "request-headers",
+            "request-body",
+            "response-headers",
+            "response-body",
+        ]
+    )
+    rendered: list[str] = []
+    for selected in parts:
+        if selected == "request-headers":
+            value = json.dumps(
+                _thaw_metadata(record.headers), ensure_ascii=False, indent=2
+            )
+        elif selected == "request-body":
+            value = record.post_data if record.post_data not in {None, ""} else "(empty request body)"
+        elif selected == "response-headers":
+            value = (
+                "(response not received)"
+                if record.response is None
+                else json.dumps(
+                    _thaw_metadata(record.response_headers),
+                    ensure_ascii=False,
+                    indent=2,
+                )
+            )
+        else:
+            value = _response_body_text(record, byte_limit=body_limit)
+        rendered.append(f"#### {selected}\n{value}")
+    return "\n\n".join(rendered)
 
 
 @_tool()
@@ -508,6 +981,25 @@ def browser_navigate(url: str) -> str:
     page.goto(url)
     snapshot = _snapshot(page)
     return _render_response(f"Navigated to {url}.", page=page, snapshot=snapshot)
+
+
+@_tool()
+def browser_resize(width: PositiveDimension, height: PositiveDimension) -> str:
+    """Resize the page viewport, not the operating-system browser window.
+
+    Responsive layout and the rendered DOM may change, so a fresh snapshot is
+    returned after ``page.set_viewport_size`` completes.
+    """
+    page = _page()
+    pixel_width = _round_half_away_from_zero(width)
+    pixel_height = _round_half_away_from_zero(height)
+    page.set_viewport_size({"width": pixel_width, "height": pixel_height})
+    snapshot = _snapshot(page)
+    return _render_response(
+        f"Viewport resized to {pixel_width}x{pixel_height} CSS pixels.",
+        page=page,
+        snapshot=snapshot,
+    )
 
 
 @_tool()
@@ -531,12 +1023,47 @@ def browser_snapshot(
         boxes=boxes,
     )
     if filename is not None:
+        if snapshot is None:
+            return _render_response(
+                "Snapshot deferred until the pending modal is handled.", page=page
+            )
         artifact = _write_text_output(snapshot, filename, purpose="snapshot")
         return _render_response(
             f"Snapshot written to `{artifact}`.",
             page=page,
         )
     return _render_response(page=page, snapshot=snapshot)
+
+
+@_tool()
+def browser_find(text: str | None = None, regex: str | None = None) -> str:
+    """Search one refreshed current outline and return compact actionable context."""
+    if (text is None) == (regex is None):
+        raise ValueError("Exactly one of text or regex is required.")
+    if regex is not None:
+        compiled = _compile_find_regex(regex)
+        matcher = compiled.search
+    else:
+        assert text is not None
+        needle = text.casefold()
+        matcher = lambda line: needle in line.casefold()
+
+    page = _page()
+    outline = _snapshot(page)
+    if outline is None:
+        return _render_response(
+            "Find deferred until the pending modal is handled.", page=page
+        )
+    matches, truncated = _find_outline_matches(
+        outline, lambda line: matcher(line) is not None if regex is not None else matcher(line)
+    )
+    if not matches:
+        result = "No matches in the current snapshot outline."
+    else:
+        result = "\n\n".join(matches)
+        if truncated:
+            result += f"\n\n… {truncated} additional matches truncated."
+    return _render_response(result, page=page)
 
 
 @_tool()
@@ -550,14 +1077,52 @@ def browser_click(
     """Click a unique target. ``element`` is only a human-readable description."""
     page = _page()
     resolved = _resolve(page, target, element)
-    resolved.locator.click(
-        click_count=2 if doubleClick else 1,
-        button=button,
-        modifiers=modifiers,
-    )
+    action = lambda: resolved.locator.click(
+            click_count=2 if doubleClick else 1,
+            button=button,
+            modifiers=modifiers,
+            timeout=1_000,
+        )
+    _run_action_with_pending_dialog(page, action)
+    with _state.event_lock:
+        registry = _state.registry_for(page)
+        retry_file_chooser = bool(
+            registry is not None and registry.file_chooser_retry_needed
+        )
+    if retry_file_chooser:
+        _, chooser = _pending_modals(page)
+        if chooser is None:
+            # A cancelled chooser after a validation failure is suppressed once
+            # by some backends. Replay this already-authorized input click once.
+            page.wait_for_timeout(50)
+            _run_action_with_pending_dialog(page, action)
+        with _state.event_lock:
+            registry = _state.registry_for(page)
+            if registry is not None:
+                registry.file_chooser_retry_needed = False
     snapshot = _snapshot(page)
     return _render_response(
         f"Clicked {resolved.display_name}.", page=page, snapshot=snapshot
+    )
+
+
+@_tool()
+def browser_drag(
+    startTarget: str,
+    endTarget: str,
+    startElement: str | None = None,
+    endElement: str | None = None,
+) -> str:
+    """Strict-resolve both endpoints and drag the first element to the second."""
+    page = _page()
+    start = _resolve(page, startTarget, startElement)
+    end = _resolve(page, endTarget, endElement)
+    page.drag_and_drop(start.selector, end.selector, strict=True)
+    snapshot = _snapshot(page)
+    return _render_response(
+        f"Dragged {start.display_name} to {end.display_name}.",
+        page=page,
+        snapshot=snapshot,
     )
 
 
@@ -617,6 +1182,51 @@ def browser_select_option(
 
 
 @_tool()
+def browser_fill_form(fields: FillFields) -> str:
+    """Fill up to 50 fields sequentially as a non-transactional batch.
+
+    If a field fails, earlier changes intentionally remain applied and the
+    structured error names the first failing field.
+    """
+    page = _page()
+    for field in fields:
+        name = field["name"]
+        try:
+            resolved = _resolve(page, field["target"], field.get("element"))
+            locator = resolved.locator
+            field_type = field["type"]
+            value = field["value"]
+            if field_type in {"textbox", "slider"}:
+                locator.fill(value)
+            elif field_type == "checkbox":
+                if value == "true":
+                    locator.check()
+                elif value == "false":
+                    locator.uncheck()
+                else:
+                    raise ValueError("checkbox value must be 'true' or 'false'")
+            elif field_type == "radio":
+                if value == "false":
+                    raise ValueError("unchecking a radio is not supported")
+                if value != "true":
+                    raise ValueError("radio value must be 'true'")
+                locator.check()
+            else:
+                try:
+                    locator.select_option(label=value)
+                except Exception:
+                    locator.select_option(value=value)
+        except Exception as exc:
+            raise ValueError(f"Field {name!r} failed: {exc}") from None
+    snapshot = _snapshot(page)
+    return _render_response(
+        f"Filled {len(fields)} fields sequentially (non-transactional).",
+        page=page,
+        snapshot=snapshot,
+    )
+
+
+@_tool()
 def browser_hover(target: str, element: str | None = None) -> str:
     """Hover a unique target. ``element`` is only a human description."""
     page = _page()
@@ -666,6 +1276,8 @@ def browser_tabs(
     context = page.context
     pages = list(context.pages)
     snapshot = None
+    for tab in pages:
+        _register_page_handlers(tab)
 
     if action == "new":
         page = context.new_page()
@@ -673,6 +1285,7 @@ def browser_tabs(
         _state.page = page
         if url is not None:
             page.goto(url)
+            _capture_page_title(page)
         snapshot = _snapshot(page)
     elif action == "select":
         if index is None or index < 0 or index >= len(pages):
@@ -682,7 +1295,9 @@ def browser_tabs(
         page = pages[index]
         _register_page_handlers(page)
         _state.page = page
-        page.bring_to_front()
+        pending_dialog, _ = _pending_modals(page)
+        if pending_dialog is None:
+            page.bring_to_front()
         snapshot = _snapshot(page)
     elif action == "close":
         if index is None:
@@ -697,6 +1312,10 @@ def browser_tabs(
                 )
             closing = pages[index]
             closing_index = index
+        if any(entry[1] is closing for entry in _pending_modal_entries(page)):
+            raise ValueError(
+                f"Tab {closing_index} has a pending modal; handle it before closing."
+            )
         was_active = closing is page
         closing.close()
         remaining = list(context.pages)
@@ -708,6 +1327,9 @@ def browser_tabs(
         _state.page = page
         snapshot = _snapshot(page)
 
+    for tab in list(context.pages):
+        _register_page_handlers(tab)
+
     return _render_response(
         f"Tab action `{action}` completed.",
         page=page,
@@ -717,14 +1339,259 @@ def browser_tabs(
 
 
 @_tool()
-def browser_handle_dialog(accept: bool, promptText: PromptText = None) -> str:
-    """Arm the one-shot policy for the next JavaScript dialog."""
+def browser_console_messages(
+    level: Literal["error", "warning", "info", "debug"] = "info",
+    all: bool = False,
+    filename: str | None = None,
+) -> str:
+    """List console records at the requested threshold under the event lock."""
     page = _page()
-    _state.arm_dialog(page, accept, promptText)
-    action = "accepted" if accept else "dismissed"
-    return _render_response(
-        f"The next dialog on the active page will be {action}.", page=page
+    with _state.event_lock:
+        registry = _state.registry_for(page)
+        epoch = 0 if registry is None else registry.navigation_epoch
+        records = [] if registry is None else list(registry.console_records)
+        if not all:
+            records = [record for record in records if record.epoch == epoch]
+        evicted = 0
+        if registry is not None:
+            evicted = (
+                sum(registry.console_evictions.values())
+                if all
+                else registry.console_evictions.get(epoch, 0)
+            )
+
+    threshold = _CONSOLE_LEVEL_RANK[level]
+    visible = [
+        record
+        for record in records
+        if _CONSOLE_LEVEL_RANK[_console_level(record.message_type)] <= threshold
+    ]
+    lines = [_format_console_record(record) for record in visible]
+    if evicted:
+        lines.append(
+            f"(console ring buffer evicted {evicted} earlier matching-scope records)"
+        )
+    content = "\n".join(lines) or "(no console messages)"
+    if filename is not None:
+        artifact = _write_text_output(content, filename, purpose="console")
+        result = f"Console messages written to `{artifact}`."
+    else:
+        result = content
+    return _render_response(result, page=page)
+
+
+@_tool()
+def browser_network_requests(
+    static: bool = False,
+    filter: str | None = None,
+    filename: str | None = None,
+) -> str:
+    """List current-navigation requests while preserving their stable indices."""
+    pattern = None
+    if filter is not None:
+        try:
+            pattern = re.compile(filter)
+        except re.error as exc:
+            raise ValueError(f"invalid network filter regex: {exc}") from None
+
+    page = _page()
+    with _state.event_lock:
+        registry = _state.registry_for(page)
+        epoch = 0 if registry is None else registry.navigation_epoch
+        records = (
+            []
+            if registry is None
+            else [
+                record
+                for record in registry.network_records
+                if record.epoch == epoch
+            ]
+        )
+        evicted = (
+            0 if registry is None else registry.network_evictions.get(epoch, 0)
+        )
+
+    visible = _filter_network_records(
+        records, include_static=static, pattern=pattern
     )
+    lines = []
+    for record in visible:
+        if record.response_status is not None:
+            status = str(record.response_status)
+        elif record.failure is not None:
+            status = "FAILED"
+        else:
+            status = "PENDING"
+        lines.append(
+            f"[{record.index}] {record.method} {status} {record.url} "
+            f"({record.resource_type})"
+        )
+    if evicted:
+        lines.append(
+            f"(network ring buffer evicted {evicted} earlier current-epoch records)"
+        )
+    content = "\n".join(lines) or "(no matching network requests)"
+    if filename is not None:
+        artifact = _write_text_output(content, filename, purpose="network")
+        result = f"Network requests written to `{artifact}`."
+    else:
+        result = content
+    return _render_response(result, page=page)
+
+
+@_tool()
+def browser_network_request(
+    index: NetworkIndex,
+    part: Literal[
+        "request-headers", "request-body", "response-headers", "response-body"
+    ]
+    | None = None,
+    filename: str | None = None,
+) -> str:
+    """Return lazy details for one stable current-navigation request index."""
+    page = _page()
+    with _state.event_lock:
+        registry = _state.registry_for(page)
+        epoch = 0 if registry is None else registry.navigation_epoch
+        navigation_start = (
+            _state.next_request_index
+            if registry is None
+            else registry.navigation_start_request_index
+        )
+        records = (
+            []
+            if registry is None
+            else [
+                record
+                for record in registry.network_records
+                if record.epoch == epoch
+            ]
+        )
+        record = next((item for item in records if item.index == index), None)
+        previous_navigation = registry is not None and (
+            index < navigation_start
+            or any(
+                item.index == index and item.epoch != epoch
+                for item in registry.network_records
+            )
+        )
+    if record is None:
+        if records:
+            valid = f"{min(item.index for item in records)}-{max(item.index for item in records)}"
+        else:
+            valid = "none"
+        if previous_navigation:
+            raise ValueError(
+                f"Request index {index} is from a previous navigation; "
+                f"current requests are {valid} (current navigation epoch)."
+            )
+        raise ValueError(
+            f"Network request index {index} is unavailable in the current "
+            f"navigation epoch; valid range: {valid}."
+        )
+
+    content = _network_record_text(
+        record,
+        part,
+        body_limit=None if filename is not None else NETWORK_BODY_INLINE_BYTES,
+    )
+    if filename is not None:
+        artifact = _write_text_output(content, filename, purpose="network-request")
+        result = f"Network request {index} written to `{artifact}`."
+    else:
+        result = content
+    return _render_response(result, page=page)
+
+
+@_tool()
+def browser_file_upload(paths: UploadPaths | None = None) -> str:
+    """Resolve a pending file chooser with confined files, or cancel with []."""
+    page = _page()
+    entries = _pending_modal_entries(page)
+    chooser_entry = next((entry for entry in entries if entry[3] is not None), None)
+    if chooser_entry is None:
+        raise ValueError("no file chooser is pending")
+    if any(dialog is not None for _, _, dialog, _ in entries):
+        raise ValueError("a dialog is pending; handle it before the file chooser")
+    _, owner_page, _, chooser = chooser_entry
+    assert chooser is not None
+
+    supplied = [] if paths is None else paths
+    chooser_released = False
+    try:
+        try:
+            multiple = bool(chooser.is_multiple())
+        except Exception:
+            multiple = False
+        if len(supplied) > 1 and not multiple:
+            raise ValueError("the pending file chooser accepts only one file")
+        policy = get_file_policy()
+        validated = [str(policy.validate_input(path)) for path in supplied]
+        # set_files([]) is the browser API's supported chooser cancellation path;
+        # unlike merely dropping our reference, it releases the chooser event.
+        chooser.set_files(validated)
+        chooser_released = True
+    finally:
+        if not chooser_released:
+            # Validation/multiplicity errors still have to release the live
+            # browser chooser before clearing our modal slot, or a later click
+            # on the same input will not produce a new chooser event.
+            try:
+                chooser.set_files([])
+            except Exception:
+                pass
+            try:
+                # Some browser backends acknowledge [] after an input already
+                # had a file without making the control reopenable. Resetting
+                # only the failed attempt's input is the compatibility
+                # workaround; explicit user cancellation still uses [] alone.
+                chooser.element.evaluate(
+                    "element => { element.value = ''; element.blur(); }"
+                )
+            except Exception:
+                pass
+            with _state.event_lock:
+                registry = _state.registry_for(owner_page)
+                if registry is not None:
+                    registry.file_chooser_retry_needed = True
+        _state.clear_pending_file_chooser(owner_page, chooser)
+
+    snapshot = _snapshot(page)
+    result = (
+        "Cancelled the pending file chooser."
+        if not supplied
+        else f"Uploaded {len(supplied)} file(s) through the pending chooser."
+    )
+    return _render_response(result, page=page, snapshot=snapshot)
+
+
+@_tool()
+def browser_handle_dialog(accept: bool, promptText: PromptText = None) -> str:
+    """Accept or dismiss the JavaScript dialog that is pending now."""
+    page = _page()
+    dialog_entry = next(
+        (
+            entry
+            for entry in _pending_modal_entries(page)
+            if entry[2] is not None
+        ),
+        None,
+    )
+    if dialog_entry is None:
+        raise ValueError("no dialog is pending")
+    _, owner_page, dialog, _ = dialog_entry
+    assert dialog is not None
+    if not accept and promptText is not None:
+        raise ValueError("promptText cannot be honored when dismissing a dialog")
+    try:
+        if accept:
+            dialog.accept(promptText)
+        else:
+            dialog.dismiss()
+    finally:
+        _state.clear_pending_dialog(owner_page, dialog)
+    action = "Accepted" if accept else "Dismissed"
+    return _render_response(f"{action} the pending dialog.", page=page)
 
 
 @_tool()

--- a/mcp/rustwright_mcp/server.py
+++ b/mcp/rustwright_mcp/server.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 from importlib import metadata
 import json
 import math
+import mimetypes
 import os
 import re
 import sys
@@ -735,6 +736,45 @@ NetworkIndex = Annotated[int, Field(ge=1)]
 UploadPaths = Annotated[list[str], Field(max_length=50)]
 
 
+_SYNTHETIC_DROP_JS = """async (target, payload) => {
+    const transfer = new DataTransfer();
+    transfer.effectAllowed = "copy";
+    transfer.dropEffect = "copy";
+
+    for (const entry of payload.files) {
+        const binary = atob(entry.base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let index = 0; index < binary.length; index += 1) {
+            bytes[index] = binary.charCodeAt(index);
+        }
+        transfer.items.add(new File([bytes], entry.name, {
+            type: entry.mime,
+            lastModified: 0,
+        }));
+    }
+    for (const [mime, value] of payload.data) {
+        transfer.setData(mime, value);
+    }
+
+    const bounds = target.getBoundingClientRect();
+    const eventOptions = {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        clientX: bounds.left + bounds.width / 2,
+        clientY: bounds.top + bounds.height / 2,
+        dataTransfer: transfer,
+    };
+    for (const type of ["dragenter", "dragover", "drop"]) {
+        target.dispatchEvent(new DragEvent(type, eventOptions));
+    }
+
+    // Let FileReader- and promise-based handlers make progress before the
+    // fresh snapshot. Application work that outlives this task remains async.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+}"""
+
+
 class FillField(TypedDict):
     """One strictly validated browser_fill_form operation."""
 
@@ -1121,6 +1161,62 @@ def browser_drag(
     snapshot = _snapshot(page)
     return _render_response(
         f"Dragged {start.display_name} to {end.display_name}.",
+        page=page,
+        snapshot=snapshot,
+    )
+
+
+@_tool()
+def browser_drop(
+    target: str,
+    element: str | None = None,
+    paths: UploadPaths | None = None,
+    data: dict[str, str] | None = None,
+) -> str:
+    """Best-effort drop files and/or MIME strings onto a unique target.
+
+    ``element`` is only a human-readable description. The tool uses synthetic DataTransfer semantics:
+    synthesized drop events; sites checking event trust or native drag sessions may behave differently.
+    """
+    supplied_paths = [] if paths is None else paths
+    supplied_data = {} if data is None else data
+    if not supplied_paths and not supplied_data:
+        raise ValueError("browser_drop requires at least one non-empty paths or data source")
+
+    normalized_mime_keys: set[str] = set()
+    for mime in supplied_data:
+        if not mime.strip():
+            raise ValueError("browser_drop data MIME keys must be non-empty")
+        normalized = mime.casefold()
+        if normalized in normalized_mime_keys:
+            raise ValueError(
+                "browser_drop data MIME keys must be unique ignoring case"
+            )
+        normalized_mime_keys.add(normalized)
+
+    page = _page()
+    resolved = _resolve(page, target, element)
+
+    policy = get_file_policy()
+    files = []
+    for path, content in policy.read_inputs(supplied_paths):
+        inferred_mime, _ = mimetypes.guess_type(path.name, strict=False)
+        files.append(
+            {
+                "name": path.name,
+                "mime": inferred_mime or "application/octet-stream",
+                "base64": base64.b64encode(content).decode("ascii"),
+            }
+        )
+
+    resolved.locator.evaluate(
+        _SYNTHETIC_DROP_JS,
+        {"files": files, "data": list(supplied_data.items())},
+    )
+    snapshot = _snapshot(page)
+    source_summary = f"{len(files)} file(s) and {len(supplied_data)} data item(s)"
+    return _render_response(
+        f"Synthesized a drop of {source_summary} on {resolved.display_name}.",
         page=page,
         snapshot=snapshot,
     )

--- a/mcp/rustwright_mcp/server.py
+++ b/mcp/rustwright_mcp/server.py
@@ -1,7 +1,7 @@
 """MCP server exposing Rustwright browser automation over stdio.
 
-Tool names mirror the Playwright MCP server so agents can switch between
-the two without re-learning the surface. Element targeting uses refs from
+Tool names mirror the de-facto standard ``browser_*`` toolset so agents can
+switch without re-learning the surface. Element targeting uses refs from
 ``browser_snapshot`` (``e1``, ``e2``, ...) or raw CSS selectors.
 
 Environment variables:
@@ -11,7 +11,9 @@ Environment variables:
     RUSTWRIGHT_MCP_CDP_ENDPOINT remote browser CDP endpoint (uses remote mode when set)
     RUSTWRIGHT_MCP_CDP_HEADERS optional JSON object of CDP connection headers
     RUSTWRIGHT_MCP_CDP_TIMEOUT_MS remote connection timeout in milliseconds (default: 60000)
-    RUSTWRIGHT_MCP_ALLOW_EVAL  "1", "true", or "yes" to expose browser_evaluate
+    RUSTWRIGHT_MCP_ALLOW_EVAL  explicit falsy value disables browser_evaluate
+    RUSTWRIGHT_MCP_CAPS        accepted comma-separated capability groups
+    RUSTWRIGHT_MCP_TOOLSET     "mirror" (default) or the smaller "lean" profile
     RUSTWRIGHT_MCP_OUTPUT_DIR   root for files written by tools
     RUSTWRIGHT_MCP_WORKSPACE    allowed input root for future upload tools
 
@@ -27,14 +29,22 @@ from importlib import metadata
 import json
 import os
 import re
+import sys
 import threading
-from typing import Any, Literal, Optional
+from typing import Annotated, Any, Literal
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import (
+    AliasChoices,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    model_validator,
+)
 
 from rustwright_mcp.filepolicy import get_file_policy
 from rustwright_mcp.session import SessionState
-from rustwright_mcp.snapshot import SNAPSHOT_JS
+from rustwright_mcp.snapshot import SNAPSHOT_JS, TARGET_SNAPSHOT_JS
 
 PACKAGE_VERSION = metadata.version("rustwright-mcp")
 mcp = FastMCP("rustwright-mcp")
@@ -55,6 +65,108 @@ def _serialized(fn):
             return fn(*args, **kwargs)
 
     return wrapper
+
+
+_FALSE_VALUES = {"0", "false", "no", "off"}
+_LEAN_TOOLS = {
+    "browser_navigate",
+    "browser_navigate_back",
+    "browser_reload",
+    "browser_snapshot",
+    "browser_click",
+    "browser_type",
+    "browser_select_option",
+    "browser_hover",
+    "browser_press_key",
+    "browser_wait_for",
+    "browser_tabs",
+    "browser_take_screenshot",
+    "browser_close",
+    # Evaluation is controlled only by RUSTWRIGHT_MCP_ALLOW_EVAL. Profiles
+    # must not quietly change that security setting.
+    "browser_evaluate",
+}
+
+
+def _allow_eval() -> bool:
+    raw = os.environ.get("RUSTWRIGHT_MCP_ALLOW_EVAL")
+    return raw is None or raw.strip().lower() not in _FALSE_VALUES
+
+
+def _toolset_profile() -> Literal["mirror", "lean"]:
+    raw = os.environ.get("RUSTWRIGHT_MCP_TOOLSET", "mirror").strip().lower()
+    if raw in {"mirror", "lean"}:
+        return raw
+    print(
+        f"warning: unknown RUSTWRIGHT_MCP_TOOLSET={raw!r}; using 'mirror'",
+        file=sys.stderr,
+    )
+    return "mirror"
+
+
+_TOOLSET_PROFILE = _toolset_profile()
+
+
+def _tool():
+    """Register a serialized tool when it belongs to the active profile."""
+
+    def decorator(fn):
+        wrapped = _serialized(fn)
+        in_profile = _TOOLSET_PROFILE == "mirror" or fn.__name__ in _LEAN_TOOLS
+        eval_allowed = fn.__name__ != "browser_evaluate" or _allow_eval()
+        if in_profile and eval_allowed:
+            mcp.tool()(wrapped)
+            registered = mcp._tool_manager.get_tool(fn.__name__)
+            if registered is None:  # pragma: no cover - registration is synchronous
+                raise RuntimeError(f"Tool registration failed for {fn.__name__}")
+
+            generated_model = registered.fn_metadata.arg_model
+
+            class StrictArguments(generated_model):
+                model_config = ConfigDict(
+                    arbitrary_types_allowed=True,
+                    extra="forbid",
+                )
+
+                @model_validator(mode="before")
+                @classmethod
+                def canonical_alias_wins(cls, data: Any) -> Any:
+                    """Discard only a legacy alias shadowed by its canonical key.
+
+                    Pydantic consumes the first ``AliasChoices`` entry, but with
+                    forbidden extras a simultaneously supplied legacy spelling
+                    would otherwise remain as an unknown key. Normalize that
+                    conflict before extra checking; a legacy spelling supplied on
+                    its own is still consumed through ``validation_alias``.
+                    """
+                    if not isinstance(data, dict):
+                        return data
+                    normalized = data.copy()
+                    for field in cls.model_fields.values():
+                        validation_alias = field.validation_alias
+                        if not isinstance(validation_alias, AliasChoices):
+                            continue
+                        canonical, *legacy_aliases = validation_alias.choices
+                        if (
+                            not isinstance(canonical, str)
+                            or canonical not in normalized
+                        ):
+                            continue
+                        for legacy_alias in legacy_aliases:
+                            if isinstance(legacy_alias, str):
+                                normalized.pop(legacy_alias, None)
+                    return normalized
+
+            # Preserve the generated model's stable schema title while replacing
+            # it with the strict subclass used for both validation and advertising.
+            StrictArguments.__name__ = generated_model.__name__
+            StrictArguments.__qualname__ = generated_model.__qualname__
+            registered.fn_metadata.arg_model = StrictArguments
+            registered.parameters = StrictArguments.model_json_schema(by_alias=True)
+        return wrapped
+
+    return decorator
+
 
 SNAPSHOT_CHAR_LIMIT = 30_000
 _OUTLINE_REF_PATTERN = re.compile(r"\[ref=(e[1-9][0-9]*)\]")
@@ -185,25 +297,114 @@ def _page():
     return _state.page
 
 
-def _snapshot(page) -> str:
+def _snapshot(
+    page: Any,
+    *,
+    target: Any | None = None,
+    depth: float | None = None,
+    boxes: bool = False,
+) -> str:
+    if depth is not None and depth < 0:
+        raise ValueError("depth must be non-negative")
     try:
         # An action may have triggered a navigation; settle before reading the DOM.
         page.wait_for_load_state(timeout=10_000)
     except Exception:
         pass
-    result = page.evaluate(SNAPSHOT_JS, _state.snapshot_start_ref())
+    options = {
+        "startRef": _state.snapshot_start_ref(),
+        "maxDepth": depth,
+        "boxes": boxes,
+    }
+    result = (
+        target.evaluate(TARGET_SNAPSHOT_JS, options)
+        if target is not None
+        else page.evaluate(SNAPSHOT_JS, options)
+    )
     outline = result["outline"]
-    header = f"Page: {page.title()}\nURL: {page.url}\n\n"
     body = outline[:SNAPSHOT_CHAR_LIMIT]
     if len(outline) > SNAPSHOT_CHAR_LIMIT:
-        body += "\n- … (snapshot truncated, use browser_get_text for full content)"
+        body += "\n- … (snapshot truncated; use a targeted snapshot for more detail)"
     delivered_refs = set(_OUTLINE_REF_PATTERN.findall(body))
     _state.record_snapshot(
         page,
         [ref for ref in result["refs"] if ref in delivered_refs],
         result["nextRef"],
     )
-    return header + body
+    return body
+
+
+def _page_details(page: Any) -> tuple[str, str, int, list[Any]]:
+    try:
+        title = str(page.title())
+    except Exception:
+        title = "(unavailable)"
+    try:
+        url = str(page.url)
+    except Exception:
+        url = "(unavailable)"
+    try:
+        pages = list(page.context.pages)
+    except Exception:
+        pages = [page]
+    try:
+        active_index = next(index for index, tab in enumerate(pages) if tab is page)
+    except StopIteration:
+        active_index = -1
+    return title, url, active_index, pages
+
+
+def _render_response(
+    result: str | None = None,
+    *,
+    page: Any | None = None,
+    snapshot: str | None = None,
+    include_tabs: bool = False,
+) -> str:
+    """Render every successful tool result with deterministic section order."""
+    sections: list[str] = []
+    details: tuple[str, str, int, list[Any]] | None = None
+    if page is not None:
+        details = _page_details(page)
+    if result is not None:
+        sections.append(f"### Result\n{result}")
+    if details is not None:
+        title, url, active_index, _ = details
+        sections.append(
+            "### Page\n"
+            f"- URL: {url}\n"
+            f"- Title: {title}\n"
+            f"- Active tab: {active_index}"
+        )
+    if include_tabs:
+        if details is None:
+            raise ValueError("tab rendering requires an active page")
+        _, _, active_index, pages = details
+        lines = []
+        for index, tab in enumerate(pages):
+            marker = " (active)" if index == active_index else ""
+            lines.append(f"- {index}: {tab.title()} — {tab.url}{marker}")
+        sections.append("### Tabs\n" + ("\n".join(lines) or "- (none)"))
+    if snapshot is not None:
+        sections.append(f"### Snapshot\n{snapshot}")
+    return "\n\n".join(sections)
+
+
+def _write_text_output(content: str, filename: str, *, purpose: str) -> str:
+    policy = get_file_policy()
+    output_path = policy.reserve_output(filename, purpose=purpose)
+    try:
+        flags = os.O_WRONLY | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = os.open(output_path, flags)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8", closefd=False) as handle:
+                handle.write(content)
+        finally:
+            os.close(descriptor)
+        return policy.finalize_output(output_path)
+    except Exception:
+        policy.discard_output(output_path)
+        raise
 
 
 def _teardown() -> None:
@@ -259,232 +460,451 @@ def _resolve(
     return ResolvedTarget(locator, display_name, "selector")
 
 
-@mcp.tool()
-@_serialized
+def _scalar_to_array(value: Any) -> Any:
+    if value is None or isinstance(value, list):
+        return value
+    return [value]
+
+
+DoubleClick = Annotated[
+    bool,
+    Field(validation_alias=AliasChoices("doubleClick", "double_click")),
+]
+Modifiers = Annotated[
+    list[Literal["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]],
+    BeforeValidator(_scalar_to_array),
+]
+Values = Annotated[
+    list[str],
+    BeforeValidator(_scalar_to_array),
+    Field(validation_alias=AliasChoices("values", "value")),
+]
+PromptText = Annotated[
+    str | None,
+    Field(validation_alias=AliasChoices("promptText", "prompt_text")),
+]
+TextGone = Annotated[
+    str | None,
+    Field(validation_alias=AliasChoices("textGone", "text_gone")),
+]
+Filename = Annotated[
+    str | None,
+    Field(validation_alias=AliasChoices("filename", "path")),
+]
+FullPage = Annotated[
+    bool,
+    Field(validation_alias=AliasChoices("fullPage", "full_page")),
+]
+Function = Annotated[
+    str,
+    Field(validation_alias=AliasChoices("function", "expression")),
+]
+
+
+@_tool()
 def browser_navigate(url: str) -> str:
-    """Navigate to a URL. Returns the page snapshot with element refs."""
+    """Navigate to a URL and return a fresh snapshot."""
     page = _page()
     page.goto(url)
-    return _snapshot(page)
+    snapshot = _snapshot(page)
+    return _render_response(f"Navigated to {url}.", page=page, snapshot=snapshot)
 
 
-@mcp.tool()
-@_serialized
-def browser_snapshot() -> str:
-    """Accessibility-style outline of the current page. Interactive elements
-    carry [ref=eN] handles usable with browser_click / browser_type."""
-    return _snapshot(_page())
+@_tool()
+def browser_snapshot(
+    target: str | None = None,
+    filename: str | None = None,
+    depth: float | None = None,
+    boxes: bool = False,
+) -> str:
+    """Return a full or targeted accessibility outline with current refs.
 
-
-@mcp.tool()
-@_serialized
-def browser_click(target: str, double_click: bool = False) -> str:
-    """Click an element. `target` is a ref from the snapshot (e.g. "e12") or a
-    CSS selector. Returns a fresh snapshot."""
+    ``depth`` bounds tree traversal, ``boxes`` adds viewport-relative CSS-pixel
+    metadata, and ``filename`` writes the snapshot through the output policy.
+    """
     page = _page()
-    resolved = _resolve(page, target)
-    if double_click:
-        resolved.locator.dblclick()
-    else:
-        resolved.locator.click()
-    return _snapshot(page)
+    resolved = None if target is None else _resolve(page, target)
+    snapshot = _snapshot(
+        page,
+        target=None if resolved is None else resolved.locator,
+        depth=depth,
+        boxes=boxes,
+    )
+    if filename is not None:
+        artifact = _write_text_output(snapshot, filename, purpose="snapshot")
+        return _render_response(
+            f"Snapshot written to `{artifact}`.",
+            page=page,
+        )
+    return _render_response(page=page, snapshot=snapshot)
 
 
-@mcp.tool()
-@_serialized
-def browser_type(target: str, text: str, submit: bool = False, clear: bool = True) -> str:
-    """Type into an input. `target` is a snapshot ref or CSS selector. Set
-    submit=True to press Enter afterwards. Returns a fresh snapshot."""
+@_tool()
+def browser_click(
+    target: str,
+    element: str | None = None,
+    doubleClick: DoubleClick = False,
+    button: Literal["left", "right", "middle"] = "left",
+    modifiers: Modifiers | None = None,
+) -> str:
+    """Click a unique target. ``element`` is only a human-readable description."""
     page = _page()
-    resolved = _resolve(page, target)
-    if clear:
-        resolved.locator.fill(text)
+    resolved = _resolve(page, target, element)
+    resolved.locator.click(
+        click_count=2 if doubleClick else 1,
+        button=button,
+        modifiers=modifiers,
+    )
+    snapshot = _snapshot(page)
+    return _render_response(
+        f"Clicked {resolved.display_name}.", page=page, snapshot=snapshot
+    )
+
+
+@_tool()
+def browser_type(
+    target: str,
+    text: str,
+    element: str | None = None,
+    submit: bool = False,
+    slowly: bool = False,
+    clear: bool = True,
+) -> str:
+    """Enter text into a target and optionally submit.
+
+    ``slowly`` types with a character delay. ``clear`` is a Rustwright
+    extension that independently controls replacement versus append behavior.
+    """
+    page = _page()
+    resolved = _resolve(page, target, element)
+    locator = resolved.locator
+    if clear and not slowly:
+        locator.fill(text)
     else:
-        resolved.locator.type(text)
+        if clear:
+            locator.fill("")
+        if slowly:
+            locator.press_sequentially(text, delay=50)
+        else:
+            locator.type(text)
     if submit:
-        resolved.locator.press("Enter")
-    return _snapshot(page)
+        locator.press("Enter")
+    snapshot = _snapshot(page)
+    return _render_response(
+        f"Entered text in {resolved.display_name}.", page=page, snapshot=snapshot
+    )
 
 
-@mcp.tool()
-@_serialized
-def browser_select_option(target: str, value: str) -> str:
-    """Select an option in a <select> element by value or visible label."""
+@_tool()
+def browser_select_option(
+    target: str,
+    values: Values,
+    element: str | None = None,
+) -> str:
+    """Select one or more values; legacy singular ``value`` is accepted."""
     page = _page()
-    resolved = _resolve(page, target)
+    resolved = _resolve(page, target, element)
     try:
-        resolved.locator.select_option(value=value)
+        resolved.locator.select_option(value=values)
     except Exception:
-        resolved.locator.select_option(label=value)
-    return _snapshot(page)
+        resolved.locator.select_option(label=values)
+    snapshot = _snapshot(page)
+    return _render_response(
+        f"Selected {json.dumps(values, ensure_ascii=False)} in {resolved.display_name}.",
+        page=page,
+        snapshot=snapshot,
+    )
 
 
-@mcp.tool()
-@_serialized
-def browser_hover(target: str) -> str:
-    """Hover over an element identified by snapshot ref or CSS selector."""
+@_tool()
+def browser_hover(target: str, element: str | None = None) -> str:
+    """Hover a unique target. ``element`` is only a human description."""
     page = _page()
-    _resolve(page, target).locator.hover()
-    return _snapshot(page)
+    resolved = _resolve(page, target, element)
+    resolved.locator.hover()
+    snapshot = _snapshot(page)
+    return _render_response(
+        f"Hovered {resolved.display_name}.", page=page, snapshot=snapshot
+    )
 
 
-@mcp.tool()
-@_serialized
+@_tool()
 def browser_press_key(key: str) -> str:
-    """Press a keyboard key (e.g. "Enter", "Escape", "ArrowDown") on the page."""
+    """Press a browser key or character on the active page."""
     page = _page()
     page.keyboard.press(key)
-    return _snapshot(page)
+    snapshot = _snapshot(page)
+    return _render_response(f"Pressed {key}.", page=page, snapshot=snapshot)
 
 
-@mcp.tool()
-@_serialized
+@_tool()
 def browser_navigate_back() -> str:
-    """Go back in browser history. Returns a fresh snapshot."""
+    """Go back in browser history and return a fresh snapshot."""
     page = _page()
     page.go_back()
-    return _snapshot(page)
+    snapshot = _snapshot(page)
+    return _render_response("Navigated back.", page=page, snapshot=snapshot)
 
 
-@mcp.tool()
-@_serialized
+@_tool()
 def browser_reload() -> str:
-    """Reload the active page. Returns a fresh snapshot."""
+    """Reload the active page and return a fresh snapshot."""
     page = _page()
     page.reload()
-    return _snapshot(page)
+    snapshot = _snapshot(page)
+    return _render_response("Reloaded the active page.", page=page, snapshot=snapshot)
 
 
-@mcp.tool()
-@_serialized
+@_tool()
 def browser_tabs(
-    action: str, index: int | None = None, url: str | None = None
+    action: Literal["list", "new", "close", "select"],
+    index: int | None = None,
+    url: str | None = None,
 ) -> str:
-    """List, open, select, or close browser tabs.
-
-    `action` is one of "list", "new", "select", or "close". `index` is
-    required when selecting or closing a tab; `url` is optional for new tabs.
-    """
+    """List, open, select, or close tabs. Every action returns the tab list."""
     page = _page()
     context = page.context
     pages = list(context.pages)
-    action = action.lower()
+    snapshot = None
 
-    if action == "list":
-        return "\n".join(
-            f"{i}: {tab.title()} — {tab.url}" for i, tab in enumerate(pages)
-        )
     if action == "new":
         page = context.new_page()
         _register_page_handlers(page)
         _state.page = page
-        if url:
+        if url is not None:
             page.goto(url)
-        return _snapshot(page)
-    if action not in {"select", "close"}:
-        raise ValueError('action must be one of "list", "new", "select", or "close"')
-    if index is None or index < 0 or index >= len(pages):
-        raise ValueError(f"Invalid tab index {index}; expected 0 through {len(pages) - 1}")
-
-    if action == "select":
+        snapshot = _snapshot(page)
+    elif action == "select":
+        if index is None or index < 0 or index >= len(pages):
+            raise ValueError(
+                f"Invalid tab index {index}; expected 0 through {len(pages) - 1}"
+            )
         page = pages[index]
         _register_page_handlers(page)
         _state.page = page
         page.bring_to_front()
-        return _snapshot(page)
+        snapshot = _snapshot(page)
+    elif action == "close":
+        if index is None:
+            closing = page
+            closing_index = next(
+                (position for position, tab in enumerate(pages) if tab is page), 0
+            )
+        else:
+            if index < 0 or index >= len(pages):
+                raise ValueError(
+                    f"Invalid tab index {index}; expected 0 through {len(pages) - 1}"
+                )
+            closing = pages[index]
+            closing_index = index
+        was_active = closing is page
+        closing.close()
+        remaining = list(context.pages)
+        if not remaining:
+            page = context.new_page()
+        elif was_active:
+            page = remaining[min(closing_index, len(remaining) - 1)]
+        _register_page_handlers(page)
+        _state.page = page
+        snapshot = _snapshot(page)
 
-    closing = pages[index]
-    was_active = closing is page
-    closing.close()
-    remaining = list(context.pages)
-    if not remaining:
-        page = context.new_page()
-    elif was_active:
-        page = remaining[min(index, len(remaining) - 1)]
-    _register_page_handlers(page)
-    _state.page = page
-    return _snapshot(page)
+    return _render_response(
+        f"Tab action `{action}` completed.",
+        page=page,
+        snapshot=snapshot,
+        include_tabs=True,
+    )
 
 
-@mcp.tool()
-@_serialized
-def browser_handle_dialog(accept: bool, prompt_text: str | None = None) -> str:
-    """Accept or dismiss the next JavaScript dialog on the active page.
-
-    A dialog opened by a brand-new popup may appear before its page can be
-    registered. The policy is consumed once; unarmed dialogs remain pending.
-    """
+@_tool()
+def browser_handle_dialog(accept: bool, promptText: PromptText = None) -> str:
+    """Arm the one-shot policy for the next JavaScript dialog."""
     page = _page()
-    _state.arm_dialog(page, accept, prompt_text)
+    _state.arm_dialog(page, accept, promptText)
     action = "accepted" if accept else "dismissed"
-    return f"The next dialog on the active page will be {action}."
+    return _render_response(
+        f"The next dialog on the active page will be {action}.", page=page
+    )
 
 
-@mcp.tool()
-@_serialized
-def browser_wait_for(text: Optional[str] = None, timeout_ms: float = 10_000) -> str:
-    """Wait for text to appear on the page (or for load state when no text
-    is given), then return a snapshot."""
+@_tool()
+def browser_wait_for(
+    time: float | None = None,
+    text: str | None = None,
+    textGone: TextGone = None,
+    timeout_ms: float = 10_000,
+) -> str:
+    """Wait for time and/or text state, then return one fresh snapshot.
+
+    ``time`` is seconds and is capped at 30. ``timeout_ms`` is a Rustwright
+    extension controlling the visible/hidden text waits.
+    """
+    if time is None and text is None and textGone is None:
+        raise ValueError("At least one of time, text, or textGone is required.")
+    if time is not None and time < 0:
+        raise ValueError("time must be non-negative")
+    if timeout_ms < 0:
+        raise ValueError("timeout_ms must be non-negative")
     page = _page()
-    if text:
-        page.wait_for_selector(f"text={text}", timeout=timeout_ms)
-    else:
-        page.wait_for_load_state(timeout=timeout_ms)
-    return _snapshot(page)
+    if time is not None:
+        page.wait_for_timeout(min(time, 30) * 1000)
+    if text is not None:
+        page.get_by_text(text).wait_for(state="visible", timeout=timeout_ms)
+    if textGone is not None:
+        page.get_by_text(textGone).wait_for(state="hidden", timeout=timeout_ms)
+    snapshot = _snapshot(page)
+    return _render_response("Wait completed.", page=page, snapshot=snapshot)
 
 
-@mcp.tool()
-@_serialized
+@_tool()
 def browser_get_text(selector: str = "body", max_chars: int = 20_000) -> str:
-    """Visible text content of a CSS selector (defaults to the whole page)."""
+    """Return visible text for a unique selector (mirror profile only)."""
     page = _page()
     text = _resolve(page, selector).locator.inner_text() or ""
-    return text[:max_chars]
+    return _render_response(text[:max_chars], page=page)
 
 
-def browser_evaluate(expression: str) -> str:
-    """Run JavaScript in the page. Use an arrow function, e.g.
-    "() => document.title". Returns the JSON-ish result as a string."""
-    return str(_page().evaluate(expression))
+@_tool()
+def browser_evaluate(
+    function: Function,
+    element: str | None = None,
+    target: str | None = None,
+    filename: str | None = None,
+) -> str:
+    """Evaluate a function in page or unique-element context and return JSON."""
+    if element is not None and target is None:
+        raise ValueError("element requires target for browser_evaluate")
+    page = _page()
+    if target is None:
+        evaluated = page.evaluate(function)
+    else:
+        resolved = _resolve(page, target, element)
+        evaluated = resolved.locator.evaluate(function)
+    serialized = json.dumps(evaluated, ensure_ascii=False, default=str)
+    result = serialized
+    if filename is not None:
+        artifact = _write_text_output(serialized, filename, purpose="evaluate")
+        result += f"\n\nSaved to: `{artifact}`"
+    snapshot = _snapshot(page)
+    return _render_response(result, page=page, snapshot=snapshot)
 
 
-def _allow_eval() -> bool:
-    return os.environ.get("RUSTWRIGHT_MCP_ALLOW_EVAL", "").lower() in {
-        "1",
-        "true",
-        "yes",
-    }
+def _supports_screenshot_scale(screenshot_target: Any) -> bool:
+    import inspect
 
-
-if _allow_eval():
-    mcp.tool()(_serialized(browser_evaluate))
-
-
-@mcp.tool()
-@_serialized
-def browser_take_screenshot(path: Optional[str] = None, full_page: bool = False) -> str:
-    """Save a PNG under the configured output root and return its artifact path."""
-    policy = get_file_policy()
-    output_path = policy.reserve_output(path, purpose="screenshot")
     try:
-        _page().screenshot(path=str(output_path), full_page=full_page)
-        return policy.finalize_output(output_path)
+        return "scale" in inspect.signature(screenshot_target.screenshot).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+@_tool()
+def browser_take_screenshot(
+    element: str | None = None,
+    target: str | None = None,
+    type: Literal["png", "jpeg"] = "png",
+    filename: Filename = None,
+    fullPage: FullPage = False,
+    scale: Literal["css", "device"] = "css",
+) -> str:
+    """Save a page or element screenshot through the confined output policy."""
+    if element is not None and target is None:
+        raise ValueError("element requires target for browser_take_screenshot")
+    if fullPage and target is not None:
+        raise ValueError("fullPage and an element target are mutually exclusive")
+
+    page = _page()
+    resolved = None if target is None else _resolve(page, target, element)
+    screenshot_target = page if resolved is None else resolved.locator
+    supports_scale = _supports_screenshot_scale(screenshot_target)
+    if scale == "device" and not supports_scale:
+        raise ValueError(
+            "scale=device is unsupported by this Rustwright screenshot API"
+        )
+
+    policy = get_file_policy()
+    output_path = policy.reserve_output(
+        filename,
+        purpose="screenshot",
+        suffix=f".{type}",
+    )
+    kwargs: dict[str, Any] = {"path": str(output_path), "type": type}
+    if supports_scale:
+        kwargs["scale"] = scale
+    if resolved is None:
+        kwargs["full_page"] = fullPage
+    try:
+        screenshot_target.screenshot(**kwargs)
+        artifact = policy.finalize_output(output_path)
     except Exception:
         policy.discard_output(output_path)
         raise
+    return _render_response(f"Screenshot written to `{artifact}`.", page=page)
 
 
-@mcp.tool()
-@_serialized
+@_tool()
 def browser_close() -> str:
-    """Close the browser. The next tool call starts a fresh session."""
+    """Close the browser. The next browser tool starts a fresh session."""
     if _state.browser is not None:
         _teardown()
-        return "Browser closed."
-    return "No browser session was open."
+        return _render_response("Browser closed.")
+    return _render_response("No browser session was open.")
+
+
+def _configured_caps(
+    argv: list[str] | None = None,
+    environ: dict[str, str] | None = None,
+) -> tuple[str, ...]:
+    """Return requested capability groups; environment takes precedence."""
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    environment = os.environ if environ is None else environ
+    if "RUSTWRIGHT_MCP_CAPS" in environment:
+        raw_groups = environment["RUSTWRIGHT_MCP_CAPS"]
+    else:
+        raw_groups = ",".join(
+            argument.removeprefix("--caps=")
+            for argument in arguments
+            if argument.startswith("--caps=")
+        )
+    groups = []
+    for group in raw_groups.split(","):
+        normalized = group.strip().lower()
+        if normalized and normalized not in groups:
+            groups.append(normalized)
+    return tuple(groups)
+
+
+def _warn_ignored_caps(groups: tuple[str, ...]) -> None:
+    for group in groups:
+        print(
+            f"warning: capability group {group!r} is not implemented and will be ignored",
+            file=sys.stderr,
+        )
+
+
+_eval_warning_emitted = False
+
+
+def _warn_eval_enabled() -> None:
+    global _eval_warning_emitted
+    if _allow_eval() and not _eval_warning_emitted:
+        print(
+            "warning: browser_evaluate is enabled; set "
+            "RUSTWRIGHT_MCP_ALLOW_EVAL=0 to disable page-world evaluation",
+            file=sys.stderr,
+        )
+        _eval_warning_emitted = True
 
 
 def main() -> None:
+    _warn_ignored_caps(_configured_caps())
+    _warn_eval_enabled()
+    # FastMCP does not consume capability flags. Strip only the accepted form
+    # so future argument parsing cannot reject a compatibility-only option.
+    sys.argv[:] = [
+        sys.argv[0],
+        *[arg for arg in sys.argv[1:] if not arg.startswith("--caps=")],
+    ]
     mcp.run()
 
 

--- a/mcp/rustwright_mcp/server.py
+++ b/mcp/rustwright_mcp/server.py
@@ -11,7 +11,7 @@ Environment variables:
     RUSTWRIGHT_MCP_CDP_ENDPOINT remote browser CDP endpoint (uses remote mode when set)
     RUSTWRIGHT_MCP_CDP_HEADERS optional JSON object of CDP connection headers
     RUSTWRIGHT_MCP_CDP_TIMEOUT_MS remote connection timeout in milliseconds (default: 60000)
-    RUSTWRIGHT_MCP_ALLOW_EVAL  explicit falsy value disables browser_evaluate
+    RUSTWRIGHT_MCP_ALLOW_EVAL  true/false toggle for browser_evaluate; unknown values fail startup
     RUSTWRIGHT_MCP_CAPS        accepted comma-separated capability groups
     RUSTWRIGHT_MCP_TOOLSET     "mirror" (default) or the smaller "lean" profile
     RUSTWRIGHT_MCP_OUTPUT_DIR   root for files written by tools
@@ -83,6 +83,7 @@ def _serialized(fn):
 
 
 _FALSE_VALUES = {"0", "false", "no", "off"}
+_TRUE_VALUES = {"1", "true", "yes", "on"}
 _MODAL_SAFE_TOOLS = {
     "browser_handle_dialog",
     "browser_file_upload",
@@ -116,7 +117,18 @@ _LEAN_TOOLS = {
 
 def _allow_eval() -> bool:
     raw = os.environ.get("RUSTWRIGHT_MCP_ALLOW_EVAL")
-    return raw is None or raw.strip().lower() not in _FALSE_VALUES
+    if raw is None:
+        return True
+    normalized = raw.strip().lower()
+    if normalized in _TRUE_VALUES:
+        return True
+    if normalized in _FALSE_VALUES:
+        return False
+    accepted = ", ".join(sorted(_TRUE_VALUES | _FALSE_VALUES))
+    raise ValueError(
+        "RUSTWRIGHT_MCP_ALLOW_EVAL must be one of "
+        f"{accepted}; got {raw!r}"
+    )
 
 
 def _toolset_profile() -> Literal["mirror", "lean"]:
@@ -1117,29 +1129,52 @@ def browser_click(
     """Click a unique target. ``element`` is only a human-readable description."""
     page = _page()
     resolved = _resolve(page, target, element)
-    action = lambda: resolved.locator.click(
+    with _state.event_lock:
+        registry = _state.registry_for(page)
+        retry_element = (
+            None if registry is None else registry.file_chooser_retry_element
+        )
+    retry_same_file_input = False
+    if retry_element is not None:
+        try:
+            retry_same_file_input = bool(
+                resolved.locator.evaluate(
+                    "(candidate, retryElement) => candidate === retryElement",
+                    retry_element,
+                )
+            )
+        except Exception:
+            # If DOM identity cannot be established, never replay a click.
+            with _state.event_lock:
+                registry = _state.registry_for(page)
+                if (
+                    registry is not None
+                    and registry.file_chooser_retry_element is retry_element
+                ):
+                    registry.file_chooser_retry_element = None
+    def action() -> None:
+        resolved.locator.click(
             click_count=2 if doubleClick else 1,
             button=button,
             modifiers=modifiers,
             timeout=1_000,
         )
+
     _run_action_with_pending_dialog(page, action)
-    with _state.event_lock:
-        registry = _state.registry_for(page)
-        retry_file_chooser = bool(
-            registry is not None and registry.file_chooser_retry_needed
-        )
-    if retry_file_chooser:
+    if retry_same_file_input:
         _, chooser = _pending_modals(page)
         if chooser is None:
             # A cancelled chooser after a validation failure is suppressed once
-            # by some backends. Replay this already-authorized input click once.
+            # by some backends. Replay only the originating input's click once.
             page.wait_for_timeout(50)
             _run_action_with_pending_dialog(page, action)
         with _state.event_lock:
             registry = _state.registry_for(page)
-            if registry is not None:
-                registry.file_chooser_retry_needed = False
+            if (
+                registry is not None
+                and registry.file_chooser_retry_element is retry_element
+            ):
+                registry.file_chooser_retry_element = None
     snapshot = _snapshot(page)
     return _render_response(
         f"Clicked {resolved.display_name}.", page=page, snapshot=snapshot
@@ -1451,9 +1486,9 @@ def browser_console_messages(
         evicted = 0
         if registry is not None:
             evicted = (
-                sum(registry.console_evictions.values())
+                registry.console_evictions_total
                 if all
-                else registry.console_evictions.get(epoch, 0)
+                else registry.console_evictions_current_epoch
             )
 
     threshold = _CONSOLE_LEVEL_RANK[level]
@@ -1614,6 +1649,7 @@ def browser_file_upload(paths: UploadPaths | None = None) -> str:
 
     supplied = [] if paths is None else paths
     chooser_released = False
+    failure: Exception | None = None
     try:
         try:
             multiple = bool(chooser.is_multiple())
@@ -1627,6 +1663,8 @@ def browser_file_upload(paths: UploadPaths | None = None) -> str:
         # unlike merely dropping our reference, it releases the chooser event.
         chooser.set_files(validated)
         chooser_released = True
+    except Exception as exc:
+        failure = exc
     finally:
         if not chooser_released:
             # Validation/multiplicity errors still have to release the live
@@ -1646,11 +1684,25 @@ def browser_file_upload(paths: UploadPaths | None = None) -> str:
                 )
             except Exception:
                 pass
+            try:
+                retry_element = chooser.element
+            except Exception:
+                retry_element = None
             with _state.event_lock:
                 registry = _state.registry_for(owner_page)
                 if registry is not None:
-                    registry.file_chooser_retry_needed = True
+                    registry.file_chooser_retry_element = retry_element
+        else:
+            with _state.event_lock:
+                registry = _state.registry_for(owner_page)
+                if registry is not None:
+                    registry.file_chooser_retry_element = None
         _state.clear_pending_file_chooser(owner_page, chooser)
+
+    if failure is not None:
+        raise ValueError(
+            f"{failure} Retry by clicking the same file input again."
+        ) from None
 
     snapshot = _snapshot(page)
     result = (

--- a/mcp/rustwright_mcp/server.py
+++ b/mcp/rustwright_mcp/server.py
@@ -8,12 +8,19 @@ Environment variables:
     RUSTWRIGHT_MCP_HEADLESS    "0" to show the browser window (default headless)
     RUSTWRIGHT_MCP_CHANNEL     chromium channel, e.g. "chrome" (default: bundled chromium)
     RUSTWRIGHT_MCP_EXECUTABLE  explicit browser executable path (overrides channel)
+    RUSTWRIGHT_MCP_CDP_ENDPOINT remote browser CDP endpoint (uses remote mode when set)
+    RUSTWRIGHT_MCP_CDP_HEADERS optional JSON object of CDP connection headers
+    RUSTWRIGHT_MCP_CDP_TIMEOUT_MS remote connection timeout in milliseconds (default: 60000)
     RUSTWRIGHT_MCP_ALLOW_EVAL  "1", "true", or "yes" to expose browser_evaluate
+
+When RUSTWRIGHT_MCP_CDP_ENDPOINT is set, the local headless, channel, and
+executable options are ignored.
 """
 
 from __future__ import annotations
 
 import functools
+import json
 import os
 import tempfile
 import threading
@@ -67,15 +74,98 @@ def _register_dialog_handler(page) -> None:
 
 
 def _page():
+    """Return the active page, launching locally or attaching over remote CDP.
+
+    In remote CDP mode, local launch options (headless, channel, and executable)
+    are ignored.
+    """
     if "page" in _session:
         try:
             # The user may have closed a headed window; detect a dead
             # session and relaunch instead of failing every call.
             _session["page"].evaluate("() => 1")
         except Exception:
+            if _session.get("remote"):
+                _teardown()
+                raise RuntimeError(
+                    "Remote CDP session is no longer reachable — "
+                    "reconnect/restart the MCP server."
+                ) from None
             _teardown()
     if "page" not in _session:
         from rustwright.sync_api import sync_playwright
+
+        endpoint = os.environ.get("RUSTWRIGHT_MCP_CDP_ENDPOINT")
+        if endpoint:
+            raw_headers = os.environ.get("RUSTWRIGHT_MCP_CDP_HEADERS", "")
+            headers: dict[str, str] = {}
+            if raw_headers:
+                try:
+                    parsed_headers = json.loads(raw_headers)
+                except json.JSONDecodeError:
+                    raise ValueError(
+                        "RUSTWRIGHT_MCP_CDP_HEADERS must contain a valid JSON object"
+                    ) from None
+                if not isinstance(parsed_headers, dict) or not all(
+                    isinstance(name, str) and isinstance(value, str)
+                    for name, value in parsed_headers.items()
+                ):
+                    raise ValueError(
+                        "RUSTWRIGHT_MCP_CDP_HEADERS must be a JSON object with "
+                        "string keys and values"
+                    )
+                headers = parsed_headers
+
+            try:
+                timeout_ms = int(
+                    os.environ.get("RUSTWRIGHT_MCP_CDP_TIMEOUT_MS", "60000")
+                )
+            except ValueError:
+                raise ValueError(
+                    "RUSTWRIGHT_MCP_CDP_TIMEOUT_MS must be a non-negative integer"
+                ) from None
+            if timeout_ms < 0:
+                raise ValueError(
+                    "RUSTWRIGHT_MCP_CDP_TIMEOUT_MS must be a non-negative integer"
+                )
+
+            pw = None
+            browser = None
+            try:
+                pw = sync_playwright().start()
+                browser = pw.chromium.connect_over_cdp(
+                    endpoint,
+                    headers=headers,
+                    timeout=timeout_ms,
+                )
+                context = browser.contexts[0]
+                pages = context.pages
+                page = pages[0] if pages else context.new_page()
+                _session.update(
+                    pw=pw,
+                    browser=browser,
+                    page=page,
+                    remote=True,
+                    snapshot_taken=False,
+                    next_ref=1,
+                    dialog_pages=[],
+                )
+                _register_dialog_handler(page)
+            except Exception:
+                for close in (
+                    lambda: browser.close() if browser is not None else None,
+                    lambda: pw.stop() if pw is not None else None,
+                ):
+                    try:
+                        close()
+                    except Exception:
+                        pass
+                _session.clear()
+                raise RuntimeError(
+                    "Remote CDP browser is unreachable; check the connection "
+                    "settings and try again."
+                ) from None
+            return _session["page"]
 
         headless = os.environ.get("RUSTWRIGHT_MCP_HEADLESS", "1") != "0"
         launch_kwargs: dict = {"headless": headless}
@@ -92,6 +182,7 @@ def _page():
             pw=pw,
             browser=browser,
             page=page,
+            remote=False,
             snapshot_taken=False,
             next_ref=1,
             dialog_pages=[],
@@ -118,6 +209,8 @@ def _snapshot(page) -> str:
 
 
 def _teardown() -> None:
+    # For remote sessions, closing the connected Browser detaches this client;
+    # Rustwright leaves the remotely owned browser running.
     for close in (
         lambda: _session["browser"].close(),
         lambda: _session["pw"].stop(),

--- a/mcp/rustwright_mcp/session.py
+++ b/mcp/rustwright_mcp/session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import deque
 from dataclasses import dataclass, field, replace
 import threading
-from typing import Any, Mapping
+from typing import Any, Callable, Mapping
 
 
 MetadataItems = tuple[tuple[str, Any], ...]
@@ -36,6 +36,7 @@ def _immutable_mapping(value: Any) -> MetadataItems:
 
 @dataclass(frozen=True)
 class ConsoleRecord:
+    sequence: int
     epoch: int
     message_type: str
     text: str
@@ -60,17 +61,15 @@ class NetworkRecord:
 
 @dataclass(frozen=True)
 class DownloadRecord:
+    sequence: int
     epoch: int
     url: str
     suggested_filename: str
     download: Any = field(compare=False, repr=False)
-
-
-@dataclass(frozen=True)
-class DialogIntent:
-    page: Any = field(compare=False, repr=False)
-    accept: bool
-    prompt_text: str | None
+    artifact: str | None = None
+    error: str | None = None
+    finished: bool = False
+    reported: bool = False
 
 
 @dataclass
@@ -83,9 +82,13 @@ class PageRegistry:
     snapshot_generation: int = 0
     snapshot_taken: bool = False
     navigation_epoch: int = 0
-    next_request_index: int = 1
+    navigation_start_request_index: int = 1
     navigation_pending: bool = False
+    last_known_title: str | None = None
+    console_evictions: dict[int, int] = field(default_factory=dict)
+    network_evictions: dict[int, int] = field(default_factory=dict)
     pending_file_chooser: Any = field(default=None, repr=False)
+    file_chooser_retry_needed: bool = False
     pending_dialog: Any = field(default=None, repr=False)
     request_keys: dict[int, tuple[int, int]] = field(default_factory=dict, repr=False)
     callbacks: dict[str, Any] = field(default_factory=dict, repr=False)
@@ -110,7 +113,13 @@ class SessionState:
     remote: bool = False
     next_ref: int = 1
     page_registries: dict[int, PageRegistry] = field(default_factory=dict)
-    dialog_intent: DialogIntent | None = None
+    next_request_index: int = 1
+    next_console_sequence: int = 1
+    next_download_sequence: int = 1
+    response_console_cursor: int = 0
+    download_saver: Callable[[Any, str], str] | None = field(
+        default=None, repr=False
+    )
     event_lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
 
     def attach(
@@ -141,6 +150,7 @@ class SessionState:
             console_records=deque(maxlen=self.console_quota),
             network_records=deque(maxlen=self.network_quota),
             downloads=deque(maxlen=self.download_quota),
+            navigation_start_request_index=self.next_request_index,
         )
         self.page_registries[key] = registry
         return registry
@@ -186,21 +196,22 @@ class SessionState:
             registry = self.page_registries.get(id(page))
             if registry is not None and registry.page is page:
                 self.page_registries.pop(id(page), None)
-            if self.dialog_intent is not None and self.dialog_intent.page is page:
-                self.dialog_intent = None
             if self.page is page:
                 self.page = None
 
     def clear(self) -> None:
         with self.event_lock:
             self.page_registries.clear()
-            self.dialog_intent = None
             self.pw = None
             self.browser = None
             self.context = None
             self.page = None
             self.remote = False
             self.next_ref = 1
+            self.next_request_index = 1
+            self.next_console_sequence = 1
+            self.next_download_sequence = 1
+            self.response_console_cursor = 0
 
     def snapshot_start_ref(self) -> int:
         with self.event_lock:
@@ -222,9 +233,73 @@ class SessionState:
                 return False, frozenset()
             return registry.snapshot_taken, registry.snapshot_refs
 
-    def arm_dialog(self, page: Any, accept: bool, prompt_text: str | None) -> None:
+    def pending_modals(self, page: Any) -> tuple[Any | None, Any | None]:
+        """Return the current dialog and file chooser without browser calls."""
         with self.event_lock:
-            self.dialog_intent = DialogIntent(page, accept, prompt_text)
+            registry = self.registry_for(page)
+            if registry is None:
+                return None, None
+            return registry.pending_dialog, registry.pending_file_chooser
+
+    def pending_modal_pages(self) -> list[tuple[Any, Any | None, Any | None]]:
+        """Return every registered page with live modal state."""
+        with self.event_lock:
+            return [
+                (registry.page, registry.pending_dialog, registry.pending_file_chooser)
+                for registry in self.page_registries.values()
+                if registry.pending_dialog is not None
+                or registry.pending_file_chooser is not None
+            ]
+
+    def remember_page_title(self, page: Any, title: str) -> None:
+        with self.event_lock:
+            registry = self.registry_for(page, create=True)
+            assert registry is not None
+            registry.last_known_title = title
+
+    def known_page_title(self, page: Any) -> str | None:
+        with self.event_lock:
+            registry = self.registry_for(page)
+            return None if registry is None else registry.last_known_title
+
+    def clear_pending_dialog(self, page: Any, dialog: Any) -> None:
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is not None and registry.pending_dialog is dialog:
+                registry.pending_dialog = None
+
+    def clear_pending_file_chooser(self, page: Any, chooser: Any) -> None:
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is not None and registry.pending_file_chooser is chooser:
+                registry.pending_file_chooser = None
+
+    def response_events(
+        self,
+    ) -> tuple[list[ConsoleRecord], int, list[DownloadRecord]]:
+        """Consume response-scoped console and completed download events."""
+        with self.event_lock:
+            console = sorted(
+                (
+                    record
+                    for registry in self.page_registries.values()
+                    for record in registry.console_records
+                    if record.sequence > self.response_console_cursor
+                ),
+                key=lambda record: record.sequence,
+            )
+            latest_console = self.next_console_sequence - 1
+            self.response_console_cursor = latest_console
+
+            downloads: list[DownloadRecord] = []
+            for registry in self.page_registries.values():
+                for position, record in enumerate(registry.downloads):
+                    if not record.finished or record.reported:
+                        continue
+                    downloads.append(record)
+                    registry.downloads[position] = replace(record, reported=True)
+            downloads.sort(key=lambda record: record.sequence)
+            return console, latest_console, downloads
 
     def _invalidate_snapshot(self, registry: PageRegistry) -> None:
         registry.snapshot_refs = frozenset()
@@ -232,7 +307,7 @@ class SessionState:
 
     def _begin_navigation(self, registry: PageRegistry) -> None:
         registry.navigation_epoch += 1
-        registry.next_request_index = 1
+        registry.navigation_start_request_index = self.next_request_index
         registry.navigation_pending = True
         self._invalidate_snapshot(registry)
 
@@ -248,14 +323,24 @@ class SessionState:
             registry = self.registry_for(page)
             if registry is None:
                 return
+            if (
+                registry.console_records.maxlen is not None
+                and len(registry.console_records) == registry.console_records.maxlen
+            ):
+                evicted_epoch = registry.console_records[0].epoch
+                registry.console_evictions[evicted_epoch] = (
+                    registry.console_evictions.get(evicted_epoch, 0) + 1
+                )
             registry.console_records.append(
                 ConsoleRecord(
+                    sequence=self.next_console_sequence,
                     epoch=registry.navigation_epoch,
                     message_type=str(message.type),
                     text=str(message.text),
                     location=_immutable_mapping(message.location),
                 )
             )
+            self.next_console_sequence += 1
 
     def _on_request(self, page: Any, request: Any) -> None:
         with self.event_lock:
@@ -264,8 +349,8 @@ class SessionState:
                 return
             if self._is_main_navigation(page, request) and not registry.navigation_pending:
                 self._begin_navigation(registry)
-            index = registry.next_request_index
-            registry.next_request_index += 1
+            index = self.next_request_index
+            self.next_request_index += 1
             record = NetworkRecord(
                 epoch=registry.navigation_epoch,
                 index=index,
@@ -276,6 +361,14 @@ class SessionState:
                 post_data=request.post_data,
                 request=request,
             )
+            if (
+                registry.network_records.maxlen is not None
+                and len(registry.network_records) == registry.network_records.maxlen
+            ):
+                evicted_epoch = registry.network_records[0].epoch
+                registry.network_evictions[evicted_epoch] = (
+                    registry.network_evictions.get(evicted_epoch, 0) + 1
+                )
             registry.network_records.append(record)
             registry.request_keys[id(request)] = (record.epoch, record.index)
             live_keys = {(item.epoch, item.index) for item in registry.network_records}
@@ -353,41 +446,51 @@ class SessionState:
                 registry.pending_file_chooser = chooser
 
     def _on_dialog(self, page: Any, dialog: Any) -> None:
-        intent: DialogIntent | None = None
         with self.event_lock:
             registry = self.registry_for(page)
             if registry is None:
                 return
             registry.pending_dialog = dialog
-            if self.dialog_intent is not None and self.dialog_intent.page is page:
-                intent = self.dialog_intent
-                self.dialog_intent = None
-
-        # Keep the existing arm-next behavior. An unarmed dialog remains in the
-        # pending slot for the modal tools introduced by a later change.
-        if intent is None:
-            return
-        if intent.accept:
-            dialog.accept(intent.prompt_text)
-        else:
-            dialog.dismiss()
-        with self.event_lock:
-            registry = self.registry_for(page)
-            if registry is not None and registry.pending_dialog is dialog:
-                registry.pending_dialog = None
 
     def _on_download(self, page: Any, download: Any) -> None:
+        record: DownloadRecord | None = None
         with self.event_lock:
             registry = self.registry_for(page)
             if registry is not None:
-                registry.downloads.append(
-                    DownloadRecord(
-                        epoch=registry.navigation_epoch,
-                        url=str(download.url),
-                        suggested_filename=str(download.suggested_filename),
-                        download=download,
-                    )
+                record = DownloadRecord(
+                    sequence=self.next_download_sequence,
+                    epoch=registry.navigation_epoch,
+                    url=str(download.url),
+                    suggested_filename=str(download.suggested_filename),
+                    download=download,
                 )
+                self.next_download_sequence += 1
+                registry.downloads.append(record)
+
+        # Browser/file I/O must never run under event_lock. The callback may be
+        # delivered while a serialized tool is in flight, so record first and
+        # publish the finished artifact in a second short critical section.
+        if record is None or self.download_saver is None:
+            return
+        artifact: str | None = None
+        error: str | None = None
+        try:
+            artifact = self.download_saver(download, record.suggested_filename)
+        except Exception as exc:
+            error = str(exc)
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is None:
+                return
+            for position, candidate in enumerate(registry.downloads):
+                if candidate.sequence == record.sequence:
+                    registry.downloads[position] = replace(
+                        candidate,
+                        artifact=artifact,
+                        error=error,
+                        finished=True,
+                    )
+                    break
 
     def _on_frame_navigated(self, page: Any, frame: Any) -> None:
         with self.event_lock:

--- a/mcp/rustwright_mcp/session.py
+++ b/mcp/rustwright_mcp/session.py
@@ -1,0 +1,408 @@
+"""Typed browser session and per-page event state."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field, replace
+import threading
+from typing import Any, Mapping
+
+
+MetadataItems = tuple[tuple[str, Any], ...]
+
+
+def _freeze_metadata(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return tuple(
+            sorted((str(key), _freeze_metadata(item)) for key, item in value.items())
+        )
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_metadata(item) for item in value)
+    if isinstance(value, (set, frozenset)):
+        return tuple(sorted((_freeze_metadata(item) for item in value), key=repr))
+    if isinstance(value, bytearray):
+        return bytes(value)
+    return value
+
+
+def _immutable_mapping(value: Any) -> MetadataItems:
+    """Copy the scalar metadata exposed by browser event objects."""
+    if not isinstance(value, Mapping):
+        return ()
+    return tuple(
+        sorted((str(key), _freeze_metadata(item)) for key, item in value.items())
+    )
+
+
+@dataclass(frozen=True)
+class ConsoleRecord:
+    epoch: int
+    message_type: str
+    text: str
+    location: MetadataItems
+
+
+@dataclass(frozen=True)
+class NetworkRecord:
+    epoch: int
+    index: int
+    method: str
+    url: str
+    resource_type: str
+    headers: MetadataItems
+    post_data: str | None
+    request: Any = field(compare=False, repr=False)
+    response_status: int | None = None
+    response_headers: MetadataItems = ()
+    response: Any = field(default=None, compare=False, repr=False)
+    failure: str | None = None
+
+
+@dataclass(frozen=True)
+class DownloadRecord:
+    epoch: int
+    url: str
+    suggested_filename: str
+    download: Any = field(compare=False, repr=False)
+
+
+@dataclass(frozen=True)
+class DialogIntent:
+    page: Any = field(compare=False, repr=False)
+    accept: bool
+    prompt_text: str | None
+
+
+@dataclass
+class PageRegistry:
+    page: Any = field(repr=False)
+    console_records: deque[ConsoleRecord] = field(default_factory=deque)
+    network_records: deque[NetworkRecord] = field(default_factory=deque)
+    downloads: deque[DownloadRecord] = field(default_factory=deque)
+    snapshot_refs: frozenset[str] = frozenset()
+    snapshot_generation: int = 0
+    snapshot_taken: bool = False
+    navigation_epoch: int = 0
+    next_request_index: int = 1
+    navigation_pending: bool = False
+    pending_file_chooser: Any = field(default=None, repr=False)
+    pending_dialog: Any = field(default=None, repr=False)
+    request_keys: dict[int, tuple[int, int]] = field(default_factory=dict, repr=False)
+    callbacks: dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class SessionState:
+    """All state owned by one stdio MCP client session.
+
+    Tool calls are serialized by the server's tool lock. Browser callbacks use
+    ``event_lock`` exclusively so an event can be delivered while a tool action
+    is waiting for the browser.
+    """
+
+    console_quota: int = 200
+    network_quota: int = 500
+    download_quota: int = 100
+    pw: Any = None
+    browser: Any = None
+    context: Any = None
+    page: Any = None
+    remote: bool = False
+    next_ref: int = 1
+    page_registries: dict[int, PageRegistry] = field(default_factory=dict)
+    dialog_intent: DialogIntent | None = None
+    event_lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
+
+    def attach(
+        self,
+        *,
+        pw: Any,
+        browser: Any,
+        context: Any,
+        page: Any,
+        remote: bool,
+    ) -> None:
+        self.pw = pw
+        self.browser = browser
+        self.context = context
+        self.page = page
+        self.remote = remote
+        self.next_ref = 1
+
+    def registry_for(self, page: Any, *, create: bool = False) -> PageRegistry | None:
+        key = id(page)
+        registry = self.page_registries.get(key)
+        if registry is not None and registry.page is page:
+            return registry
+        if not create:
+            return None
+        registry = PageRegistry(
+            page=page,
+            console_records=deque(maxlen=self.console_quota),
+            network_records=deque(maxlen=self.network_quota),
+            downloads=deque(maxlen=self.download_quota),
+        )
+        self.page_registries[key] = registry
+        return registry
+
+    def register_page_handlers(self, page: Any) -> PageRegistry:
+        """Register every browser event handler once for ``page``."""
+        with self.event_lock:
+            existing = self.registry_for(page)
+            if existing is not None and existing.callbacks:
+                return existing
+            registry = self.registry_for(page, create=True)
+            assert registry is not None
+            callbacks = {
+                "console": lambda message: self._on_console(page, message),
+                "request": lambda request: self._on_request(page, request),
+                "response": lambda response: self._on_response(page, response),
+                "requestfailed": lambda request: self._on_request_failed(page, request),
+                "filechooser": lambda chooser: self._on_file_chooser(page, chooser),
+                "dialog": lambda dialog: self._on_dialog(page, dialog),
+                "download": lambda download: self._on_download(page, download),
+                "framenavigated": lambda frame: self._on_frame_navigated(page, frame),
+                "close": lambda *_: self.drop_page(page),
+            }
+            registry.callbacks = callbacks
+
+        attached: list[tuple[str, Any]] = []
+        try:
+            for event, callback in callbacks.items():
+                page.on(event, callback)
+                attached.append((event, callback))
+        except Exception:
+            for event, callback in reversed(attached):
+                try:
+                    page.remove_listener(event, callback)
+                except Exception:
+                    pass
+            self.drop_page(page)
+            raise
+        return registry
+
+    def drop_page(self, page: Any) -> None:
+        with self.event_lock:
+            registry = self.page_registries.get(id(page))
+            if registry is not None and registry.page is page:
+                self.page_registries.pop(id(page), None)
+            if self.dialog_intent is not None and self.dialog_intent.page is page:
+                self.dialog_intent = None
+            if self.page is page:
+                self.page = None
+
+    def clear(self) -> None:
+        with self.event_lock:
+            self.page_registries.clear()
+            self.dialog_intent = None
+            self.pw = None
+            self.browser = None
+            self.context = None
+            self.page = None
+            self.remote = False
+            self.next_ref = 1
+
+    def snapshot_start_ref(self) -> int:
+        with self.event_lock:
+            return self.next_ref
+
+    def record_snapshot(self, page: Any, refs: list[str], next_ref: int) -> None:
+        with self.event_lock:
+            registry = self.registry_for(page, create=True)
+            assert registry is not None
+            registry.snapshot_refs = frozenset(refs)
+            registry.snapshot_generation += 1
+            registry.snapshot_taken = True
+            self.next_ref = next_ref
+
+    def snapshot_status(self, page: Any) -> tuple[bool, frozenset[str]]:
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is None:
+                return False, frozenset()
+            return registry.snapshot_taken, registry.snapshot_refs
+
+    def arm_dialog(self, page: Any, accept: bool, prompt_text: str | None) -> None:
+        with self.event_lock:
+            self.dialog_intent = DialogIntent(page, accept, prompt_text)
+
+    def _invalidate_snapshot(self, registry: PageRegistry) -> None:
+        registry.snapshot_refs = frozenset()
+        registry.snapshot_taken = False
+
+    def _begin_navigation(self, registry: PageRegistry) -> None:
+        registry.navigation_epoch += 1
+        registry.next_request_index = 1
+        registry.navigation_pending = True
+        self._invalidate_snapshot(registry)
+
+    @staticmethod
+    def _is_main_navigation(page: Any, request: Any) -> bool:
+        try:
+            return bool(request.is_navigation_request()) and request.frame is page.main_frame
+        except Exception:
+            return False
+
+    def _on_console(self, page: Any, message: Any) -> None:
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is None:
+                return
+            registry.console_records.append(
+                ConsoleRecord(
+                    epoch=registry.navigation_epoch,
+                    message_type=str(message.type),
+                    text=str(message.text),
+                    location=_immutable_mapping(message.location),
+                )
+            )
+
+    def _on_request(self, page: Any, request: Any) -> None:
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is None:
+                return
+            if self._is_main_navigation(page, request) and not registry.navigation_pending:
+                self._begin_navigation(registry)
+            index = registry.next_request_index
+            registry.next_request_index += 1
+            record = NetworkRecord(
+                epoch=registry.navigation_epoch,
+                index=index,
+                method=str(request.method),
+                url=str(request.url),
+                resource_type=str(request.resource_type),
+                headers=_immutable_mapping(request.headers),
+                post_data=request.post_data,
+                request=request,
+            )
+            registry.network_records.append(record)
+            registry.request_keys[id(request)] = (record.epoch, record.index)
+            live_keys = {(item.epoch, item.index) for item in registry.network_records}
+            registry.request_keys = {
+                request_id: key
+                for request_id, key in registry.request_keys.items()
+                if key in live_keys
+            }
+
+    @staticmethod
+    def _request_record_position(
+        registry: PageRegistry, request: Any
+    ) -> int | None:
+        key = registry.request_keys.get(id(request))
+        if key is None:
+            return None
+        for position, record in enumerate(registry.network_records):
+            if (
+                (record.epoch, record.index) == key
+                and record.request is request
+            ):
+                return position
+        registry.request_keys.pop(id(request), None)
+        return None
+
+    def _replace_request_record(
+        self, registry: PageRegistry, request: Any, **changes: Any
+    ) -> None:
+        position = self._request_record_position(registry, request)
+        if position is not None:
+            registry.network_records[position] = replace(
+                registry.network_records[position], **changes
+            )
+
+    def _on_response(self, page: Any, response: Any) -> None:
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is None:
+                return
+            request = response.request
+            if request is None:
+                return
+            if self._request_record_position(registry, request) is None:
+                return
+            self._replace_request_record(
+                registry,
+                request,
+                response_status=(
+                    None if response.status is None else int(response.status)
+                ),
+                response_headers=_immutable_mapping(response.headers),
+                response=response,
+            )
+
+    def _on_request_failed(self, page: Any, request: Any) -> None:
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is None:
+                return
+            if self._request_record_position(registry, request) is None:
+                return
+            failure = request.failure
+            self._replace_request_record(
+                registry,
+                request,
+                failure=None if failure is None else str(failure),
+            )
+            if self._is_main_navigation(page, request):
+                registry.navigation_pending = False
+
+    def _on_file_chooser(self, page: Any, chooser: Any) -> None:
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is not None:
+                registry.pending_file_chooser = chooser
+
+    def _on_dialog(self, page: Any, dialog: Any) -> None:
+        intent: DialogIntent | None = None
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is None:
+                return
+            registry.pending_dialog = dialog
+            if self.dialog_intent is not None and self.dialog_intent.page is page:
+                intent = self.dialog_intent
+                self.dialog_intent = None
+
+        # Keep the existing arm-next behavior. An unarmed dialog remains in the
+        # pending slot for the modal tools introduced by a later change.
+        if intent is None:
+            return
+        if intent.accept:
+            dialog.accept(intent.prompt_text)
+        else:
+            dialog.dismiss()
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is not None and registry.pending_dialog is dialog:
+                registry.pending_dialog = None
+
+    def _on_download(self, page: Any, download: Any) -> None:
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is not None:
+                registry.downloads.append(
+                    DownloadRecord(
+                        epoch=registry.navigation_epoch,
+                        url=str(download.url),
+                        suggested_filename=str(download.suggested_filename),
+                        download=download,
+                    )
+                )
+
+    def _on_frame_navigated(self, page: Any, frame: Any) -> None:
+        with self.event_lock:
+            registry = self.registry_for(page)
+            if registry is None:
+                return
+            try:
+                is_main_frame = frame is page.main_frame
+            except Exception:
+                is_main_frame = False
+            if not is_main_frame:
+                return
+            if registry.navigation_pending:
+                registry.navigation_pending = False
+            else:
+                self._begin_navigation(registry)
+                registry.navigation_pending = False
+            self._invalidate_snapshot(registry)

--- a/mcp/rustwright_mcp/session.py
+++ b/mcp/rustwright_mcp/session.py
@@ -85,10 +85,11 @@ class PageRegistry:
     navigation_start_request_index: int = 1
     navigation_pending: bool = False
     last_known_title: str | None = None
-    console_evictions: dict[int, int] = field(default_factory=dict)
+    console_evictions_total: int = 0
+    console_evictions_current_epoch: int = 0
     network_evictions: dict[int, int] = field(default_factory=dict)
     pending_file_chooser: Any = field(default=None, repr=False)
-    file_chooser_retry_needed: bool = False
+    file_chooser_retry_element: Any = field(default=None, repr=False)
     pending_dialog: Any = field(default=None, repr=False)
     request_keys: dict[int, tuple[int, int]] = field(default_factory=dict, repr=False)
     callbacks: dict[str, Any] = field(default_factory=dict, repr=False)
@@ -120,6 +121,7 @@ class SessionState:
     download_saver: Callable[[Any, str], str] | None = field(
         default=None, repr=False
     )
+    context_page_callback: Any = field(default=None, repr=False)
     event_lock: threading.RLock = field(default_factory=threading.RLock, repr=False)
 
     def attach(
@@ -131,12 +133,41 @@ class SessionState:
         page: Any,
         remote: bool,
     ) -> None:
+        self._remove_context_page_handler()
         self.pw = pw
         self.browser = browser
         self.context = context
         self.page = page
         self.remote = remote
         self.next_ref = 1
+
+        callback = lambda created_page: self.register_page_handlers(created_page)
+        self.context_page_callback = callback
+        try:
+            context.on("page", callback)
+            existing_pages = list(context.pages)
+        except Exception:
+            try:
+                context.remove_listener("page", callback)
+            except Exception:
+                pass
+            self.context_page_callback = None
+            raise
+        for existing_page in existing_pages:
+            self.register_page_handlers(existing_page)
+        if not any(existing_page is page for existing_page in existing_pages):
+            self.register_page_handlers(page)
+
+    def _remove_context_page_handler(self) -> None:
+        context = self.context
+        callback = self.context_page_callback
+        self.context_page_callback = None
+        if context is None or callback is None:
+            return
+        try:
+            context.remove_listener("page", callback)
+        except Exception:
+            pass
 
     def registry_for(self, page: Any, *, create: bool = False) -> PageRegistry | None:
         key = id(page)
@@ -200,6 +231,7 @@ class SessionState:
                 self.page = None
 
     def clear(self) -> None:
+        self._remove_context_page_handler()
         with self.event_lock:
             self.page_registries.clear()
             self.pw = None
@@ -309,6 +341,9 @@ class SessionState:
         registry.navigation_epoch += 1
         registry.navigation_start_request_index = self.next_request_index
         registry.navigation_pending = True
+        registry.console_evictions_current_epoch = 0
+        registry.network_evictions.clear()
+        registry.file_chooser_retry_element = None
         self._invalidate_snapshot(registry)
 
     @staticmethod
@@ -328,9 +363,9 @@ class SessionState:
                 and len(registry.console_records) == registry.console_records.maxlen
             ):
                 evicted_epoch = registry.console_records[0].epoch
-                registry.console_evictions[evicted_epoch] = (
-                    registry.console_evictions.get(evicted_epoch, 0) + 1
-                )
+                registry.console_evictions_total += 1
+                if evicted_epoch == registry.navigation_epoch:
+                    registry.console_evictions_current_epoch += 1
             registry.console_records.append(
                 ConsoleRecord(
                     sequence=self.next_console_sequence,
@@ -366,9 +401,10 @@ class SessionState:
                 and len(registry.network_records) == registry.network_records.maxlen
             ):
                 evicted_epoch = registry.network_records[0].epoch
-                registry.network_evictions[evicted_epoch] = (
-                    registry.network_evictions.get(evicted_epoch, 0) + 1
-                )
+                if evicted_epoch == registry.navigation_epoch:
+                    registry.network_evictions[evicted_epoch] = (
+                        registry.network_evictions.get(evicted_epoch, 0) + 1
+                    )
             registry.network_records.append(record)
             registry.request_keys[id(request)] = (record.epoch, record.index)
             live_keys = {(item.epoch, item.index) for item in registry.network_records}

--- a/mcp/rustwright_mcp/snapshot.py
+++ b/mcp/rustwright_mcp/snapshot.py
@@ -1,16 +1,14 @@
-"""In-page snapshot script.
+"""In-page snapshot scripts.
 
-Produces a compact accessibility-style outline of the page and tags every
-emitted element with a ``data-mcp-ref`` attribute so tools can act on it
-later via an attribute selector. Refs increase for the lifetime of a browser
-session and are regenerated on every snapshot; acting on a ref from an older
-snapshot raises a clear error in the server.
+The page and targeted variants share one implementation. They produce a
+compact accessibility-style outline, stamp current ``data-mcp-ref`` handles,
+optionally bound traversal depth, and optionally add viewport-relative boxes.
 """
 
-SNAPSHOT_JS = r"""
-(startRef) => {
+_SNAPSHOT_BODY = r"""
   const MAX_NAME = 120;
   const MAX_LINES = 1200;
+  const {startRef, maxDepth = null, boxes = false} = options;
   let refCounter = startRef;
   const lines = [];
   const refs = [];
@@ -57,12 +55,11 @@ SNAPSHOT_JS = r"""
       const parts = labelled.split(/\s+/)
         .map((id) => document.getElementById(id))
         .filter(Boolean)
-        .map((n) => n.textContent.trim());
+        .map((node) => node.textContent.trim());
       if (parts.length) return parts.join(' ');
     }
     const ariaLabel = el.getAttribute('aria-label');
     if (ariaLabel) return ariaLabel;
-    // Associated <label> outranks placeholder/title in accessible-name order.
     if (el.labels && el.labels.length) return el.labels[0].textContent.trim();
     const direct = el.getAttribute('alt') || el.getAttribute('title')
       || el.getAttribute('placeholder');
@@ -78,24 +75,36 @@ SNAPSHOT_JS = r"""
      'slider', 'option', 'tab', 'menuitem', 'switch'].includes(role)
     || el.hasAttribute('onclick') || el.tabIndex >= 0;
 
-  const walk = (el, depth) => {
+  const enclosingBox = (rect) => {
+    if (rect.width <= 0 || rect.height <= 0) return null;
+    // Enclose fractional CSS-pixel geometry: floor the origin and ceil the far
+    // edge. This produces integer viewport-relative bounds without shrinking
+    // the rendered area.
+    const left = Math.floor(rect.left);
+    const top = Math.floor(rect.top);
+    const right = Math.ceil(rect.right);
+    const bottom = Math.ceil(rect.bottom);
+    return [left, top, right - left, bottom - top];
+  };
+
+  const walk = (el, treeDepth) => {
     if (lines.length >= MAX_LINES) return;
-    // SVG element tagNames are not uppercased; normalize before lookups.
+    if (maxDepth !== null && treeDepth > maxDepth) return;
     const tag = String(el.tagName || '').toUpperCase();
     if (SKIP_TAGS.has(tag) || el.namespaceURI === 'http://www.w3.org/2000/svg') return;
     if (!isVisible(el)) return;
     if (tag === 'IFRAME' || tag === 'FRAME') {
       const label = el.getAttribute('title') || el.getAttribute('name') || el.getAttribute('src') || '';
-      lines.push(`${'  '.repeat(depth)}- iframe "${label.slice(0, MAX_NAME)}" (content not captured)`);
+      lines.push(`${'  '.repeat(treeDepth)}- iframe "${label.slice(0, MAX_NAME)}" (content not captured)`);
       return;
     }
 
     const role = roleOf(el);
-    let emittedDepth = depth;
+    let childDepth = treeDepth;
     if (role) {
       let name = nameOf(el);
       if (name.length > MAX_NAME) name = name.slice(0, MAX_NAME) + '…';
-      const parts = [`${'  '.repeat(depth)}- ${role}`];
+      const parts = [`${'  '.repeat(treeDepth)}- ${role}`];
       if (name) parts.push(`"${name}"`);
       if (/^H[1-6]$/.test(el.tagName)) parts.push(`[level=${el.tagName[1]}]`);
       if (el.tagName === 'A' && el.href) parts.push(`[href=${el.getAttribute('href')}]`);
@@ -115,31 +124,31 @@ SNAPSHOT_JS = r"""
         refs.push(ref);
         parts.push(`[ref=${ref}]`);
       }
+      if (boxes) {
+        const box = enclosingBox(el.getBoundingClientRect());
+        if (box) parts.push(`[box=${box.join(',')}]`);
+      }
       lines.push(parts.join(' '));
-      emittedDepth = depth + 1;
-      // Named leaf: children's text is already in the name, skip descent.
+      childDepth = treeDepth + 1;
       const hasElementChildren = el.children.length > 0;
       if (!hasElementChildren || ['link', 'button', 'heading', 'option', 'label'].includes(role)) {
         return;
       }
-    } else {
-      // Text-bearing node with no element children becomes a text line.
-      if (el.children.length === 0) {
-        const text = (el.textContent || '').trim().replace(/\s+/g, ' ');
-        if (text) {
-          lines.push(`${'  '.repeat(depth)}- text: ${text.slice(0, MAX_NAME)}`);
-        }
-        return;
-      }
+    } else if (el.children.length === 0) {
+      const text = (el.textContent || '').trim().replace(/\s+/g, ' ');
+      if (text) lines.push(`${'  '.repeat(treeDepth)}- text: ${text.slice(0, MAX_NAME)}`);
+      return;
     }
-    for (const child of el.children) walk(child, emittedDepth);
+    for (const child of el.children) walk(child, childDepth);
   };
 
-  if (!document.body) {
+  if (!root) {
     return {outline: '- (page has no body yet)', nextRef: refCounter, refs};
   }
-  walk(document.body, 0);
+  walk(root, 0);
   if (lines.length >= MAX_LINES) lines.push('- … (snapshot truncated)');
   return {outline: lines.join('\n'), nextRef: refCounter, refs};
-}
 """
+
+SNAPSHOT_JS = "(options) => { const root = document.body;" + _SNAPSHOT_BODY + "}"
+TARGET_SNAPSHOT_JS = "(root, options) => {" + _SNAPSHOT_BODY + "}"

--- a/mcp/rustwright_mcp/snapshot.py
+++ b/mcp/rustwright_mcp/snapshot.py
@@ -13,6 +13,7 @@ SNAPSHOT_JS = r"""
   const MAX_LINES = 1200;
   let refCounter = startRef;
   const lines = [];
+  const refs = [];
 
   for (const el of document.querySelectorAll('[data-mcp-ref]')) {
     el.removeAttribute('data-mcp-ref');
@@ -111,6 +112,7 @@ SNAPSHOT_JS = r"""
         const ref = `e${refCounter}`;
         refCounter += 1;
         el.setAttribute('data-mcp-ref', ref);
+        refs.push(ref);
         parts.push(`[ref=${ref}]`);
       }
       lines.push(parts.join(' '));
@@ -134,10 +136,10 @@ SNAPSHOT_JS = r"""
   };
 
   if (!document.body) {
-    return {outline: '- (page has no body yet)', nextRef: refCounter};
+    return {outline: '- (page has no body yet)', nextRef: refCounter, refs};
   }
   walk(document.body, 0);
   if (lines.length >= MAX_LINES) lines.push('- … (snapshot truncated)');
-  return {outline: lines.join('\n'), nextRef: refCounter};
+  return {outline: lines.join('\n'), nextRef: refCounter, refs};
 }
 """

--- a/mcp/tests/contract/__init__.py
+++ b/mcp/tests/contract/__init__.py
@@ -1,0 +1,1 @@
+"""Clean-room MCP contract comparison tests."""

--- a/mcp/tests/contract/contract_schema.py
+++ b/mcp/tests/contract/contract_schema.py
@@ -12,30 +12,72 @@ _MISSING = object()
 
 
 @dataclass(frozen=True)
-class ParamContract:
-    name: str
+class SchemaContract:
     type: str
-    required: bool
     enum: tuple[Any, ...] | None = None
     default: Any = _MISSING
+    params: tuple["ParamContract", ...] = ()
+    items: "SchemaContract | None" = None
+    additional_properties: "SchemaContract | None" = None
 
     @classmethod
-    def from_mapping(cls, raw: Mapping[str, Any]) -> "ParamContract":
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "SchemaContract":
         return cls(
-            name=raw["name"],
             type=raw["type"],
-            required=raw["required"],
             enum=tuple(raw["enum"]) if "enum" in raw else None,
             default=raw.get("default", _MISSING),
+            params=tuple(
+                ParamContract.from_mapping(item) for item in raw.get("params", ())
+            ),
+            items=(
+                cls.from_mapping(raw["items"])
+                if "items" in raw
+                else None
+            ),
+            additional_properties=(
+                cls.from_mapping(raw["additionalProperties"])
+                if isinstance(raw.get("additionalProperties"), Mapping)
+                else None
+            ),
         )
 
     def to_mapping(self) -> dict[str, Any]:
-        raw = {"name": self.name, "type": self.type, "required": self.required}
+        raw: dict[str, Any] = {"type": self.type}
         if self.enum is not None:
             raw["enum"] = list(self.enum)
         if self.default is not _MISSING:
             raw["default"] = self.default
+        if self.params:
+            raw["params"] = [param.to_mapping() for param in self.params]
+        if self.items is not None:
+            raw["items"] = self.items.to_mapping()
+        if self.additional_properties is not None:
+            raw["additionalProperties"] = self.additional_properties.to_mapping()
         return raw
+
+
+@dataclass(frozen=True)
+class ParamContract(SchemaContract):
+    name: str = ""
+    required: bool = False
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "ParamContract":
+        shape = SchemaContract.from_mapping(raw)
+        return cls(
+            name=raw["name"],
+            required=raw["required"],
+            type=shape.type,
+            enum=shape.enum,
+            default=shape.default,
+            params=shape.params,
+            items=shape.items,
+            additional_properties=shape.additional_properties,
+        )
+
+    def to_mapping(self) -> dict[str, Any]:
+        raw = super().to_mapping()
+        return {"name": self.name, **raw, "required": self.required}
 
 
 @dataclass(frozen=True)
@@ -90,10 +132,157 @@ def _advertised_enum(schema: Mapping[str, Any]) -> list[Any] | None:
         enum = candidate.get("enum")
         if isinstance(enum, list):
             return enum
-        items = candidate.get("items")
-        if isinstance(items, Mapping) and isinstance(items.get("enum"), list):
-            return items["enum"]
     return None
+
+
+def _resolve_ref(
+    schema: Mapping[str, Any], definitions: Mapping[str, Any]
+) -> Mapping[str, Any]:
+    reference = schema.get("$ref")
+    if not isinstance(reference, str) or not reference.startswith("#/$defs/"):
+        return schema
+    name = reference.removeprefix("#/$defs/")
+    resolved = definitions.get(name)
+    return resolved if isinstance(resolved, Mapping) else schema
+
+
+def _schema_for_type(
+    schema: Mapping[str, Any], expected_type: str, definitions: Mapping[str, Any]
+) -> Mapping[str, Any]:
+    resolved = _resolve_ref(schema, definitions)
+    if resolved.get("type") == expected_type:
+        return resolved
+    for candidate in resolved.get("anyOf", ()):
+        if not isinstance(candidate, Mapping):
+            continue
+        candidate = _resolve_ref(candidate, definitions)
+        if candidate.get("type") == expected_type:
+            return candidate
+    return resolved
+
+
+def _compare_params(
+    properties: Mapping[str, Any],
+    advertised_required: set[str],
+    expected_params: tuple[ParamContract, ...],
+    definitions: Mapping[str, Any],
+    path: str,
+    errors: list[str],
+) -> None:
+    expected_by_name = {param.name: param for param in expected_params}
+    advertised_names = set(properties)
+    expected_names = set(expected_by_name)
+    missing = expected_names - advertised_names
+    unexpected = advertised_names - expected_names
+    if missing:
+        errors.append(f"{path}missing params: {sorted(missing)}")
+    if unexpected:
+        errors.append(f"{path}unexpected params: {sorted(unexpected)}")
+
+    expected_required = {
+        param.name for param in expected_params if param.required
+    }
+    if advertised_required != expected_required:
+        errors.append(
+            f"{path}required params mismatch: expected "
+            f"{sorted(expected_required)}, got {sorted(advertised_required)}"
+        )
+
+    for name in sorted(advertised_names & expected_names):
+        property_schema = properties[name]
+        if not isinstance(property_schema, Mapping):
+            errors.append(f"{path}{name} schema is not an object")
+            continue
+        _compare_shape(
+            property_schema,
+            expected_by_name[name],
+            definitions,
+            f"{path}{name}",
+            errors,
+        )
+
+
+def _compare_shape(
+    advertised: Mapping[str, Any],
+    expected: SchemaContract,
+    definitions: Mapping[str, Any],
+    path: str,
+    errors: list[str],
+) -> None:
+    resolved_advertised = _resolve_ref(advertised, definitions)
+    advertised_types = _advertised_types(resolved_advertised) - {"null"}
+    if advertised_types != {expected.type}:
+        errors.append(
+            f"type mismatch for {path}: expected {expected.type}, "
+            f"got {sorted(advertised_types)}"
+        )
+
+    advertised_enum = _advertised_enum(resolved_advertised)
+    expected_enum = None if expected.enum is None else list(expected.enum)
+    if advertised_enum != expected_enum:
+        errors.append(
+            f"enum mismatch for {path}: expected {expected_enum}, "
+            f"got {advertised_enum}"
+        )
+
+    advertised_default = advertised.get(
+        "default", resolved_advertised.get("default", _MISSING)
+    )
+    if advertised_default is None and expected.default is _MISSING:
+        advertised_default = _MISSING
+    if advertised_default != expected.default:
+        shown_expected = "<missing>" if expected.default is _MISSING else expected.default
+        shown_actual = "<missing>" if advertised_default is _MISSING else advertised_default
+        errors.append(
+            f"default mismatch for {path}: expected {shown_expected!r}, "
+            f"got {shown_actual!r}"
+        )
+
+    typed_schema = _schema_for_type(
+        resolved_advertised, expected.type, definitions
+    )
+    if expected.type == "array":
+        advertised_items = typed_schema.get("items")
+        if expected.items is None:
+            if isinstance(advertised_items, Mapping):
+                errors.append(f"unexpected items schema for {path}")
+        elif not isinstance(advertised_items, Mapping):
+            errors.append(f"missing items schema for {path}")
+        else:
+            _compare_shape(
+                advertised_items,
+                expected.items,
+                definitions,
+                f"{path}[]",
+                errors,
+            )
+
+    if expected.type == "object":
+        advertised_properties = typed_schema.get("properties", {})
+        if not isinstance(advertised_properties, Mapping):
+            advertised_properties = {}
+        _compare_params(
+            advertised_properties,
+            set(typed_schema.get("required", ())),
+            expected.params,
+            definitions,
+            f"{path}.",
+            errors,
+        )
+        advertised_additional = typed_schema.get("additionalProperties")
+        if expected.additional_properties is None:
+            if isinstance(advertised_additional, Mapping):
+                errors.append(f"unexpected additionalProperties schema for {path}")
+        elif not isinstance(advertised_additional, Mapping):
+            errors.append(f"missing additionalProperties schema for {path}")
+        else:
+            _compare_shape(
+                advertised_additional,
+                expected.additional_properties,
+                definitions,
+                f"{path}.*",
+                errors,
+            )
 
 
 def compare_tool_schema(
@@ -102,24 +291,39 @@ def compare_tool_schema(
     """Return compatibility mismatches for one advertised input schema."""
     errors: list[str] = []
     properties = advertised.get("properties", {})
-    advertised_required = set(advertised.get("required", ()))
-    fixture_required = {param.name for param in contract.params if param.required}
-    extra_required = advertised_required - fixture_required
-    if extra_required:
-        errors.append(f"unexpected required params: {sorted(extra_required)}")
+    if not isinstance(properties, Mapping):
+        return ["tool properties schema is not an object"]
+    definitions = advertised.get("$defs", {})
+    if not isinstance(definitions, Mapping):
+        definitions = {}
+    _compare_params(
+        properties,
+        set(advertised.get("required", ())),
+        contract.params,
+        definitions,
+        "",
+        errors,
+    )
+    return errors
 
-    for param in contract.params:
-        if param.name not in properties:
-            errors.append(f"missing accepted param: {param.name}")
-            continue
-        property_schema = properties[param.name]
-        if param.type not in _advertised_types(property_schema):
-            errors.append(f"type mismatch for {param.name}: expected {param.type}")
-        if param.enum is not None and _advertised_enum(property_schema) != list(param.enum):
-            errors.append(f"enum mismatch for {param.name}")
-        if (
-            param.default is not _MISSING
-            and property_schema.get("default", _MISSING) != param.default
-        ):
-            errors.append(f"default mismatch for {param.name}")
+
+def compare_tool_inventory(
+    advertised: Mapping[str, Mapping[str, Any]],
+    contract: Mapping[str, ToolContract],
+    *,
+    allowed_additions: frozenset[str] = frozenset(),
+) -> list[str]:
+    """Compare the exact tool inventory and every normalized input schema."""
+    errors: list[str] = []
+    advertised_names = set(advertised)
+    contract_names = set(contract)
+    missing = contract_names - advertised_names
+    unexpected = advertised_names - contract_names - set(allowed_additions)
+    if missing:
+        errors.append(f"missing tools: {sorted(missing)}")
+    if unexpected:
+        errors.append(f"unpinned tools: {sorted(unexpected)}")
+    for name in sorted(contract_names & advertised_names):
+        for mismatch in compare_tool_schema(advertised[name], contract[name]):
+            errors.append(f"{name}: {mismatch}")
     return errors

--- a/mcp/tests/contract/contract_schema.py
+++ b/mcp/tests/contract/contract_schema.py
@@ -82,6 +82,20 @@ def _advertised_types(schema: Mapping[str, Any]) -> set[str]:
     }
 
 
+def _advertised_enum(schema: Mapping[str, Any]) -> list[Any] | None:
+    candidates = [schema, *schema.get("anyOf", ())]
+    for candidate in candidates:
+        if not isinstance(candidate, Mapping):
+            continue
+        enum = candidate.get("enum")
+        if isinstance(enum, list):
+            return enum
+        items = candidate.get("items")
+        if isinstance(items, Mapping) and isinstance(items.get("enum"), list):
+            return items["enum"]
+    return None
+
+
 def compare_tool_schema(
     advertised: Mapping[str, Any], contract: ToolContract
 ) -> list[str]:
@@ -101,7 +115,7 @@ def compare_tool_schema(
         property_schema = properties[param.name]
         if param.type not in _advertised_types(property_schema):
             errors.append(f"type mismatch for {param.name}: expected {param.type}")
-        if param.enum is not None and property_schema.get("enum") != list(param.enum):
+        if param.enum is not None and _advertised_enum(property_schema) != list(param.enum):
             errors.append(f"enum mismatch for {param.name}")
         if (
             param.default is not _MISSING

--- a/mcp/tests/contract/contract_schema.py
+++ b/mcp/tests/contract/contract_schema.py
@@ -1,0 +1,111 @@
+"""Loader and comparator for the neutral tool-schema contract fixture."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class ParamContract:
+    name: str
+    type: str
+    required: bool
+    enum: tuple[Any, ...] | None = None
+    default: Any = _MISSING
+
+    @classmethod
+    def from_mapping(cls, raw: Mapping[str, Any]) -> "ParamContract":
+        return cls(
+            name=raw["name"],
+            type=raw["type"],
+            required=raw["required"],
+            enum=tuple(raw["enum"]) if "enum" in raw else None,
+            default=raw.get("default", _MISSING),
+        )
+
+    def to_mapping(self) -> dict[str, Any]:
+        raw = {"name": self.name, "type": self.type, "required": self.required}
+        if self.enum is not None:
+            raw["enum"] = list(self.enum)
+        if self.default is not _MISSING:
+            raw["default"] = self.default
+        return raw
+
+
+@dataclass(frozen=True)
+class ToolContract:
+    name: str
+    params: tuple[ParamContract, ...]
+
+    @classmethod
+    def from_mapping(cls, name: str, raw: Mapping[str, Any]) -> "ToolContract":
+        return cls(
+            name=name,
+            params=tuple(ParamContract.from_mapping(item) for item in raw["params"]),
+        )
+
+    def to_mapping(self) -> dict[str, Any]:
+        return {"params": [param.to_mapping() for param in self.params]}
+
+
+def load_contract(path: Path) -> dict[str, ToolContract]:
+    raw = json.loads(path.read_text())
+    if not isinstance(raw, dict):
+        raise ValueError("contract fixture must contain a tool object")
+    return {
+        name: ToolContract.from_mapping(name, tool)
+        for name, tool in raw.items()
+    }
+
+
+def dump_contract(contract: Mapping[str, ToolContract]) -> dict[str, Any]:
+    return {name: tool.to_mapping() for name, tool in contract.items()}
+
+
+def _advertised_types(schema: Mapping[str, Any]) -> set[str]:
+    declared = schema.get("type")
+    if isinstance(declared, str):
+        return {declared}
+    if isinstance(declared, list):
+        return {item for item in declared if isinstance(item, str)}
+    alternatives = schema.get("anyOf", ())
+    return {
+        item["type"]
+        for item in alternatives
+        if isinstance(item, Mapping) and isinstance(item.get("type"), str)
+    }
+
+
+def compare_tool_schema(
+    advertised: Mapping[str, Any], contract: ToolContract
+) -> list[str]:
+    """Return compatibility mismatches for one advertised input schema."""
+    errors: list[str] = []
+    properties = advertised.get("properties", {})
+    advertised_required = set(advertised.get("required", ()))
+    fixture_required = {param.name for param in contract.params if param.required}
+    extra_required = advertised_required - fixture_required
+    if extra_required:
+        errors.append(f"unexpected required params: {sorted(extra_required)}")
+
+    for param in contract.params:
+        if param.name not in properties:
+            errors.append(f"missing accepted param: {param.name}")
+            continue
+        property_schema = properties[param.name]
+        if param.type not in _advertised_types(property_schema):
+            errors.append(f"type mismatch for {param.name}: expected {param.type}")
+        if param.enum is not None and property_schema.get("enum") != list(param.enum):
+            errors.append(f"enum mismatch for {param.name}")
+        if (
+            param.default is not _MISSING
+            and property_schema.get("default", _MISSING) != param.default
+        ):
+            errors.append(f"default mismatch for {param.name}")
+    return errors

--- a/mcp/tests/contract/fixtures/default_toolset.json
+++ b/mcp/tests/contract/fixtures/default_toolset.json
@@ -1,0 +1,26 @@
+{
+  "browser_close": {
+    "params": []
+  },
+  "browser_navigate": {
+    "params": [
+      {
+        "name": "url",
+        "type": "string",
+        "required": true
+      }
+    ]
+  },
+  "browser_navigate_back": {
+    "params": []
+  },
+  "browser_press_key": {
+    "params": [
+      {
+        "name": "key",
+        "type": "string",
+        "required": true
+      }
+    ]
+  }
+}

--- a/mcp/tests/contract/fixtures/default_toolset.json
+++ b/mcp/tests/contract/fixtures/default_toolset.json
@@ -26,6 +26,14 @@
       {"name": "endTarget", "type": "string", "required": true}
     ]
   },
+  "browser_drop": {
+    "params": [
+      {"name": "element", "type": "string", "required": false},
+      {"name": "target", "type": "string", "required": true},
+      {"name": "paths", "type": "array", "required": false},
+      {"name": "data", "type": "object", "required": false}
+    ]
+  },
   "browser_evaluate": {
     "params": [
       {"name": "element", "type": "string", "required": false},

--- a/mcp/tests/contract/fixtures/default_toolset.json
+++ b/mcp/tests/contract/fixtures/default_toolset.json
@@ -11,12 +11,43 @@
   "browser_close": {
     "params": []
   },
+  "browser_console_messages": {
+    "params": [
+      {"name": "level", "type": "string", "required": false, "enum": ["error", "warning", "info", "debug"], "default": "info"},
+      {"name": "all", "type": "boolean", "required": false, "default": false},
+      {"name": "filename", "type": "string", "required": false}
+    ]
+  },
+  "browser_drag": {
+    "params": [
+      {"name": "startElement", "type": "string", "required": false},
+      {"name": "startTarget", "type": "string", "required": true},
+      {"name": "endElement", "type": "string", "required": false},
+      {"name": "endTarget", "type": "string", "required": true}
+    ]
+  },
   "browser_evaluate": {
     "params": [
       {"name": "element", "type": "string", "required": false},
       {"name": "target", "type": "string", "required": false},
       {"name": "function", "type": "string", "required": true},
       {"name": "filename", "type": "string", "required": false}
+    ]
+  },
+  "browser_file_upload": {
+    "params": [
+      {"name": "paths", "type": "array", "required": false}
+    ]
+  },
+  "browser_fill_form": {
+    "params": [
+      {"name": "fields", "type": "array", "required": true}
+    ]
+  },
+  "browser_find": {
+    "params": [
+      {"name": "text", "type": "string", "required": false},
+      {"name": "regex", "type": "string", "required": false}
     ]
   },
   "browser_handle_dialog": {
@@ -39,9 +70,29 @@
   "browser_navigate_back": {
     "params": []
   },
+  "browser_network_request": {
+    "params": [
+      {"name": "index", "type": "integer", "required": true},
+      {"name": "part", "type": "string", "required": false, "enum": ["request-headers", "request-body", "response-headers", "response-body"]},
+      {"name": "filename", "type": "string", "required": false}
+    ]
+  },
+  "browser_network_requests": {
+    "params": [
+      {"name": "static", "type": "boolean", "required": false, "default": false},
+      {"name": "filter", "type": "string", "required": false},
+      {"name": "filename", "type": "string", "required": false}
+    ]
+  },
   "browser_press_key": {
     "params": [
       {"name": "key", "type": "string", "required": true}
+    ]
+  },
+  "browser_resize": {
+    "params": [
+      {"name": "width", "type": "number", "required": true},
+      {"name": "height", "type": "number", "required": true}
     ]
   },
   "browser_select_option": {

--- a/mcp/tests/contract/fixtures/default_toolset.json
+++ b/mcp/tests/contract/fixtures/default_toolset.json
@@ -5,7 +5,7 @@
       {"name": "target", "type": "string", "required": true},
       {"name": "doubleClick", "type": "boolean", "required": false, "default": false},
       {"name": "button", "type": "string", "required": false, "enum": ["left", "right", "middle"], "default": "left"},
-      {"name": "modifiers", "type": "array", "required": false, "enum": ["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]}
+      {"name": "modifiers", "type": "array", "required": false, "items": {"type": "string", "enum": ["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]}}
     ]
   },
   "browser_close": {
@@ -30,8 +30,8 @@
     "params": [
       {"name": "element", "type": "string", "required": false},
       {"name": "target", "type": "string", "required": true},
-      {"name": "paths", "type": "array", "required": false},
-      {"name": "data", "type": "object", "required": false}
+      {"name": "paths", "type": "array", "required": false, "items": {"type": "string"}},
+      {"name": "data", "type": "object", "required": false, "additionalProperties": {"type": "string"}}
     ]
   },
   "browser_evaluate": {
@@ -44,12 +44,18 @@
   },
   "browser_file_upload": {
     "params": [
-      {"name": "paths", "type": "array", "required": false}
+      {"name": "paths", "type": "array", "required": false, "items": {"type": "string"}}
     ]
   },
   "browser_fill_form": {
     "params": [
-      {"name": "fields", "type": "array", "required": true}
+      {"name": "fields", "type": "array", "required": true, "items": {"type": "object", "params": [
+        {"name": "element", "type": "string", "required": false},
+        {"name": "target", "type": "string", "required": true},
+        {"name": "name", "type": "string", "required": true},
+        {"name": "type", "type": "string", "required": true, "enum": ["textbox", "checkbox", "radio", "combobox", "slider"]},
+        {"name": "value", "type": "string", "required": true}
+      ]}}
     ]
   },
   "browser_find": {
@@ -64,6 +70,12 @@
       {"name": "promptText", "type": "string", "required": false}
     ]
   },
+  "browser_get_text": {
+    "params": [
+      {"name": "selector", "type": "string", "required": false, "default": "body"},
+      {"name": "max_chars", "type": "integer", "required": false, "default": 20000}
+    ]
+  },
   "browser_hover": {
     "params": [
       {"name": "element", "type": "string", "required": false},
@@ -76,6 +88,9 @@
     ]
   },
   "browser_navigate_back": {
+    "params": []
+  },
+  "browser_reload": {
     "params": []
   },
   "browser_network_request": {
@@ -107,7 +122,7 @@
     "params": [
       {"name": "element", "type": "string", "required": false},
       {"name": "target", "type": "string", "required": true},
-      {"name": "values", "type": "array", "required": true}
+      {"name": "values", "type": "array", "required": true, "items": {"type": "string"}}
     ]
   },
   "browser_snapshot": {
@@ -115,7 +130,7 @@
       {"name": "target", "type": "string", "required": false},
       {"name": "filename", "type": "string", "required": false},
       {"name": "depth", "type": "number", "required": false},
-      {"name": "boxes", "type": "boolean", "required": false}
+      {"name": "boxes", "type": "boolean", "required": false, "default": false}
     ]
   },
   "browser_tabs": {
@@ -141,14 +156,16 @@
       {"name": "target", "type": "string", "required": true},
       {"name": "text", "type": "string", "required": true},
       {"name": "submit", "type": "boolean", "required": false, "default": false},
-      {"name": "slowly", "type": "boolean", "required": false, "default": false}
+      {"name": "slowly", "type": "boolean", "required": false, "default": false},
+      {"name": "clear", "type": "boolean", "required": false, "default": true}
     ]
   },
   "browser_wait_for": {
     "params": [
       {"name": "time", "type": "number", "required": false},
       {"name": "text", "type": "string", "required": false},
-      {"name": "textGone", "type": "string", "required": false}
+      {"name": "textGone", "type": "string", "required": false},
+      {"name": "timeout_ms", "type": "number", "required": false, "default": 10000}
     ]
   }
 }

--- a/mcp/tests/contract/fixtures/default_toolset.json
+++ b/mcp/tests/contract/fixtures/default_toolset.json
@@ -1,14 +1,39 @@
 {
+  "browser_click": {
+    "params": [
+      {"name": "element", "type": "string", "required": false},
+      {"name": "target", "type": "string", "required": true},
+      {"name": "doubleClick", "type": "boolean", "required": false, "default": false},
+      {"name": "button", "type": "string", "required": false, "enum": ["left", "right", "middle"], "default": "left"},
+      {"name": "modifiers", "type": "array", "required": false, "enum": ["Alt", "Control", "ControlOrMeta", "Meta", "Shift"]}
+    ]
+  },
   "browser_close": {
     "params": []
   },
+  "browser_evaluate": {
+    "params": [
+      {"name": "element", "type": "string", "required": false},
+      {"name": "target", "type": "string", "required": false},
+      {"name": "function", "type": "string", "required": true},
+      {"name": "filename", "type": "string", "required": false}
+    ]
+  },
+  "browser_handle_dialog": {
+    "params": [
+      {"name": "accept", "type": "boolean", "required": true},
+      {"name": "promptText", "type": "string", "required": false}
+    ]
+  },
+  "browser_hover": {
+    "params": [
+      {"name": "element", "type": "string", "required": false},
+      {"name": "target", "type": "string", "required": true}
+    ]
+  },
   "browser_navigate": {
     "params": [
-      {
-        "name": "url",
-        "type": "string",
-        "required": true
-      }
+      {"name": "url", "type": "string", "required": true}
     ]
   },
   "browser_navigate_back": {
@@ -16,11 +41,55 @@
   },
   "browser_press_key": {
     "params": [
-      {
-        "name": "key",
-        "type": "string",
-        "required": true
-      }
+      {"name": "key", "type": "string", "required": true}
+    ]
+  },
+  "browser_select_option": {
+    "params": [
+      {"name": "element", "type": "string", "required": false},
+      {"name": "target", "type": "string", "required": true},
+      {"name": "values", "type": "array", "required": true}
+    ]
+  },
+  "browser_snapshot": {
+    "params": [
+      {"name": "target", "type": "string", "required": false},
+      {"name": "filename", "type": "string", "required": false},
+      {"name": "depth", "type": "number", "required": false},
+      {"name": "boxes", "type": "boolean", "required": false}
+    ]
+  },
+  "browser_tabs": {
+    "params": [
+      {"name": "action", "type": "string", "required": true, "enum": ["list", "new", "close", "select"]},
+      {"name": "index", "type": "integer", "required": false},
+      {"name": "url", "type": "string", "required": false}
+    ]
+  },
+  "browser_take_screenshot": {
+    "params": [
+      {"name": "element", "type": "string", "required": false},
+      {"name": "target", "type": "string", "required": false},
+      {"name": "type", "type": "string", "required": false, "enum": ["png", "jpeg"], "default": "png"},
+      {"name": "filename", "type": "string", "required": false},
+      {"name": "fullPage", "type": "boolean", "required": false, "default": false},
+      {"name": "scale", "type": "string", "required": false, "enum": ["css", "device"], "default": "css"}
+    ]
+  },
+  "browser_type": {
+    "params": [
+      {"name": "element", "type": "string", "required": false},
+      {"name": "target", "type": "string", "required": true},
+      {"name": "text", "type": "string", "required": true},
+      {"name": "submit", "type": "boolean", "required": false, "default": false},
+      {"name": "slowly", "type": "boolean", "required": false, "default": false}
+    ]
+  },
+  "browser_wait_for": {
+    "params": [
+      {"name": "time", "type": "number", "required": false},
+      {"name": "text", "type": "string", "required": false},
+      {"name": "textGone", "type": "string", "required": false}
     ]
   }
 }

--- a/mcp/tests/contract/test_contract.py
+++ b/mcp/tests/contract/test_contract.py
@@ -1,0 +1,64 @@
+"""Compatibility checks for the clean-room default tool contract."""
+
+import asyncio
+import json
+from pathlib import Path
+
+from rustwright_mcp.server import mcp
+
+from contract.contract_schema import (
+    ParamContract,
+    ToolContract,
+    compare_tool_schema,
+    dump_contract,
+    load_contract,
+)
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "default_toolset.json"
+
+
+def test_default_toolset_contract():
+    contract = load_contract(FIXTURE)
+    advertised = {
+        tool.name: tool.inputSchema for tool in asyncio.run(mcp.list_tools())
+    }
+
+    for name, tool_contract in contract.items():
+        assert name in advertised
+        assert compare_tool_schema(advertised[name], tool_contract) == []
+
+
+def test_contract_fixture_round_trip():
+    contract = load_contract(FIXTURE)
+    assert dump_contract(contract) == json.loads(FIXTURE.read_text())
+
+
+def test_deliberate_contract_mismatch_is_reported():
+    contract = ToolContract(
+        name="example_tool",
+        params=(
+            ParamContract(
+                name="action",
+                type="string",
+                required=False,
+                enum=("one", "two"),
+                default="one",
+            ),
+        ),
+    )
+    advertised = {
+        "type": "object",
+        "properties": {
+            "action": {"type": "integer", "enum": ["one"], "default": "two"},
+            "extra": {"type": "string"},
+        },
+        "required": ["extra"],
+    }
+
+    assert compare_tool_schema(advertised, contract) == [
+        "unexpected required params: ['extra']",
+        "type mismatch for action: expected string",
+        "enum mismatch for action",
+        "default mismatch for action",
+    ]

--- a/mcp/tests/contract/test_contract.py
+++ b/mcp/tests/contract/test_contract.py
@@ -8,7 +8,9 @@ from rustwright_mcp.server import mcp
 
 from contract.contract_schema import (
     ParamContract,
+    SchemaContract,
     ToolContract,
+    compare_tool_inventory,
     compare_tool_schema,
     dump_contract,
     load_contract,
@@ -16,6 +18,7 @@ from contract.contract_schema import (
 
 
 FIXTURE = Path(__file__).parent / "fixtures" / "default_toolset.json"
+INTENTIONAL_TOOL_ADDITIONS: frozenset[str] = frozenset()
 
 
 def test_default_toolset_contract():
@@ -24,9 +27,11 @@ def test_default_toolset_contract():
         tool.name: tool.inputSchema for tool in asyncio.run(mcp.list_tools())
     }
 
-    for name, tool_contract in contract.items():
-        assert name in advertised
-        assert compare_tool_schema(advertised[name], tool_contract) == []
+    assert compare_tool_inventory(
+        advertised,
+        contract,
+        allowed_additions=INTENTIONAL_TOOL_ADDITIONS,
+    ) == []
 
 
 def test_contract_fixture_round_trip():
@@ -34,7 +39,7 @@ def test_contract_fixture_round_trip():
     assert dump_contract(contract) == json.loads(FIXTURE.read_text())
 
 
-def test_comparator_allows_required_subset_and_accepted_superset():
+def test_comparator_rejects_optional_superset_and_required_drift():
     contract = ToolContract(
         name="example_tool",
         params=(ParamContract(name="target", type="string", required=True),),
@@ -48,7 +53,46 @@ def test_comparator_allows_required_subset_and_accepted_superset():
         "required": [],
     }
 
-    assert compare_tool_schema(advertised, contract) == []
+    assert compare_tool_schema(advertised, contract) == [
+        "unexpected params: ['extension']",
+        "required params mismatch: expected ['target'], got []",
+    ]
+
+
+def test_inventory_rejects_unpinned_tool():
+    contract = {
+        "pinned": ToolContract(name="pinned", params=()),
+    }
+    empty_schema = {"type": "object", "properties": {}}
+
+    assert compare_tool_inventory(
+        {"pinned": empty_schema, "silent_addition": empty_schema}, contract
+    ) == ["unpinned tools: ['silent_addition']"]
+
+
+def test_comparator_rejects_nested_schema_change():
+    contract = ToolContract(
+        name="nested",
+        params=(
+            ParamContract(
+                name="items",
+                type="array",
+                required=True,
+                items=SchemaContract(type="string"),
+            ),
+        ),
+    )
+    advertised = {
+        "type": "object",
+        "properties": {
+            "items": {"type": "array", "items": {"type": "integer"}},
+        },
+        "required": ["items"],
+    }
+
+    assert compare_tool_schema(advertised, contract) == [
+        "type mismatch for items[]: expected string, got ['integer']"
+    ]
 
 
 def test_deliberate_contract_mismatch_is_reported():
@@ -73,9 +117,11 @@ def test_deliberate_contract_mismatch_is_reported():
         "required": ["extra"],
     }
 
-    assert compare_tool_schema(advertised, contract) == [
-        "unexpected required params: ['extra']",
-        "type mismatch for action: expected string",
-        "enum mismatch for action",
-        "default mismatch for action",
-    ]
+    errors = compare_tool_schema(advertised, contract)
+    assert "unexpected params: ['extra']" in errors
+    assert (
+        "required params mismatch: expected [], got ['extra']" in errors
+    )
+    assert "type mismatch for action: expected string, got ['integer']" in errors
+    assert "enum mismatch for action: expected ['one', 'two'], got ['one']" in errors
+    assert "default mismatch for action: expected 'one', got 'two'" in errors

--- a/mcp/tests/contract/test_contract.py
+++ b/mcp/tests/contract/test_contract.py
@@ -34,6 +34,23 @@ def test_contract_fixture_round_trip():
     assert dump_contract(contract) == json.loads(FIXTURE.read_text())
 
 
+def test_comparator_allows_required_subset_and_accepted_superset():
+    contract = ToolContract(
+        name="example_tool",
+        params=(ParamContract(name="target", type="string", required=True),),
+    )
+    advertised = {
+        "type": "object",
+        "properties": {
+            "target": {"type": "string"},
+            "extension": {"type": "boolean", "default": False},
+        },
+        "required": [],
+    }
+
+    assert compare_tool_schema(advertised, contract) == []
+
+
 def test_deliberate_contract_mismatch_is_reported():
     contract = ToolContract(
         name="example_tool",

--- a/mcp/tests/fixtures/drop_conformance.html
+++ b/mcp/tests/fixtures/drop_conformance.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Drop Conformance</title>
+  <style>
+    .dropzone { border: 1px solid #444; margin: 8px; min-height: 36px; padding: 8px; }
+    #results { white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <main>
+    <div id="standard" class="dropzone">Standard HTML5 dropzone</div>
+    <div id="trust" class="dropzone">Event trust dropzone</div>
+    <div id="items" class="dropzone">Types and items dropzone</div>
+    <div id="framework" class="dropzone">Framework-style dropzone</div>
+    <pre id="results"></pre>
+  </main>
+  <script>
+    const observed = {
+      a: {events: [], files: [], data: {}, status: "pending"},
+      b: {isTrusted: {}},
+      c: {types: [], items: []},
+      d: {events: [], dragoverPrevented: false, accepted: false, value: null},
+    };
+    const results = document.querySelector("#results");
+    const render = () => { results.textContent = JSON.stringify(observed); };
+    const readFile = (file) => new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.addEventListener("load", () => resolve(String(reader.result)));
+      reader.addEventListener("error", () => reject(reader.error));
+      reader.readAsText(file);
+    });
+
+    const standard = document.querySelector("#standard");
+    standard.addEventListener("dragenter", () => {
+      observed.a.events.push("dragenter");
+      render();
+    });
+    standard.addEventListener("dragover", (event) => {
+      event.preventDefault();
+      observed.a.events.push("dragover");
+      render();
+    });
+    standard.addEventListener("drop", async (event) => {
+      event.preventDefault();
+      observed.a.events.push("drop");
+      observed.a.data = {
+        "text/plain": event.dataTransfer.getData("text/plain"),
+        "application/x-conformance": event.dataTransfer.getData("application/x-conformance"),
+      };
+      observed.a.files = await Promise.all(
+        Array.from(event.dataTransfer.files, async (file) => ({
+          name: file.name,
+          size: file.size,
+          type: file.type,
+          content: await readFile(file),
+        }))
+      );
+      observed.a.status = "done";
+      render();
+    });
+
+    const trust = document.querySelector("#trust");
+    for (const type of ["dragenter", "dragover", "drop"]) {
+      trust.addEventListener(type, (event) => {
+        if (type === "dragover") event.preventDefault();
+        observed.b.isTrusted[type] = event.isTrusted;
+        render();
+      });
+    }
+
+    const items = document.querySelector("#items");
+    items.addEventListener("dragover", (event) => event.preventDefault());
+    items.addEventListener("drop", (event) => {
+      event.preventDefault();
+      observed.c.types = Array.from(event.dataTransfer.types);
+      observed.c.items = Array.from(event.dataTransfer.items, (item) => ({
+        kind: item.kind,
+        type: item.type,
+      }));
+      render();
+    });
+
+    const framework = document.querySelector("#framework");
+    framework.addEventListener("dragenter", () => {
+      observed.d.events.push("dragenter");
+      render();
+    });
+    framework.addEventListener("dragover", (event) => {
+      event.preventDefault();
+      observed.d.events.push("dragover");
+      observed.d.dragoverPrevented = event.defaultPrevented;
+      render();
+    });
+    framework.addEventListener("drop", (event) => {
+      observed.d.events.push("drop");
+      if (observed.d.dragoverPrevented) {
+        event.preventDefault();
+        observed.d.accepted = true;
+        observed.d.value = event.dataTransfer.getData("text/plain");
+      }
+      render();
+    });
+
+    render();
+  </script>
+</body>
+</html>

--- a/mcp/tests/fixtures/pr3.html
+++ b/mcp/tests/fixtures/pr3.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>PR3 Compatibility</title>
+  <link rel="stylesheet" href="/static.css">
+</head>
+<body>
+  <main>
+    <h1>PR3 fixture</h1>
+    <p id="responsive">wide layout</p>
+
+    <form id="all-fields">
+      <label for="text-field">Text field</label>
+      <input id="text-field" type="text">
+      <label for="check-field">Check field</label>
+      <input id="check-field" type="checkbox">
+      <label for="radio-field">Radio field</label>
+      <input id="radio-field" name="choice" type="radio">
+      <label for="combo-field">Combo field</label>
+      <select id="combo-field">
+        <option value="small-value">Small label</option>
+        <option value="large-value">Large label</option>
+      </select>
+      <label for="slider-field">Slider field</label>
+      <input id="slider-field" type="range" min="0" max="100" value="10">
+    </form>
+
+    <section id="find-root">
+      <h2>Find region</h2>
+      <button id="find-before">Before match</button>
+      <button id="find-match">Unique Needle</button>
+      <button id="find-after">After match</button>
+    </section>
+
+    <div id="drag-source" draggable="true">Drag source</div>
+    <div id="drag-target">Drag target</div>
+    <p id="drag-result">not dropped</p>
+
+    <button id="alert" onclick="alert('alert message')">Open alert</button>
+    <button id="confirm" onclick="window.confirmResult = confirm('confirm message')">Open confirm</button>
+    <button id="prompt" onclick="window.promptResult = prompt('prompt message', 'default')">Open prompt</button>
+
+    <input id="upload" type="file">
+    <p id="upload-result">no upload</p>
+    <a id="download" href="/download" download>Download artifact</a>
+  </main>
+  <script>
+    console.error('console-error');
+    console.warn('console-warning');
+    console.info('console-info');
+    console.debug('console-debug');
+    fetch('/api/get');
+    fetch('/api/post', {method: 'POST', headers: {'Content-Type': 'text/plain'}, body: 'posted-body'});
+
+    document.getElementById('drag-source').addEventListener('dragstart', (event) => {
+      event.dataTransfer.setData('text/plain', 'dragged');
+    });
+    document.getElementById('drag-target').addEventListener('dragover', (event) => event.preventDefault());
+    document.getElementById('drag-target').addEventListener('drop', (event) => {
+      event.preventDefault();
+      document.getElementById('drag-result').textContent = event.dataTransfer.getData('text/plain');
+    });
+    document.getElementById('upload').addEventListener('change', (event) => {
+      document.getElementById('upload-result').textContent = event.target.files[0]?.name || 'cancelled';
+    });
+  </script>
+</body>
+</html>

--- a/mcp/tests/fixtures/static.css
+++ b/mcp/tests/fixtures/static.css
@@ -1,0 +1,3 @@
+body { font-family: sans-serif; }
+#drag-source, #drag-target { border: 1px solid black; margin: 8px; padding: 12px; }
+@media (max-width: 500px) { #responsive { font-size: 10px; } }

--- a/mcp/tests/test_cdp.py
+++ b/mcp/tests/test_cdp.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from rustwright.sync_api import sync_playwright
 
-from test_smoke import _call, _run_session
+from test_smoke import _call, _result_section, _run_session
 
 FIXTURE = Path(__file__).parent / "fixtures" / "form.html"
 
@@ -20,14 +20,17 @@ def test_stdio_connects_over_cdp():
 
         async def checks(session):
             snap = await _call(session, "browser_navigate", url=FIXTURE.as_uri())
-            assert snap.startswith("Page: Form Test")
+            assert "- Title: Form Test" in snap
+            assert "### Snapshot" in snap
             assert "Customer name" in snap
 
             snap = await _call(session, "browser_snapshot")
-            assert snap.startswith("Page: Form Test")
+            assert "- Title: Form Test" in snap
             assert "Place order" in snap
 
-            assert await _call(session, "browser_close") == "Browser closed."
+            assert _result_section(await _call(session, "browser_close")) == (
+                "Browser closed."
+            )
 
         try:
             asyncio.run(

--- a/mcp/tests/test_cdp.py
+++ b/mcp/tests/test_cdp.py
@@ -1,0 +1,75 @@
+"""Real stdio tests for remote CDP browser sessions."""
+
+import asyncio
+from pathlib import Path
+
+from rustwright.sync_api import sync_playwright
+
+from test_smoke import _call, _run_session
+
+FIXTURE = Path(__file__).parent / "fixtures" / "form.html"
+
+
+def test_stdio_connects_over_cdp():
+    with sync_playwright() as playwright:
+        remote_browser = playwright.chromium.launch(
+            headless=True,
+            args=["--remote-debugging-port=0"],
+        )
+        endpoint = remote_browser._ws_endpoint
+
+        async def checks(session):
+            snap = await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+            assert snap.startswith("Page: Form Test")
+            assert "Customer name" in snap
+
+            snap = await _call(session, "browser_snapshot")
+            assert snap.startswith("Page: Form Test")
+            assert "Place order" in snap
+
+            assert await _call(session, "browser_close") == "Browser closed."
+
+        try:
+            asyncio.run(
+                _run_session(
+                    checks,
+                    {
+                        "RUSTWRIGHT_MCP_CDP_ENDPOINT": endpoint,
+                        "RUSTWRIGHT_MCP_CDP_HEADERS": '{"x-test":"rustwright-mcp"}',
+                        "RUSTWRIGHT_MCP_CDP_TIMEOUT_MS": "10000",
+                    },
+                )
+            )
+            assert remote_browser.is_connected()
+        finally:
+            remote_browser.close()
+
+
+def test_dead_cdp_endpoint_fails_without_local_fallback():
+    endpoint = "ws://127.0.0.1:1/devtools/browser/nope"
+    header_value = "not-a-real-secret"
+
+    async def checks(session):
+        result = await session.call_tool("browser_snapshot", {})
+        text = "\n".join(c.text for c in result.content if c.type == "text")
+
+        assert result.isError
+        assert "Remote CDP browser is unreachable" in text
+        assert "Failed to launch chromium" not in text
+        assert "Page:" not in text
+        assert endpoint not in text
+        assert header_value not in text
+
+    asyncio.run(
+        _run_session(
+            checks,
+            {
+                "RUSTWRIGHT_MCP_CDP_ENDPOINT": endpoint,
+                "RUSTWRIGHT_MCP_CDP_HEADERS": (
+                    '{"Authorization":"' + header_value + '"}'
+                ),
+                "RUSTWRIGHT_MCP_CDP_TIMEOUT_MS": "1000",
+                "RUSTWRIGHT_MCP_EXECUTABLE": "/not/a/browser",
+            },
+        )
+    )

--- a/mcp/tests/test_filepolicy.py
+++ b/mcp/tests/test_filepolicy.py
@@ -102,6 +102,31 @@ def test_per_file_cap_and_oldest_first_total_eviction(tmp_path):
     assert not too_large.exists()
 
 
+def test_existing_configured_root_file_is_never_evicted_or_chmodded(
+    monkeypatch, tmp_path
+):
+    root = tmp_path / "existing-output"
+    root.mkdir(mode=0o755)
+    os.chmod(root, 0o755)
+    preexisting = root / "unrelated.txt"
+    preexisting.write_text("keep this unrelated file")
+    monkeypatch.setenv("RUSTWRIGHT_MCP_OUTPUT_DIR", str(root))
+    policy = FilePolicy(max_file_bytes=4, max_total_bytes=6)
+
+    old = policy.reserve_output("old.bin")
+    old.write_bytes(b"1234")
+    policy.finalize_output(old)
+    os.utime(old, ns=(1, 1))
+    new = policy.reserve_output("new.bin")
+    new.write_bytes(b"5678")
+    policy.finalize_output(new)
+
+    assert not old.exists()
+    assert new.exists()
+    assert preexisting.read_text() == "keep this unrelated file"
+    assert stat.S_IMODE(root.stat().st_mode) == 0o755
+
+
 def test_screenshot_policy_error_and_no_path_artifact(monkeypatch, tmp_path):
     policy = FilePolicy(output_root=tmp_path / "output")
     monkeypatch.setattr(server, "get_file_policy", lambda: policy)

--- a/mcp/tests/test_filepolicy.py
+++ b/mcp/tests/test_filepolicy.py
@@ -1,0 +1,166 @@
+"""Tests for confined MCP file inputs and outputs."""
+
+import asyncio
+import os
+from pathlib import Path
+import stat
+
+import pytest
+
+from rustwright_mcp.filepolicy import FilePolicy, FilePolicyError
+from rustwright_mcp import server
+from test_smoke import FIXTURE, _call, _run_session
+
+
+class StaticRoots:
+    def __init__(self, *roots):
+        self._roots = roots
+
+    def roots(self):
+        return self._roots
+
+
+def test_output_containment_exclusive_create_and_permissions(tmp_path):
+    root = tmp_path / "output"
+    policy = FilePolicy(output_root=root)
+    outside = tmp_path / "outside.png"
+
+    with pytest.raises(FilePolicyError) as error:
+        policy.reserve_output(str(outside), purpose="screenshot")
+    assert str(error.value) == (
+        f"screenshot paths are confined to RUSTWRIGHT_MCP_OUTPUT_DIR "
+        f"({root}); got {outside}"
+    )
+
+    output = policy.reserve_output("nested/capture.png", purpose="screenshot")
+    assert output == root / "nested" / "capture.png"
+    assert stat.S_IMODE(root.stat().st_mode) == 0o700
+    assert stat.S_IMODE(output.stat().st_mode) == 0o600
+    with pytest.raises(FilePolicyError, match="already exists"):
+        policy.reserve_output("nested/capture.png", purpose="screenshot")
+
+
+def test_output_rejects_symlink_parent(tmp_path):
+    root = tmp_path / "output"
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    policy = FilePolicy(output_root=root)
+    (root / "linked").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(FilePolicyError, match="confined"):
+        policy.reserve_output("linked/capture.png", purpose="screenshot")
+    assert not (outside / "capture.png").exists()
+
+
+def test_input_requires_allowed_regular_non_symlink_file(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source = workspace / "upload.txt"
+    source.write_text("content")
+    policy = FilePolicy(
+        output_root=tmp_path / "output",
+        roots_provider=StaticRoots(workspace),
+    )
+
+    assert policy.validate_input(source) == source
+    with pytest.raises(FilePolicyError, match="absolute"):
+        policy.validate_input(Path("upload.txt"))
+
+    link = workspace / "link.txt"
+    link.symlink_to(source)
+    with pytest.raises(FilePolicyError, match="must not be a symlink"):
+        policy.validate_input(link)
+
+    outside = tmp_path / "outside.txt"
+    outside.write_text("content")
+    with pytest.raises(FilePolicyError, match="outside the allowed workspace"):
+        policy.validate_input(outside)
+
+
+def test_per_file_cap_and_oldest_first_total_eviction(tmp_path):
+    policy = FilePolicy(
+        output_root=tmp_path / "output",
+        max_file_bytes=4,
+        max_total_bytes=6,
+    )
+    old = policy.reserve_output("old.bin")
+    old.write_bytes(b"1234")
+    policy.finalize_output(old)
+    os.utime(old, ns=(1, 1))
+
+    new = policy.reserve_output("new.bin")
+    new.write_bytes(b"5678")
+    assert policy.finalize_output(new) == "new.bin"
+    assert not old.exists()
+    assert new.exists()
+
+    too_large = policy.reserve_output("large.bin")
+    too_large.write_bytes(b"12345")
+    with pytest.raises(FilePolicyError, match="per-file cap"):
+        policy.finalize_output(too_large)
+    assert not too_large.exists()
+
+
+def test_screenshot_policy_error_and_no_path_artifact(monkeypatch, tmp_path):
+    policy = FilePolicy(output_root=tmp_path / "output")
+    monkeypatch.setattr(server, "get_file_policy", lambda: policy)
+
+    outside = tmp_path / "outside.png"
+    with pytest.raises(FilePolicyError) as error:
+        server.browser_take_screenshot(path=str(outside))
+    assert str(error.value) == (
+        f"screenshot paths are confined to RUSTWRIGHT_MCP_OUTPUT_DIR "
+        f"({policy.output_root}); got {outside}"
+    )
+
+    class FakePage:
+        def screenshot(self, *, path, full_page):
+            Path(path).write_bytes(b"PNG")
+
+    monkeypatch.setattr(server, "_page", lambda: FakePage())
+    artifact = server.browser_take_screenshot()
+    assert not Path(artifact).is_absolute()
+    assert (policy.output_root / artifact).read_bytes() == b"PNG"
+
+
+def test_stdio_screenshot_outside_root_is_structured_error(tmp_path):
+    output_root = tmp_path / "output"
+    outside = tmp_path / "outside.png"
+
+    async def checks(session):
+        result = await session.call_tool(
+            "browser_take_screenshot", {"path": str(outside)}
+        )
+        text = "\n".join(item.text for item in result.content if item.type == "text")
+        assert result.isError
+        assert (
+            f"screenshot paths are confined to RUSTWRIGHT_MCP_OUTPUT_DIR "
+            f"({output_root}); got {outside}"
+        ) in text
+
+    asyncio.run(
+        _run_session(
+            checks,
+            {"RUSTWRIGHT_MCP_OUTPUT_DIR": str(output_root)},
+        )
+    )
+
+
+def test_stdio_screenshot_without_path_stays_in_output_root(tmp_path):
+    output_root = tmp_path / "output"
+
+    async def checks(session):
+        await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+        artifact = await _call(session, "browser_take_screenshot")
+        assert not Path(artifact).is_absolute()
+        screenshot = output_root / artifact
+        assert screenshot.read_bytes().startswith(b"\x89PNG")
+        assert stat.S_IMODE(screenshot.stat().st_mode) == 0o600
+        await _call(session, "browser_close")
+
+    asyncio.run(
+        _run_session(
+            checks,
+            {"RUSTWRIGHT_MCP_OUTPUT_DIR": str(output_root)},
+        )
+    )

--- a/mcp/tests/test_filepolicy.py
+++ b/mcp/tests/test_filepolicy.py
@@ -3,6 +3,7 @@
 import asyncio
 import os
 from pathlib import Path
+import re
 import stat
 
 import pytest
@@ -107,18 +108,19 @@ def test_screenshot_policy_error_and_no_path_artifact(monkeypatch, tmp_path):
 
     outside = tmp_path / "outside.png"
     with pytest.raises(FilePolicyError) as error:
-        server.browser_take_screenshot(path=str(outside))
+        server.browser_take_screenshot(filename=str(outside))
     assert str(error.value) == (
         f"screenshot paths are confined to RUSTWRIGHT_MCP_OUTPUT_DIR "
         f"({policy.output_root}); got {outside}"
     )
 
     class FakePage:
-        def screenshot(self, *, path, full_page):
+        def screenshot(self, *, path, full_page, type, scale):
             Path(path).write_bytes(b"PNG")
 
     monkeypatch.setattr(server, "_page", lambda: FakePage())
-    artifact = server.browser_take_screenshot()
+    response = server.browser_take_screenshot()
+    artifact = re.search(r"`([^`]+)`", response).group(1)
     assert not Path(artifact).is_absolute()
     assert (policy.output_root / artifact).read_bytes() == b"PNG"
 
@@ -151,7 +153,8 @@ def test_stdio_screenshot_without_path_stays_in_output_root(tmp_path):
 
     async def checks(session):
         await _call(session, "browser_navigate", url=FIXTURE.as_uri())
-        artifact = await _call(session, "browser_take_screenshot")
+        response = await _call(session, "browser_take_screenshot")
+        artifact = re.search(r"`([^`]+)`", response).group(1)
         assert not Path(artifact).is_absolute()
         screenshot = output_root / artifact
         assert screenshot.read_bytes().startswith(b"\x89PNG")

--- a/mcp/tests/test_hardening.py
+++ b/mcp/tests/test_hardening.py
@@ -82,16 +82,15 @@ def test_browser_tabs_and_dialog_policy():
         assert "1: Hardening Test" in tabs
         await _call(session, "browser_tabs", action="close", index=1)
 
+        pending = await _call(session, "browser_click", target="#prompt")
+        assert "### Modal" in pending
         confirmation = await _call(
             session,
             "browser_handle_dialog",
             accept=True,
             prompt_text="Rustwright",
         )
-        assert _result_section(confirmation) == (
-            "The next dialog on the active page will be accepted."
-        )
-        await _call(session, "browser_click", target="#prompt")
+        assert _result_section(confirmation) == "Accepted the pending dialog."
         assert _result_section(
             await _call(session, "browser_get_text", selector="#out")
         ) == "Rustwright"

--- a/mcp/tests/test_hardening.py
+++ b/mcp/tests/test_hardening.py
@@ -4,7 +4,7 @@ import asyncio
 import re
 from pathlib import Path
 
-from test_smoke import _call, _run_session
+from test_smoke import _call, _result_section, _run_session
 
 FIXTURE = Path(__file__).parent / "fixtures" / "hardening.html"
 
@@ -40,18 +40,18 @@ def test_snapshot_refs_are_never_reused():
     asyncio.run(_run_session(checks))
 
 
-def test_browser_evaluate_registration_is_opt_in():
+def test_browser_evaluate_is_default_on_and_explicitly_disableable():
     async def check_default(session):
-        tools = {t.name for t in (await session.list_tools()).tools}
-        assert "browser_evaluate" not in tools
-
-    async def check_enabled(session):
         tools = {t.name for t in (await session.list_tools()).tools}
         assert "browser_evaluate" in tools
 
+    async def check_disabled(session):
+        tools = {t.name for t in (await session.list_tools()).tools}
+        assert "browser_evaluate" not in tools
+
     asyncio.run(_run_session(check_default))
     asyncio.run(
-        _run_session(check_enabled, {"RUSTWRIGHT_MCP_ALLOW_EVAL": "1"})
+        _run_session(check_disabled, {"RUSTWRIGHT_MCP_ALLOW_EVAL": "0"})
     )
 
 
@@ -59,7 +59,8 @@ def test_browser_reload_returns_snapshot():
     async def checks(session):
         await _call(session, "browser_navigate", url=FIXTURE.as_uri())
         snap = await _call(session, "browser_reload")
-        assert snap.startswith("Page: Hardening Test")
+        assert "- Title: Hardening Test" in snap
+        assert "### Snapshot" in snap
         assert "SECRET_PW" not in snap
         await _call(session, "browser_close")
 
@@ -75,7 +76,8 @@ def test_browser_tabs_and_dialog_policy():
         snap = await _call(
             session, "browser_tabs", action="new", url=FIXTURE.as_uri()
         )
-        assert snap.startswith("Page: Hardening Test")
+        assert "- Title: Hardening Test" in snap
+        assert "### Tabs" in snap
         tabs = await _call(session, "browser_tabs", action="list")
         assert "1: Hardening Test" in tabs
         await _call(session, "browser_tabs", action="close", index=1)
@@ -86,9 +88,13 @@ def test_browser_tabs_and_dialog_policy():
             accept=True,
             prompt_text="Rustwright",
         )
-        assert confirmation == "The next dialog on the active page will be accepted."
+        assert _result_section(confirmation) == (
+            "The next dialog on the active page will be accepted."
+        )
         await _call(session, "browser_click", target="#prompt")
-        assert await _call(session, "browser_get_text", selector="#out") == "Rustwright"
+        assert _result_section(
+            await _call(session, "browser_get_text", selector="#out")
+        ) == "Rustwright"
         await _call(session, "browser_close")
 
     asyncio.run(_run_session(checks))

--- a/mcp/tests/test_hardening.py
+++ b/mcp/tests/test_hardening.py
@@ -31,7 +31,10 @@ def test_snapshot_refs_are_never_reused():
         result = await session.call_tool("browser_click", {"target": old_ref})
         text = "\n".join(c.text for c in result.content if c.type == "text")
         assert result.isError
-        assert "stale snapshot" in text
+        assert (
+            "Ref " + old_ref
+            + " is not in the current page snapshot; take a fresh snapshot."
+        ) in text
         await _call(session, "browser_close")
 
     asyncio.run(_run_session(checks))

--- a/mcp/tests/test_identity.py
+++ b/mcp/tests/test_identity.py
@@ -1,0 +1,29 @@
+"""Real-stdio initialize identity test."""
+
+import asyncio
+from importlib import metadata
+import os
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from test_smoke import _server_command
+
+
+def test_stdio_initialize_reports_package_identity():
+    async def checks():
+        command = _server_command()
+        params = StdioServerParameters(
+            command=command[0],
+            args=command[1:],
+            env=dict(os.environ),
+        )
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                initialized = await session.initialize()
+                assert initialized.serverInfo.name == "rustwright-mcp"
+                assert initialized.serverInfo.version == metadata.version(
+                    "rustwright-mcp"
+                )
+
+    asyncio.run(checks())

--- a/mcp/tests/test_pr2_compatibility.py
+++ b/mcp/tests/test_pr2_compatibility.py
@@ -460,13 +460,14 @@ def test_caps_argv_and_env_warn_without_blocking_tools_list() -> None:
 
 def test_mirror_and_lean_tool_profiles_with_eval_default_on() -> None:
     mirror, _ = asyncio.run(_stdio_tools())
-    assert len(mirror) == 24
+    assert len(mirror) == 25
     assert {
         "browser_evaluate",
         "browser_get_text",
         "browser_handle_dialog",
         "browser_console_messages",
         "browser_drag",
+        "browser_drop",
         "browser_file_upload",
         "browser_fill_form",
         "browser_find",

--- a/mcp/tests/test_pr2_compatibility.py
+++ b/mcp/tests/test_pr2_compatibility.py
@@ -286,15 +286,31 @@ def test_evaluate_function_expression_target_json_and_precedence(
 
 
 def test_dialog_camel_snake_and_canonical_precedence(fake_page) -> None:
+    class Dialog:
+        def __init__(self) -> None:
+            self.prompt_text = None
+
+        def accept(self, prompt_text=None) -> None:
+            self.prompt_text = prompt_text
+
+    def pending_dialog() -> Dialog:
+        registry = server._state.registry_for(fake_page, create=True)
+        dialog = Dialog()
+        registry.pending_dialog = dialog
+        return dialog
+
+    camel = pending_dialog()
     _tool_call("browser_handle_dialog", {"accept": True, "promptText": "camel"})
-    assert server._state.dialog_intent.prompt_text == "camel"
+    assert camel.prompt_text == "camel"
+    snake = pending_dialog()
     _tool_call("browser_handle_dialog", {"accept": True, "prompt_text": "snake"})
-    assert server._state.dialog_intent.prompt_text == "snake"
+    assert snake.prompt_text == "snake"
+    winner = pending_dialog()
     _tool_call(
         "browser_handle_dialog",
         {"accept": True, "promptText": "winner", "prompt_text": "loser"},
     )
-    assert server._state.dialog_intent.prompt_text == "winner"
+    assert winner.prompt_text == "winner"
 
 
 def test_wait_camel_snake_precedence_time_cap_and_text_states(fake_page) -> None:
@@ -444,8 +460,20 @@ def test_caps_argv_and_env_warn_without_blocking_tools_list() -> None:
 
 def test_mirror_and_lean_tool_profiles_with_eval_default_on() -> None:
     mirror, _ = asyncio.run(_stdio_tools())
-    assert len(mirror) == 16
-    assert {"browser_evaluate", "browser_get_text", "browser_handle_dialog"} <= mirror
+    assert len(mirror) == 24
+    assert {
+        "browser_evaluate",
+        "browser_get_text",
+        "browser_handle_dialog",
+        "browser_console_messages",
+        "browser_drag",
+        "browser_file_upload",
+        "browser_fill_form",
+        "browser_find",
+        "browser_network_request",
+        "browser_network_requests",
+        "browser_resize",
+    } <= mirror
 
     lean, _ = asyncio.run(
         _stdio_tools(env_overrides={"RUSTWRIGHT_MCP_TOOLSET": "lean"})

--- a/mcp/tests/test_pr2_compatibility.py
+++ b/mcp/tests/test_pr2_compatibility.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import os
 from pathlib import Path
+import subprocess
 import sys
 import tempfile
 
@@ -53,7 +54,9 @@ class FakeLocator:
     def hover(self) -> None:
         self.page.events.append(("hover", self.selector))
 
-    def evaluate(self, function: str):
+    def evaluate(self, function: str, argument=None):
+        if argument is not None:
+            return self.selector == argument.selector
         self.page.events.append(("locator-evaluate", self.selector, function))
         return {"context": self.selector, "function": function}
 
@@ -166,6 +169,43 @@ def test_click_camel_snake_scalar_array_and_canonical_precedence(fake_page) -> N
     assert clicks[0][2]["modifiers"] == ["Alt"]
     assert clicks[1][2]["click_count"] == 2
     assert clicks[2][2]["click_count"] == 1
+
+
+def test_failed_upload_does_not_replay_click_on_different_element(
+    fake_page, monkeypatch, tmp_path
+) -> None:
+    class OriginatingElement:
+        selector = "#upload"
+
+        def evaluate(self, function):
+            fake_page.events.append(("reset-upload", function))
+
+    class Chooser:
+        element = OriginatingElement()
+
+        def is_multiple(self):
+            return False
+
+        def set_files(self, paths):
+            fake_page.events.append(("set-files", paths))
+
+    state = server._state
+    registry = state.register_page_handlers(fake_page)
+    registry.pending_file_chooser = Chooser()
+    policy = FilePolicy(output_root=tmp_path / "output")
+    monkeypatch.setattr(server, "get_file_policy", lambda: policy)
+
+    with pytest.raises(ValueError, match="Retry by clicking the same file input"):
+        server.browser_file_upload(paths=["relative.txt"])
+    assert registry.file_chooser_retry_element is not None
+
+    server.browser_click(target="#unrelated")
+    unrelated_clicks = [
+        event
+        for event in fake_page.events
+        if event[0] == "click" and event[1] == "#unrelated"
+    ]
+    assert len(unrelated_clicks) == 1
 
 
 def test_type_canonical_slowly_and_legacy_clear_are_independent(fake_page) -> None:
@@ -410,6 +450,23 @@ def test_caps_parser_env_precedence_and_warnings(capsys) -> None:
     warning = capsys.readouterr().err
     assert "capability group 'vision' is not implemented" in warning
     assert "capability group 'pdf' is not implemented" in warning
+
+
+def test_unknown_allow_eval_value_fails_startup_instead_of_enabling_eval() -> None:
+    env = dict(os.environ)
+    env["RUSTWRIGHT_MCP_ALLOW_EVAL"] = "flase"
+    result = subprocess.run(
+        [sys.executable, "-c", "import rustwright_mcp.server"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "RUSTWRIGHT_MCP_ALLOW_EVAL must be one of" in result.stderr
+    assert "'flase'" in result.stderr
 
 
 async def _stdio_tools(

--- a/mcp/tests/test_pr2_compatibility.py
+++ b/mcp/tests/test_pr2_compatibility.py
@@ -1,0 +1,514 @@
+"""Phase-A schema, response, capability, and profile compatibility tests."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+from mcp.server.fastmcp.exceptions import ToolError
+import pytest
+
+from rustwright_mcp import server
+from rustwright_mcp.filepolicy import FilePolicy
+from rustwright_mcp.session import SessionState
+from test_smoke import _call, _result_section, _run_session
+
+
+FORM_FIXTURE = Path(__file__).parent / "fixtures" / "form.html"
+
+
+class FakeLocator:
+    def __init__(self, page: "FakePage", selector: str) -> None:
+        self.page = page
+        self.selector = selector
+
+    def count(self) -> int:
+        return 1
+
+    def click(self, **kwargs) -> None:
+        self.page.events.append(("click", self.selector, kwargs))
+
+    def fill(self, value: str) -> None:
+        self.page.events.append(("fill", self.selector, value))
+
+    def type(self, value: str) -> None:
+        self.page.events.append(("type", self.selector, value))
+
+    def press_sequentially(self, value: str, *, delay: float) -> None:
+        self.page.events.append(("slow", self.selector, value, delay))
+
+    def press(self, key: str) -> None:
+        self.page.events.append(("press", self.selector, key))
+
+    def select_option(self, *, value=None, label=None):
+        self.page.events.append(("select", self.selector, value, label))
+        return value or label
+
+    def hover(self) -> None:
+        self.page.events.append(("hover", self.selector))
+
+    def evaluate(self, function: str):
+        self.page.events.append(("locator-evaluate", self.selector, function))
+        return {"context": self.selector, "function": function}
+
+    def inner_text(self) -> str:
+        return "fake text"
+
+    def screenshot(self, *, path: str, type: str, scale: str) -> None:
+        Path(path).write_bytes(b"image")
+        self.page.events.append(("element-screenshot", self.selector, type, scale))
+
+
+class FakeTextLocator:
+    def __init__(self, page: "FakePage", text: str) -> None:
+        self.page = page
+        self.text = text
+
+    def wait_for(self, *, state: str, timeout: float) -> None:
+        self.page.events.append(("text-wait", self.text, state, timeout))
+
+
+class FakeKeyboard:
+    def __init__(self, page: "FakePage") -> None:
+        self.page = page
+
+    def press(self, key: str) -> None:
+        self.page.events.append(("page-press", key))
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.pages: list[FakePage] = []
+
+    def new_page(self) -> "FakePage":
+        return FakePage(self)
+
+
+class FakePage:
+    def __init__(self, context: FakeContext | None = None) -> None:
+        self.context = context or FakeContext()
+        self.context.pages.append(self)
+        self.url = "https://example.test/"
+        self.events: list[tuple] = []
+        self.keyboard = FakeKeyboard(self)
+        self.handlers: dict[str, list] = {}
+
+    def title(self) -> str:
+        return "Fake page"
+
+    def locator(self, selector: str) -> FakeLocator:
+        return FakeLocator(self, selector)
+
+    def evaluate(self, function: str):
+        self.events.append(("page-evaluate", function))
+        return {"context": "page", "function": function}
+
+    def get_by_text(self, text: str) -> FakeTextLocator:
+        return FakeTextLocator(self, text)
+
+    def wait_for_timeout(self, timeout: float) -> None:
+        self.events.append(("time-wait", timeout))
+
+    def screenshot(
+        self, *, path: str, type: str, scale: str, full_page: bool
+    ) -> None:
+        Path(path).write_bytes(b"image")
+        self.events.append(("page-screenshot", type, scale, full_page))
+
+    def on(self, event: str, callback) -> None:
+        self.handlers.setdefault(event, []).append(callback)
+
+    def bring_to_front(self) -> None:
+        self.events.append(("front",))
+
+    def close(self) -> None:
+        self.context.pages.remove(self)
+
+
+@pytest.fixture
+def fake_page(monkeypatch) -> FakePage:
+    page = FakePage()
+    state = SessionState(page=page)
+    monkeypatch.setattr(server, "_state", state)
+    monkeypatch.setattr(server, "_page", lambda: page)
+    monkeypatch.setattr(server, "_snapshot", lambda *args, **kwargs: "- snapshot")
+    return page
+
+
+def _tool_call(name: str, arguments: dict):
+    return asyncio.run(server.mcp._tool_manager.call_tool(name, arguments, {}))
+
+
+def test_click_camel_snake_scalar_array_and_canonical_precedence(fake_page) -> None:
+    _tool_call(
+        "browser_click",
+        {
+            "target": "#one",
+            "element": "First button",
+            "doubleClick": True,
+            "modifiers": "Alt",
+        },
+    )
+    _tool_call("browser_click", {"target": "#two", "double_click": True})
+    _tool_call(
+        "browser_click",
+        {"target": "#three", "doubleClick": False, "double_click": True},
+    )
+
+    clicks = [event for event in fake_page.events if event[0] == "click"]
+    assert clicks[0][2]["click_count"] == 2
+    assert clicks[0][2]["modifiers"] == ["Alt"]
+    assert clicks[1][2]["click_count"] == 2
+    assert clicks[2][2]["click_count"] == 1
+
+
+def test_type_canonical_slowly_and_legacy_clear_are_independent(fake_page) -> None:
+    _tool_call(
+        "browser_type",
+        {"target": "#field", "text": "abc", "slowly": True, "clear": True},
+    )
+    _tool_call(
+        "browser_type",
+        {"target": "#field", "text": "xyz", "clear": False},
+    )
+    assert ("fill", "#field", "") in fake_page.events
+    assert ("slow", "#field", "abc", 50) in fake_page.events
+    assert ("type", "#field", "xyz") in fake_page.events
+
+
+def test_select_values_and_legacy_value_with_canonical_precedence(fake_page) -> None:
+    _tool_call("browser_select_option", {"target": "#size", "values": ["m"]})
+    _tool_call("browser_select_option", {"target": "#size", "value": "s"})
+    _tool_call(
+        "browser_select_option",
+        {"target": "#size", "values": ["l"], "value": "s"},
+    )
+    selected = [event[2] for event in fake_page.events if event[0] == "select"]
+    assert selected == [["m"], ["s"], ["l"]]
+
+
+def test_hover_accepts_description_and_legacy_target_only(fake_page) -> None:
+    _tool_call("browser_hover", {"target": "#one", "element": "First item"})
+    _tool_call("browser_hover", {"target": "#two"})
+    assert ("hover", "#one") in fake_page.events
+    assert ("hover", "#two") in fake_page.events
+
+
+def test_snapshot_canonical_options_and_legacy_minimal_call(fake_page, monkeypatch) -> None:
+    calls: list[dict] = []
+
+    def snapshot(page, **kwargs):
+        calls.append(kwargs)
+        return "- snapshot"
+
+    monkeypatch.setattr(server, "_snapshot", snapshot)
+    _tool_call(
+        "browser_snapshot",
+        {"target": "#root", "depth": 2, "boxes": True},
+    )
+    _tool_call("browser_snapshot", {})
+    assert calls[0]["target"].selector == "#root"
+    assert calls[0]["depth"] == 2
+    assert calls[0]["boxes"] is True
+    assert calls[1] == {"target": None, "depth": None, "boxes": False}
+
+
+def test_screenshot_camel_snake_and_canonical_precedence(
+    fake_page, monkeypatch, tmp_path
+) -> None:
+    policy = FilePolicy(output_root=tmp_path / "output")
+    monkeypatch.setattr(server, "get_file_policy", lambda: policy)
+
+    _tool_call(
+        "browser_take_screenshot",
+        {"filename": "camel.png", "fullPage": True, "scale": "device"},
+    )
+    _tool_call(
+        "browser_take_screenshot",
+        {"path": "snake.png", "full_page": True},
+    )
+    _tool_call(
+        "browser_take_screenshot",
+        {
+            "filename": "winner.png",
+            "path": "loser.png",
+            "fullPage": False,
+            "full_page": True,
+        },
+    )
+    _tool_call(
+        "browser_take_screenshot",
+        {"target": "#field", "element": "Field", "filename": "element.png"},
+    )
+    assert (policy.output_root / "camel.png").exists()
+    assert (policy.output_root / "snake.png").exists()
+    assert (policy.output_root / "winner.png").exists()
+    assert (policy.output_root / "element.png").exists()
+    assert not (policy.output_root / "loser.png").exists()
+    screenshots = [event for event in fake_page.events if event[0] == "page-screenshot"]
+    assert screenshots == [
+        ("page-screenshot", "png", "device", True),
+        ("page-screenshot", "png", "css", True),
+        ("page-screenshot", "png", "css", False),
+    ]
+    assert ("element-screenshot", "#field", "png", "css") in fake_page.events
+
+
+def test_evaluate_function_expression_target_json_and_precedence(
+    fake_page, monkeypatch, tmp_path
+) -> None:
+    policy = FilePolicy(output_root=tmp_path / "output")
+    monkeypatch.setattr(server, "get_file_policy", lambda: policy)
+    canonical = _tool_call("browser_evaluate", {"function": "canonical"})
+    legacy = _tool_call("browser_evaluate", {"expression": "legacy"})
+    winner = _tool_call(
+        "browser_evaluate",
+        {"function": "winner", "expression": "loser", "filename": "value.json"},
+    )
+    targeted = _tool_call(
+        "browser_evaluate",
+        {"function": "element => element.id", "target": "#field", "element": "Field"},
+    )
+
+    assert '"function": "canonical"' in canonical
+    assert '"function": "legacy"' in legacy
+    assert '"function": "winner"' in winner
+    assert "loser" not in winner
+    assert '"context": "#field"' in targeted
+    assert "### Snapshot" in targeted
+    assert '"function": "winner"' in (policy.output_root / "value.json").read_text()
+
+
+def test_dialog_camel_snake_and_canonical_precedence(fake_page) -> None:
+    _tool_call("browser_handle_dialog", {"accept": True, "promptText": "camel"})
+    assert server._state.dialog_intent.prompt_text == "camel"
+    _tool_call("browser_handle_dialog", {"accept": True, "prompt_text": "snake"})
+    assert server._state.dialog_intent.prompt_text == "snake"
+    _tool_call(
+        "browser_handle_dialog",
+        {"accept": True, "promptText": "winner", "prompt_text": "loser"},
+    )
+    assert server._state.dialog_intent.prompt_text == "winner"
+
+
+def test_wait_camel_snake_precedence_time_cap_and_text_states(fake_page) -> None:
+    _tool_call(
+        "browser_wait_for",
+        {"time": 99, "text": "visible", "textGone": "camel", "timeout_ms": 123},
+    )
+    _tool_call("browser_wait_for", {"text_gone": "snake"})
+    _tool_call(
+        "browser_wait_for",
+        {"textGone": "winner", "text_gone": "loser"},
+    )
+    assert ("time-wait", 30_000) in fake_page.events
+    assert ("text-wait", "visible", "visible", 123) in fake_page.events
+    assert ("text-wait", "camel", "hidden", 123) in fake_page.events
+    assert ("text-wait", "snake", "hidden", 10_000) in fake_page.events
+    assert ("text-wait", "winner", "hidden", 10_000) in fake_page.events
+    assert not any(event[1:2] == ("loser",) for event in fake_page.events)
+
+
+def test_tabs_list_and_close_current_register_replacement(fake_page) -> None:
+    listed = _tool_call("browser_tabs", {"action": "list"})
+    assert "### Tabs" in listed
+    assert "0: Fake page" in listed
+    closed = _tool_call("browser_tabs", {"action": "close"})
+    assert "### Tabs" in closed
+    assert server._state.page is not fake_page
+    assert len(server._state.page.context.pages) == 1
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "arguments"),
+    [
+        ("browser_click", {"target": "#x", "button": "primary"}),
+        ("browser_click", {"target": "#x", "modifiers": ["Command"]}),
+        ("browser_take_screenshot", {"type": "gif"}),
+        ("browser_take_screenshot", {"scale": "logical"}),
+        ("browser_tabs", {"action": "switch"}),
+    ],
+)
+def test_literal_enums_reject_unknown_values(fake_page, tool_name, arguments) -> None:
+    with pytest.raises(ToolError, match="validation error"):
+        _tool_call(tool_name, arguments)
+
+
+def test_runtime_structured_rejections(fake_page) -> None:
+    with pytest.raises(ToolError, match="At least one"):
+        _tool_call("browser_wait_for", {})
+    with pytest.raises(ToolError, match="element requires target"):
+        _tool_call("browser_evaluate", {"function": "x", "element": "orphan"})
+    with pytest.raises(ToolError, match="mutually exclusive"):
+        _tool_call(
+            "browser_take_screenshot",
+            {"target": "#x", "fullPage": True},
+        )
+
+
+def test_device_scale_has_structured_unsupported_error(fake_page, monkeypatch) -> None:
+    monkeypatch.setattr(server, "_supports_screenshot_scale", lambda target: False)
+    with pytest.raises(ToolError, match="scale=device is unsupported"):
+        _tool_call("browser_take_screenshot", {"scale": "device"})
+
+
+def test_advertised_schema_hides_legacy_aliases() -> None:
+    schemas = {
+        tool.name: tool.inputSchema for tool in asyncio.run(server.mcp.list_tools())
+    }
+    assert "doubleClick" in schemas["browser_click"]["properties"]
+    assert "double_click" not in schemas["browser_click"]["properties"]
+    assert "promptText" in schemas["browser_handle_dialog"]["properties"]
+    assert "prompt_text" not in schemas["browser_handle_dialog"]["properties"]
+    assert "textGone" in schemas["browser_wait_for"]["properties"]
+    assert "text_gone" not in schemas["browser_wait_for"]["properties"]
+    assert "fullPage" in schemas["browser_take_screenshot"]["properties"]
+    assert "full_page" not in schemas["browser_take_screenshot"]["properties"]
+    assert "function" in schemas["browser_evaluate"]["properties"]
+    assert "expression" not in schemas["browser_evaluate"]["properties"]
+
+
+def test_response_envelope_has_deterministic_section_order(fake_page) -> None:
+    response = server._render_response(
+        "ok", page=fake_page, include_tabs=True, snapshot="- tree"
+    )
+    headings = ["### Result", "### Page", "### Tabs", "### Snapshot"]
+    assert all(heading in response for heading in headings)
+    assert [response.index(heading) for heading in headings] == sorted(
+        response.index(heading) for heading in headings
+    )
+
+
+def test_caps_parser_env_precedence_and_warnings(capsys) -> None:
+    assert server._configured_caps(
+        ["--caps=vision,pdf"], {"RUSTWRIGHT_MCP_CAPS": "network, testing"}
+    ) == ("network", "testing")
+    assert server._configured_caps(["--caps=vision,pdf"], {}) == ("vision", "pdf")
+    server._warn_ignored_caps(("vision", "pdf"))
+    warning = capsys.readouterr().err
+    assert "capability group 'vision' is not implemented" in warning
+    assert "capability group 'pdf' is not implemented" in warning
+
+
+async def _stdio_tools(
+    *, env_overrides: dict[str, str] | None = None, extra_args: list[str] | None = None
+) -> tuple[set[str], str]:
+    env = dict(os.environ)
+    for name in (
+        "RUSTWRIGHT_MCP_ALLOW_EVAL",
+        "RUSTWRIGHT_MCP_CAPS",
+        "RUSTWRIGHT_MCP_TOOLSET",
+    ):
+        env.pop(name, None)
+    if env_overrides:
+        env.update(env_overrides)
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "rustwright_mcp", *(extra_args or [])],
+        env=env,
+    )
+    with tempfile.TemporaryFile(mode="w+", encoding="utf-8") as errlog:
+        async with stdio_client(params, errlog=errlog) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                tools = {tool.name for tool in (await session.list_tools()).tools}
+        errlog.seek(0)
+        errors = errlog.read()
+    return tools, errors
+
+
+def test_caps_argv_and_env_warn_without_blocking_tools_list() -> None:
+    argv_tools, argv_stderr = asyncio.run(
+        _stdio_tools(extra_args=["--caps=vision,pdf"])
+    )
+    assert "browser_navigate" in argv_tools
+    assert "capability group 'vision' is not implemented" in argv_stderr
+    assert "capability group 'pdf' is not implemented" in argv_stderr
+
+    env_tools, env_stderr = asyncio.run(
+        _stdio_tools(
+            env_overrides={"RUSTWRIGHT_MCP_CAPS": "network"},
+            extra_args=["--caps=vision"],
+        )
+    )
+    assert "browser_navigate" in env_tools
+    assert "capability group 'network' is not implemented" in env_stderr
+    assert "capability group 'vision'" not in env_stderr
+
+
+def test_mirror_and_lean_tool_profiles_with_eval_default_on() -> None:
+    mirror, _ = asyncio.run(_stdio_tools())
+    assert len(mirror) == 16
+    assert {"browser_evaluate", "browser_get_text", "browser_handle_dialog"} <= mirror
+
+    lean, _ = asyncio.run(
+        _stdio_tools(env_overrides={"RUSTWRIGHT_MCP_TOOLSET": "lean"})
+    )
+    assert lean == server._LEAN_TOOLS
+
+    lean_without_eval, _ = asyncio.run(
+        _stdio_tools(
+            env_overrides={
+                "RUSTWRIGHT_MCP_TOOLSET": "lean",
+                "RUSTWRIGHT_MCP_ALLOW_EVAL": "0",
+            }
+        )
+    )
+    assert lean_without_eval == server._LEAN_TOOLS - {"browser_evaluate"}
+
+
+def test_real_snapshot_target_depth_boxes_files_and_target_evaluate(tmp_path) -> None:
+    output_root = tmp_path / "output"
+
+    async def checks(session) -> None:
+        await _call(session, "browser_navigate", url=FORM_FIXTURE.as_uri())
+        targeted = await _call(
+            session,
+            "browser_snapshot",
+            target="#f",
+            depth=1,
+            boxes=True,
+        )
+        assert "### Snapshot" in targeted
+        assert "- form" in targeted
+        assert "[box=" in targeted
+        assert 'option "Small"' not in targeted
+
+        written = await _call(
+            session,
+            "browser_snapshot",
+            target="#f",
+            filename="tree.md",
+        )
+        assert "Snapshot written to `tree.md`" in written
+        assert (output_root / "tree.md").read_text().startswith("- form")
+
+        evaluated = await _call(
+            session,
+            "browser_evaluate",
+            function="element => ({tag: element.tagName, id: element.id})",
+            element="Customer name field",
+            target="#name",
+            filename="value.json",
+        )
+        serialized = _result_section(evaluated).split("\n\nSaved to:", 1)[0]
+        assert json.loads(serialized) == {"tag": "INPUT", "id": "name"}
+        assert "### Snapshot" in evaluated
+        assert json.loads((output_root / "value.json").read_text()) == {
+            "tag": "INPUT",
+            "id": "name",
+        }
+        await _call(session, "browser_close")
+
+    asyncio.run(
+        _run_session(
+            checks,
+            {"RUSTWRIGHT_MCP_OUTPUT_DIR": str(output_root)},
+        )
+    )

--- a/mcp/tests/test_pr3_compatibility.py
+++ b/mcp/tests/test_pr3_compatibility.py
@@ -1,0 +1,704 @@
+"""PR-3 default tools, observability cursors, and pending-modal semantics."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+import json
+from pathlib import Path
+import re
+from types import SimpleNamespace
+import threading
+import time
+
+import pytest
+
+from rustwright_mcp import server
+from rustwright_mcp.filepolicy import FilePolicy
+from rustwright_mcp.session import SessionState
+from test_smoke import _call, _result_section, _run_session
+
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class FixtureHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(FIXTURES), **kwargs)
+
+    def do_GET(self) -> None:
+        if self.path == "/":
+            self.path = "/pr3.html"
+        if self.path == "/api/get":
+            payload = b'{"kind":"get-response"}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+        if self.path == "/download":
+            payload = b"download-body"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header(
+                "Content-Disposition", 'attachment; filename="fixture-download.txt"'
+            )
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+            return
+        super().do_GET()
+
+    def do_POST(self) -> None:
+        if self.path != "/api/post":
+            self.send_error(404)
+            return
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        payload = b"post-response:" + body
+        self.send_response(201)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, format: str, *args) -> None:
+        del format, args
+
+
+@contextmanager
+def fixture_server():
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), FixtureHandler)
+    worker = threading.Thread(target=httpd.serve_forever, daemon=True)
+    worker.start()
+    try:
+        host, port = httpd.server_address
+        yield f"http://{host}:{port}/"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        worker.join(timeout=2)
+
+
+def _error_text(result) -> str:
+    return "\n".join(item.text for item in result.content if item.type == "text")
+
+
+def test_new_schemas_are_strict_canonical_and_nested_strict() -> None:
+    schemas = {
+        tool.name: tool.inputSchema for tool in asyncio.run(server.mcp.list_tools())
+    }
+    expected = {
+        "browser_resize": {"width", "height"},
+        "browser_drag": {"startElement", "startTarget", "endElement", "endTarget"},
+        "browser_fill_form": {"fields"},
+        "browser_find": {"text", "regex"},
+        "browser_console_messages": {"level", "all", "filename"},
+        "browser_network_requests": {"static", "filter", "filename"},
+        "browser_network_request": {"index", "part", "filename"},
+        "browser_file_upload": {"paths"},
+    }
+    for name, properties in expected.items():
+        assert schemas[name]["additionalProperties"] is False
+        assert set(schemas[name]["properties"]) == properties
+    fill_definition = schemas["browser_fill_form"]["$defs"]["FillField"]
+    assert fill_definition["additionalProperties"] is False
+    assert set(fill_definition["required"]) == {"target", "name", "type", "value"}
+    assert fill_definition["properties"]["type"]["enum"] == [
+        "textbox",
+        "checkbox",
+        "radio",
+        "combobox",
+        "slider",
+    ]
+
+
+def test_resize_rounds_fractional_dimensions_half_away_from_zero(
+    monkeypatch,
+) -> None:
+    class Page:
+        url = "https://example.test/"
+
+        def __init__(self) -> None:
+            self.context = SimpleNamespace(pages=[self])
+            self.viewport = None
+
+        def title(self) -> str:
+            return "Resize fixture"
+
+        def set_viewport_size(self, viewport) -> None:
+            self.viewport = viewport
+
+    page = Page()
+    state = SessionState(page=page)
+    monkeypatch.setattr(server, "_state", state)
+    monkeypatch.setattr(server, "_page", lambda: page)
+    monkeypatch.setattr(server, "_snapshot", lambda current: "- snapshot")
+
+    response = server.browser_resize(480.5, 639.5)
+
+    assert page.viewport == {"width": 481, "height": 640}
+    assert "Viewport resized to 481x640 CSS pixels" in response
+    assert server._round_half_away_from_zero(-2.5) == -3
+
+
+def test_background_dialog_is_visible_tabs_are_fast_and_handle_is_cross_tab(
+    monkeypatch,
+) -> None:
+    class Page:
+        def __init__(self, title: str) -> None:
+            self.handlers = {}
+            self.url = f"https://example.test/{title.lower()}"
+            self._title = title
+            self.title_calls = 0
+            self.dialog_pending = False
+
+        def on(self, event, callback) -> None:
+            self.handlers.setdefault(event, []).append(callback)
+
+        def title(self) -> str:
+            self.title_calls += 1
+            assert not self.dialog_pending, "title() called on dialog-blocked tab"
+            return self._title
+
+    class Dialog:
+        type = "alert"
+        message = "second-tab alert"
+
+        def __init__(self) -> None:
+            self.accepted = False
+
+        def accept(self, prompt_text=None) -> None:
+            del prompt_text
+            self.accepted = True
+
+    first = Page("First")
+    second = Page("Second")
+    context = SimpleNamespace(pages=[first, second])
+    first.context = context
+    second.context = context
+    state = SessionState(page=first)
+    monkeypatch.setattr(server, "_state", state)
+    monkeypatch.setattr(server, "_page", lambda: first)
+    monkeypatch.setattr(server, "_snapshot", lambda current, **kwargs: "- fresh")
+    server._register_page_handlers(first)
+    second_registry = state.register_page_handlers(second)
+    state.remember_page_title(second, "Second")
+    dialog = Dialog()
+    second_registry.pending_dialog = dialog
+    second.dialog_pending = True
+
+    acting_on_first = server.browser_snapshot()
+    assert "### Modal" in acting_on_first
+    assert "Tab 1: Dialog pending: type=alert" in acting_on_first
+    assert "second-tab alert" in acting_on_first
+    assert "### Snapshot" not in acting_on_first
+
+    started = time.monotonic()
+    tabs = server.browser_tabs("list")
+    assert time.monotonic() - started < 0.5
+    assert "### Tabs" in tabs and "1: Second" in tabs
+    assert second.title_calls == 0
+
+    handled = server.browser_handle_dialog(True)
+    assert "Accepted the pending dialog" in handled
+    assert dialog.accepted
+    assert second_registry.pending_dialog is None
+    assert state.page is first
+
+
+def test_download_name_is_sanitized_and_confined(monkeypatch, tmp_path) -> None:
+    policy = FilePolicy(output_root=tmp_path / "output")
+    monkeypatch.setattr(server, "get_file_policy", lambda: policy)
+
+    class Download:
+        def save_as(self, path: str) -> None:
+            Path(path).write_bytes(b"safe")
+
+    artifact = server._save_download(Download(), "../../unsafe name.txt")
+    assert artifact == "unsafe_name.txt"
+    assert (policy.output_root / artifact).read_bytes() == b"safe"
+    assert not (tmp_path / "unsafe name.txt").exists()
+
+
+def test_find_regex_flags_errors_paths_and_context() -> None:
+    assert server._compile_find_regex("Needle").search("Needle")
+    assert not server._compile_find_regex("Needle").search("needle")
+    assert server._compile_find_regex("/Needle/i").search("needle")
+    assert server._compile_find_regex("/^second/m").search("first\nsecond")
+    assert server._compile_find_regex("/first.second/s").search("first\nsecond")
+    with pytest.raises(ValueError, match="supported: i, m, s"):
+        server._compile_find_regex("/x/g")
+    with pytest.raises(ValueError, match="invalid regex"):
+        server._compile_find_regex("[")
+
+    outline = "\n".join(
+        [
+            '- main "Fixture"',
+            '  - region "Find region"',
+            '    - button "Before" [ref=e1]',
+            '    - button "Unique Needle" [ref=e2]',
+            '    - button "After" [ref=e3]',
+        ]
+    )
+    matches, truncated = server._find_outline_matches(
+        outline, lambda line: "needle" in line.casefold()
+    )
+    assert truncated == 0
+    assert "Path: - main" in matches[0]
+    assert "- region" in matches[0]
+    assert "[ref=e1]" in matches[0]
+    assert ">     - button \"Unique Needle\" [ref=e2]" in matches[0]
+    assert "[ref=e3]" in matches[0]
+
+
+def test_network_static_filter_and_original_index_stability() -> None:
+    records = [
+        SimpleNamespace(
+            index=4,
+            url="https://example.test/image.png",
+            resource_type="image",
+            response_status=200,
+        ),
+        SimpleNamespace(
+            index=7,
+            url="https://example.test/api",
+            resource_type="fetch",
+            response_status=200,
+        ),
+        SimpleNamespace(
+            index=9,
+            url="https://example.test/broken.css",
+            resource_type="stylesheet",
+            response_status=500,
+        ),
+    ]
+    visible = server._filter_network_records(
+        records,
+        include_static=False,
+        pattern=re.compile("api|css"),
+    )
+    assert [record.index for record in visible] == [7, 9]
+    assert server._STATIC_RESOURCE_TYPES == {
+        "image",
+        "media",
+        "font",
+        "stylesheet",
+    }
+
+
+def test_response_console_cursor_is_terse_bounded_and_once(monkeypatch) -> None:
+    class Page:
+        def __init__(self) -> None:
+            self.handlers = {}
+            self.url = "https://example.test/"
+            self.context = SimpleNamespace(pages=[self])
+
+        def on(self, event, callback) -> None:
+            self.handlers.setdefault(event, []).append(callback)
+
+        def title(self) -> str:
+            return "Cursor fixture"
+
+        def emit(self, event, value) -> None:
+            for callback in self.handlers.get(event, []):
+                callback(value)
+
+    page = Page()
+    state = SessionState(console_quota=20, page=page)
+    state.register_page_handlers(page)
+    monkeypatch.setattr(server, "_state", state)
+    for index in range(7):
+        page.emit(
+            "console",
+            SimpleNamespace(
+                type="warning",
+                text=f"warning-{index}",
+                location={"url": "https://example.test/app.js", "lineNumber": index},
+            ),
+        )
+    page.emit(
+        "console",
+        SimpleNamespace(type="info", text="quiet", location={}),
+    )
+
+    first = server._render_response("done", page=page)
+    assert first.count("WARNING ") == 5
+    assert "(and 2 more)" in first
+    assert "quiet" not in first
+    second = server._render_response("again", page=page)
+    assert "### Console" not in second
+
+
+def test_console_ring_eviction_and_response_body_states(monkeypatch) -> None:
+    class Page:
+        def __init__(self) -> None:
+            self.handlers = {}
+            self.url = "https://example.test/"
+            self.context = SimpleNamespace(pages=[self])
+
+        def on(self, event, callback) -> None:
+            self.handlers.setdefault(event, []).append(callback)
+
+        def title(self) -> str:
+            return "Ring fixture"
+
+        def emit(self, event, value) -> None:
+            for callback in self.handlers.get(event, []):
+                callback(value)
+
+    page = Page()
+    state = SessionState(console_quota=2, page=page)
+    state.register_page_handlers(page)
+    monkeypatch.setattr(server, "_state", state)
+    monkeypatch.setattr(server, "_page", lambda: page)
+    for index in range(3):
+        page.emit(
+            "console",
+            SimpleNamespace(type="error", text=f"error-{index}", location={}),
+        )
+    listed = server.browser_console_messages()
+    assert "error-0" not in listed
+    assert "error-1" in listed and "error-2" in listed
+    assert "ring buffer evicted 1" in listed
+
+    unavailable = SimpleNamespace(response=None, response_headers=())
+    assert server._response_body_text(unavailable, byte_limit=10) == "(response not received)"
+    empty = SimpleNamespace(
+        response=SimpleNamespace(body=lambda: b""),
+        response_headers=(("content-type", "text/plain"),),
+    )
+    assert server._response_body_text(empty, byte_limit=10) == "(empty response body)"
+    binary = SimpleNamespace(
+        response=SimpleNamespace(body=lambda: b"\x00\x01\x02"),
+        response_headers=(("content-type", "application/octet-stream"),),
+    )
+    rendered = server._response_body_text(binary, byte_limit=2)
+    assert "AAE=" in rendered
+    assert "base64-encoded non-text" in rendered
+    assert "truncated to 2 bytes" in rendered
+
+
+def test_real_resize_drag_fill_and_find(tmp_path) -> None:
+    with fixture_server() as url:
+        async def checks(session) -> None:
+            tools = {tool.name for tool in (await session.list_tools()).tools}
+            assert {
+                "browser_resize",
+                "browser_drag",
+                "browser_fill_form",
+                "browser_find",
+            } <= tools
+            await _call(session, "browser_navigate", url=url)
+
+            resized = await _call(session, "browser_resize", width=480, height=640)
+            assert "Viewport resized to 480x640" in resized
+            assert "### Snapshot" in resized
+
+            filled = await _call(
+                session,
+                "browser_fill_form",
+                fields=[
+                    {"target": "#text-field", "name": "text", "type": "textbox", "value": "filled"},
+                    {"target": "#check-field", "name": "check", "type": "checkbox", "value": "true"},
+                    {"target": "#radio-field", "name": "radio", "type": "radio", "value": "true"},
+                    {"target": "#combo-field", "name": "combo", "type": "combobox", "value": "Large label"},
+                    {"target": "#slider-field", "name": "slider", "type": "slider", "value": "55"},
+                ],
+            )
+            assert "Filled 5 fields sequentially" in filled
+            assert filled.count("### Snapshot") == 1
+            values = await _call(
+                session,
+                "browser_evaluate",
+                function="() => ({text: document.querySelector('#text-field').value, check: document.querySelector('#check-field').checked, radio: document.querySelector('#radio-field').checked, combo: document.querySelector('#combo-field').value, slider: document.querySelector('#slider-field').value})",
+            )
+            assert json.loads(_result_section(values)) == {
+                "text": "filled",
+                "check": True,
+                "radio": True,
+                "combo": "large-value",
+                "slider": "55",
+            }
+
+            partial = await session.call_tool(
+                "browser_fill_form",
+                {
+                    "fields": [
+                        {"target": "#text-field", "name": "earlier", "type": "textbox", "value": "kept"},
+                        {"target": "#radio-field", "name": "bad-radio", "type": "radio", "value": "false"},
+                    ]
+                },
+            )
+            assert partial.isError
+            assert "bad-radio" in _error_text(partial)
+            assert "unchecking a radio is not supported" in _error_text(partial)
+            kept = await _call(
+                session,
+                "browser_evaluate",
+                function="() => document.querySelector('#text-field').value",
+            )
+            assert json.loads(_result_section(kept)) == "kept"
+
+            dragged = await _call(
+                session,
+                "browser_drag",
+                startTarget="#drag-source",
+                startElement="source",
+                endTarget="#drag-target",
+                endElement="target",
+            )
+            assert "Dragged source to target" in dragged
+            assert "dragged" in await _call(
+                session, "browser_get_text", selector="#drag-result"
+            )
+
+            found = await _call(session, "browser_find", text="unique needle")
+            assert "Path:" in found and "[ref=" in found
+            ref = re.search(r'Unique Needle[^\n]*\[ref=(e\d+)\]', found).group(1)
+            assert "Clicked" in await _call(session, "browser_click", target=ref)
+            regex_found = await _call(session, "browser_find", regex="/unique needle/i")
+            assert "Unique Needle" in regex_found
+            invalid = await session.call_tool("browser_find", {"regex": "/x/g"})
+            assert invalid.isError and "invalid regex flags" in _error_text(invalid)
+            both = await session.call_tool(
+                "browser_find", {"text": "x", "regex": "x"}
+            )
+            assert both.isError and "Exactly one" in _error_text(both)
+            await _call(session, "browser_close")
+
+        asyncio.run(
+            _run_session(
+                checks,
+                {"RUSTWRIGHT_MCP_OUTPUT_DIR": str(tmp_path / "output")},
+            )
+        )
+
+
+def test_real_console_and_network_observability(tmp_path) -> None:
+    output = tmp_path / "output"
+    with fixture_server() as url:
+        async def checks(session) -> None:
+            navigated = await _call(session, "browser_navigate", url=url)
+            assert "### Console" in navigated
+            assert "ERROR" in navigated and "WARNING" in navigated
+            assert "console-info" not in navigated
+            await _call(session, "browser_wait_for", time=0.2)
+
+            error_only = await _call(
+                session, "browser_console_messages", level="error"
+            )
+            assert "console-error" in error_only
+            assert "console-warning" not in error_only
+            debug = await _call(
+                session,
+                "browser_console_messages",
+                level="debug",
+                all=True,
+                filename="console.txt",
+            )
+            assert "Console messages written to `console.txt`" in debug
+            console_file = (output / "console.txt").read_text()
+            assert all(
+                value in console_file
+                for value in (
+                    "console-error",
+                    "console-warning",
+                    "console-info",
+                    "console-debug",
+                )
+            )
+
+            default_list = await _call(session, "browser_network_requests")
+            assert "/api/get" in default_list and "/api/post" in default_list
+            assert "static.css" not in default_list
+            all_list = await _call(
+                session, "browser_network_requests", static=True
+            )
+            assert "static.css" in all_list
+            filtered = await _call(
+                session,
+                "browser_network_requests",
+                static=True,
+                filter="/api/(get|post)$",
+                filename="network.txt",
+            )
+            assert "Network requests written to `network.txt`" in filtered
+            network_file = (output / "network.txt").read_text()
+            assert "/api/get" in network_file and "/api/post" in network_file
+            indices = {
+                endpoint: int(
+                    re.search(rf"\[(\d+)\].*{re.escape(endpoint)}", all_list).group(1)
+                )
+                for endpoint in ("/api/get", "/api/post")
+            }
+
+            post = await _call(
+                session,
+                "browser_network_request",
+                index=indices["/api/post"],
+                part="request-body",
+            )
+            assert "posted-body" in post
+            get = await _call(
+                session,
+                "browser_network_request",
+                index=indices["/api/get"],
+                part="response-body",
+            )
+            assert "get-response" in get
+            full = await _call(
+                session,
+                "browser_network_request",
+                index=indices["/api/get"],
+                filename="request.txt",
+            )
+            assert "Network request" in full
+            assert "get-response" in (output / "request.txt").read_text()
+            invalid = await session.call_tool(
+                "browser_network_requests", {"filter": "["}
+            )
+            assert invalid.isError and "invalid network filter regex" in _error_text(invalid)
+            missing = await session.call_tool(
+                "browser_network_request", {"index": 9999}
+            )
+            assert missing.isError and "valid range" in _error_text(missing)
+            await _call(session, "browser_close")
+
+        asyncio.run(
+            _run_session(
+                checks,
+                {"RUSTWRIGHT_MCP_OUTPUT_DIR": str(output)},
+            )
+        )
+
+
+def test_real_file_upload_security_cancel_and_download_cursor(tmp_path) -> None:
+    output = tmp_path / "output"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    upload = workspace / "upload.txt"
+    upload.write_text("upload-body")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside")
+    symlink = workspace / "link.txt"
+    symlink.symlink_to(upload)
+
+    with fixture_server() as url:
+        async def checks(session) -> None:
+            await _call(session, "browser_navigate", url=url)
+            pending = await _call(session, "browser_click", target="#upload")
+            assert "### Modal" in pending and "File chooser pending" in pending
+            assert "### Snapshot" not in pending
+            uploaded = await _call(
+                session, "browser_file_upload", paths=[str(upload)]
+            )
+            assert "Uploaded 1 file" in uploaded and "### Snapshot" in uploaded
+            assert "upload.txt" in await _call(
+                session, "browser_get_text", selector="#upload-result"
+            )
+            no_pending = await session.call_tool("browser_file_upload", {})
+            assert no_pending.isError and "no file chooser is pending" in _error_text(no_pending)
+
+            for rejected, message in (
+                ("relative.txt", "absolute"),
+                (str(outside), "outside the allowed workspace"),
+                (str(symlink), "must not be a symlink"),
+            ):
+                await _call(session, "browser_click", target="#upload")
+                result = await session.call_tool(
+                    "browser_file_upload", {"paths": [rejected]}
+                )
+                assert result.isError and message in _error_text(result)
+
+            await _call(session, "browser_click", target="#upload")
+            cancelled = await _call(session, "browser_file_upload")
+            assert "Cancelled" in cancelled and "### Snapshot" in cancelled
+
+            downloaded = await _call(session, "browser_click", target="#download")
+            assert "### Downloads" in downloaded
+            assert "fixture-download.txt" in downloaded
+            assert (output / "fixture-download.txt").read_bytes() == b"download-body"
+            next_response = await _call(session, "browser_snapshot")
+            assert "### Downloads" not in next_response
+            await _call(session, "browser_close")
+
+        asyncio.run(
+            _run_session(
+                checks,
+                {
+                    "RUSTWRIGHT_MCP_OUTPUT_DIR": str(output),
+                    "RUSTWRIGHT_MCP_WORKSPACE": str(workspace),
+                },
+            )
+        )
+
+
+def test_real_pending_dialog_flip_and_no_hang(tmp_path) -> None:
+    with fixture_server() as url:
+        async def checks(session) -> None:
+            await _call(session, "browser_navigate", url=url)
+
+            started = time.monotonic()
+            alert = await _call(session, "browser_click", target="#alert")
+            elapsed = time.monotonic() - started
+            assert elapsed < 3
+            assert "### Modal" in alert and "type=alert" in alert
+            assert "alert message" in alert
+            assert "### Snapshot" not in alert
+            snapshot_started = time.monotonic()
+            blocked_snapshot = await _call(session, "browser_snapshot")
+            assert time.monotonic() - snapshot_started < 1
+            assert "### Modal" in blocked_snapshot
+            assert "### Snapshot" not in blocked_snapshot
+            accepted = await _call(
+                session, "browser_handle_dialog", accept=True
+            )
+            assert "Accepted the pending dialog" in accepted
+            missing = await session.call_tool(
+                "browser_handle_dialog", {"accept": True}
+            )
+            assert missing.isError and "no dialog is pending" in _error_text(missing)
+
+            await _call(session, "browser_click", target="#confirm")
+            await _call(session, "browser_handle_dialog", accept=False)
+            confirm_false = await _call(
+                session,
+                "browser_evaluate",
+                function="() => window.confirmResult",
+            )
+            assert json.loads(_result_section(confirm_false)) is False
+
+            await _call(session, "browser_click", target="#confirm")
+            await _call(session, "browser_handle_dialog", accept=True)
+            confirm_true = await _call(
+                session,
+                "browser_evaluate",
+                function="() => window.confirmResult",
+            )
+            assert json.loads(_result_section(confirm_true)) is True
+
+            prompt = await _call(session, "browser_click", target="#prompt")
+            assert "prompt message" in prompt
+            await _call(
+                session,
+                "browser_handle_dialog",
+                accept=True,
+                promptText="typed prompt",
+            )
+            prompt_value = await _call(
+                session,
+                "browser_evaluate",
+                function="() => window.promptResult",
+            )
+            assert json.loads(_result_section(prompt_value)) == "typed prompt"
+            await _call(session, "browser_close")
+
+        asyncio.run(
+            _run_session(
+                checks,
+                {"RUSTWRIGHT_MCP_OUTPUT_DIR": str(tmp_path / "output")},
+            )
+        )

--- a/mcp/tests/test_pr4_drop.py
+++ b/mcp/tests/test_pr4_drop.py
@@ -61,8 +61,18 @@ def test_drop_schema_contract_description_and_profiles() -> None:
         "params": [
             {"name": "element", "type": "string", "required": False},
             {"name": "target", "type": "string", "required": True},
-            {"name": "paths", "type": "array", "required": False},
-            {"name": "data", "type": "object", "required": False},
+            {
+                "name": "paths",
+                "type": "array",
+                "required": False,
+                "items": {"type": "string"},
+            },
+            {
+                "name": "data",
+                "type": "object",
+                "required": False,
+                "additionalProperties": {"type": "string"},
+            },
         ]
     }
     assert raw_contract["browser_drop"] == expected
@@ -71,7 +81,8 @@ def test_drop_schema_contract_description_and_profiles() -> None:
     mismatched = copy.deepcopy(advertised)
     mismatched["properties"]["data"] = {"type": "array"}
     assert compare_tool_schema(mismatched, contract) == [
-        "type mismatch for data: expected object"
+        "type mismatch for data: expected object, got ['array']",
+        "missing additionalProperties schema for data",
     ]
 
     mirror, _ = asyncio.run(

--- a/mcp/tests/test_pr4_drop.py
+++ b/mcp/tests/test_pr4_drop.py
@@ -1,0 +1,331 @@
+"""PR-4 schema, policy, synthesis, and conformance coverage for browser_drop."""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+from rustwright_mcp import server
+
+sys.path.insert(0, str(Path(__file__).parent))
+from contract.contract_schema import ToolContract, compare_tool_schema
+from test_pr2_compatibility import _stdio_tools
+from test_smoke import _call, _result_section, _run_session
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "drop_conformance.html"
+CONTRACT_FIXTURE = (
+    Path(__file__).parent / "contract" / "fixtures" / "default_toolset.json"
+)
+CONFORMANCE_OUTPUT = Path(__file__).parent / "output" / "browser_drop_conformance.json"
+
+
+def _error_text(result) -> str:
+    return "\n".join(item.text for item in result.content if item.type == "text")
+
+
+def _schema_branch(schema: dict, expected_type: str) -> dict:
+    if schema.get("type") == expected_type:
+        return schema
+    return next(
+        branch
+        for branch in schema.get("anyOf", [])
+        if branch.get("type") == expected_type
+    )
+
+
+def test_drop_schema_contract_description_and_profiles() -> None:
+    tools = {tool.name: tool for tool in asyncio.run(server.mcp.list_tools())}
+    advertised = tools["browser_drop"].inputSchema
+    assert advertised["additionalProperties"] is False
+    assert set(advertised["properties"]) == {"element", "target", "paths", "data"}
+    assert set(advertised["required"]) == {"target"}
+    assert _schema_branch(advertised["properties"]["paths"], "array")[
+        "maxItems"
+    ] == 50
+    data_schema = _schema_branch(advertised["properties"]["data"], "object")
+    assert data_schema["additionalProperties"] == {"type": "string"}
+    assert (
+        "synthesized drop events; sites checking event trust or native drag "
+        "sessions may behave differently"
+        in tools["browser_drop"].description
+    )
+
+    raw_contract = json.loads(CONTRACT_FIXTURE.read_text())
+    expected = {
+        "params": [
+            {"name": "element", "type": "string", "required": False},
+            {"name": "target", "type": "string", "required": True},
+            {"name": "paths", "type": "array", "required": False},
+            {"name": "data", "type": "object", "required": False},
+        ]
+    }
+    assert raw_contract["browser_drop"] == expected
+    contract = ToolContract.from_mapping("browser_drop", expected)
+    assert compare_tool_schema(advertised, contract) == []
+    mismatched = copy.deepcopy(advertised)
+    mismatched["properties"]["data"] = {"type": "array"}
+    assert compare_tool_schema(mismatched, contract) == [
+        "type mismatch for data: expected object"
+    ]
+
+    mirror, _ = asyncio.run(
+        _stdio_tools(env_overrides={"RUSTWRIGHT_MCP_ALLOW_EVAL": "0"})
+    )
+    lean, _ = asyncio.run(
+        _stdio_tools(
+            env_overrides={
+                "RUSTWRIGHT_MCP_TOOLSET": "lean",
+                "RUSTWRIGHT_MCP_ALLOW_EVAL": "0",
+            }
+        )
+    )
+    assert "browser_drop" in mirror
+    assert "browser_drop" not in lean
+
+
+def test_drop_synthetic_conformance_matrix_and_record(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    text_file = workspace / "note.txt"
+    text_file.write_text("plain file content\n")
+    json_file = workspace / "record.json"
+    json_file.write_text('{"answer":42}\n')
+
+    async def checks(session) -> None:
+        listed = {tool.name: tool for tool in (await session.list_tools()).tools}
+        assert "browser_drop" in listed
+        assert "browser_evaluate" not in listed
+        assert "synthetic DataTransfer semantics" in listed["browser_drop"].description
+
+        await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+        standard = await _call(
+            session,
+            "browser_drop",
+            target="#standard",
+            element="Standard zone description",
+            paths=[str(text_file), str(json_file)],
+            data={
+                "text/plain": "plain string",
+                "application/x-conformance": "custom string",
+            },
+        )
+        assert "Standard zone description" in standard
+        assert "2 file(s) and 2 data item(s)" in standard
+        assert "### Snapshot" in standard
+
+        trust = await _call(
+            session,
+            "browser_drop",
+            target="#trust",
+            data={"text/plain": "trust probe"},
+        )
+        assert "### Snapshot" in trust
+        items = await _call(
+            session,
+            "browser_drop",
+            target="#items",
+            paths=[str(text_file)],
+            data={
+                "text/plain": "ordered first",
+                "application/x-conformance": "ordered second",
+            },
+        )
+        assert "### Snapshot" in items
+        framework = await _call(
+            session,
+            "browser_drop",
+            target="#framework",
+            data={"text/plain": "framework value"},
+        )
+        assert "### Snapshot" in framework
+
+        await _call(session, "browser_wait_for", time=0.1)
+        result = await _call(session, "browser_get_text", selector="#results")
+        observed = json.loads(_result_section(result))
+
+        assert observed["a"] == {
+            "events": ["dragenter", "dragover", "drop"],
+            "files": [
+                {
+                    "name": "note.txt",
+                    "size": 19,
+                    "type": "text/plain",
+                    "content": "plain file content\n",
+                },
+                {
+                    "name": "record.json",
+                    "size": 14,
+                    "type": "application/json",
+                    "content": '{"answer":42}\n',
+                },
+            ],
+            "data": {
+                "text/plain": "plain string",
+                "application/x-conformance": "custom string",
+            },
+            "status": "done",
+        }
+        assert observed["b"] == {
+            "isTrusted": {"dragenter": False, "dragover": False, "drop": False}
+        }
+        assert observed["c"] == {
+            "types": ["text/plain", "application/x-conformance", "Files"],
+            "items": [
+                {"kind": "file", "type": "text/plain"},
+                {"kind": "string", "type": "text/plain"},
+                {"kind": "string", "type": "application/x-conformance"},
+            ],
+        }
+        assert observed["d"] == {
+            "events": ["dragenter", "dragover", "drop"],
+            "dragoverPrevented": True,
+            "accepted": True,
+            "value": "framework value",
+        }
+
+        record = {
+            "implementation": "best-effort-synthetic-data-transfer",
+            "cases": observed,
+        }
+        CONFORMANCE_OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+        CONFORMANCE_OUTPUT.write_text(
+            json.dumps(record, indent=2, sort_keys=True) + "\n"
+        )
+        print("browser_drop_conformance=" + json.dumps(record, sort_keys=True))
+
+    asyncio.run(
+        _run_session(
+            checks,
+            {
+                "RUSTWRIGHT_MCP_ALLOW_EVAL": "0",
+                "RUSTWRIGHT_MCP_WORKSPACE": str(workspace),
+            },
+        )
+    )
+
+
+def test_drop_runtime_rejections_are_structured(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    valid = workspace / "valid.txt"
+    valid.write_text("valid")
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside")
+    link = workspace / "link.txt"
+    try:
+        link.symlink_to(valid)
+    except OSError:
+        pytest.skip("symlinks are unavailable")
+
+    async def checks(session) -> None:
+        await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+        cases = [
+            (
+                {"target": "#standard"},
+                "at least one non-empty paths or data source",
+            ),
+            (
+                {"target": "#standard", "paths": [], "data": {}},
+                "at least one non-empty paths or data source",
+            ),
+            (
+                {"target": "#standard", "paths": [str(outside)]},
+                "outside the allowed workspace",
+            ),
+            (
+                {"target": "#standard", "paths": [str(link)]},
+                "must not be a symlink",
+            ),
+            (
+                {"target": ".dropzone", "data": {"text/plain": "value"}},
+                "matched 4 elements",
+            ),
+            (
+                {"target": "#standard", "data": {"": "value"}},
+                "MIME keys must be non-empty",
+            ),
+            (
+                {
+                    "target": "#standard",
+                    "data": {"text/plain": "one", "TEXT/PLAIN": "two"},
+                },
+                "unique ignoring case",
+            ),
+            (
+                {
+                    "target": "#standard",
+                    "data": {"text/plain": "value"},
+                    "filePaths": [str(valid)],
+                },
+                "Extra inputs are not permitted",
+            ),
+        ]
+        for arguments, expected in cases:
+            result = await session.call_tool("browser_drop", arguments)
+            assert result.isError, arguments
+            assert expected in _error_text(result), _error_text(result)
+
+    asyncio.run(
+        _run_session(checks, {"RUSTWRIGHT_MCP_WORKSPACE": str(workspace)})
+    )
+
+
+def test_drop_oversized_file_rejection_is_structured(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    oversized = workspace / "oversized.bin"
+    oversized.write_bytes(b"12345")
+
+    async def checks(session) -> None:
+        await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+        result = await session.call_tool(
+            "browser_drop",
+            {"target": "#standard", "paths": [str(oversized)]},
+        )
+        assert result.isError
+        assert "4-byte per-file cap" in _error_text(result)
+
+    asyncio.run(
+        _run_session(
+            checks,
+            {
+                "RUSTWRIGHT_MCP_WORKSPACE": str(workspace),
+                "RUSTWRIGHT_MCP_OUTPUT_MAX_FILE_BYTES": "4",
+            },
+        )
+    )
+
+
+def test_drop_total_input_cap_rejection_is_structured(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first = workspace / "first.bin"
+    second = workspace / "second.bin"
+    first.write_bytes(b"123")
+    second.write_bytes(b"456")
+
+    async def checks(session) -> None:
+        await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+        result = await session.call_tool(
+            "browser_drop",
+            {"target": "#standard", "paths": [str(first), str(second)]},
+        )
+        assert result.isError
+        assert "5-byte total cap" in _error_text(result)
+
+    asyncio.run(
+        _run_session(
+            checks,
+            {
+                "RUSTWRIGHT_MCP_WORKSPACE": str(workspace),
+                "RUSTWRIGHT_MCP_OUTPUT_MAX_FILE_BYTES": "4",
+                "RUSTWRIGHT_MCP_OUTPUT_MAX_TOTAL_BYTES": "5",
+            },
+        )
+    )

--- a/mcp/tests/test_resolver.py
+++ b/mcp/tests/test_resolver.py
@@ -1,0 +1,88 @@
+"""Unit tests for strict ref-or-selector target resolution."""
+
+import pytest
+
+from rustwright_mcp import server
+from rustwright_mcp.session import SessionState
+
+
+class FakeLocator:
+    def __init__(self, selector, count):
+        self.selector = selector
+        self._count = count
+
+    def count(self):
+        return self._count
+
+
+class FakePage:
+    def __init__(self, counts=None):
+        self.counts = counts or {}
+        self.locators = []
+
+    def locator(self, selector):
+        locator = FakeLocator(selector, self.counts.get(selector, 0))
+        self.locators.append(locator)
+        return locator
+
+
+def test_ref_requires_current_snapshot(monkeypatch):
+    state = SessionState()
+    page = FakePage()
+    monkeypatch.setattr(server, "_state", state)
+
+    with pytest.raises(ValueError) as error:
+        server._resolve(page, "e1")
+    assert str(error.value) == "No current snapshot; call browser_snapshot first."
+
+
+def test_ref_must_be_in_current_registry(monkeypatch):
+    state = SessionState()
+    page = FakePage()
+    state.record_snapshot(page, ["e2"], 3)
+    monkeypatch.setattr(server, "_state", state)
+
+    with pytest.raises(ValueError) as error:
+        server._resolve(page, "e1")
+    assert str(error.value) == (
+        "Ref e1 is not in the current page snapshot; take a fresh snapshot."
+    )
+
+
+def test_selector_must_match_at_least_one_element(monkeypatch):
+    page = FakePage({"#missing": 0})
+    monkeypatch.setattr(server, "_state", SessionState())
+
+    with pytest.raises(ValueError) as error:
+        server._resolve(page, "#missing")
+    assert str(error.value) == "Target selector matched no elements: #missing"
+
+
+def test_selector_must_be_unique(monkeypatch):
+    page = FakePage({"button": 3})
+    monkeypatch.setattr(server, "_state", SessionState())
+
+    with pytest.raises(ValueError) as error:
+        server._resolve(page, "button")
+    assert str(error.value) == (
+        "Target selector matched 3 elements; provide a unique selector: button"
+    )
+
+
+def test_ref_and_selector_success_return_typed_targets(monkeypatch):
+    state = SessionState()
+    page = FakePage({"#unique": 1, "e0": 1})
+    state.record_snapshot(page, ["e7"], 8)
+    monkeypatch.setattr(server, "_state", state)
+
+    ref = server._resolve(page, "e7", element_description="Submit button")
+    assert ref.source == "ref"
+    assert ref.display_name == "Submit button"
+    assert ref.locator.selector == '[data-mcp-ref="e7"]'
+
+    selector = server._resolve(page, "#unique")
+    assert selector.source == "selector"
+    assert selector.display_name == "#unique"
+    assert selector.locator.selector == "#unique"
+
+    assert server._resolve(page, "e0").source == "selector"

--- a/mcp/tests/test_session.py
+++ b/mcp/tests/test_session.py
@@ -22,6 +22,22 @@ class FakePage:
             callback(*args)
 
 
+class FakeContext:
+    def __init__(self, *pages):
+        self.pages = list(pages)
+        self.handlers = {}
+
+    def on(self, event, callback):
+        self.handlers.setdefault(event, []).append(callback)
+
+    def remove_listener(self, event, callback):
+        self.handlers[event].remove(callback)
+
+    def emit(self, event, *args):
+        for callback in list(self.handlers.get(event, ())):
+            callback(*args)
+
+
 class FakeConsole:
     def __init__(self, text):
         self.type = "log"
@@ -92,6 +108,36 @@ def test_registrar_is_once_per_page_and_cleanup_is_per_page():
     assert state.page is None
 
 
+def test_context_page_event_registers_window_open_popup_before_its_events():
+    initial = FakePage()
+    context = FakeContext(initial)
+    state = SessionState()
+    state.attach(
+        pw=object(),
+        browser=object(),
+        context=context,
+        page=initial,
+        remote=False,
+    )
+
+    popup = FakePage()
+    context.pages.append(popup)
+    context.emit("page", popup)
+    console = FakeConsole("popup console")
+    dialog = FakeDialog()
+    popup.emit("console", console)
+    popup.emit("dialog", dialog)
+
+    registry = state.registry_for(popup)
+    assert registry is not None
+    assert [record.text for record in registry.console_records] == ["popup console"]
+    assert registry.pending_dialog is dialog
+
+    callback = state.context_page_callback
+    state.clear()
+    assert callback not in context.handlers["page"]
+
+
 def test_event_records_are_immutable_bounded_and_epoch_indexed():
     state = SessionState(console_quota=2, network_quota=2, download_quota=1)
     page = FakePage()
@@ -132,6 +178,31 @@ def test_event_records_are_immutable_bounded_and_epoch_indexed():
     page.emit("download", FakeDownload())
     assert registry.pending_file_chooser is chooser
     assert registry.downloads[-1].download.__class__ is FakeDownload
+
+
+def test_navigation_eviction_counters_remain_bounded_across_many_epochs():
+    state = SessionState(console_quota=1, network_quota=1)
+    page = FakePage()
+    registry = state.register_page_handlers(page)
+
+    for index in range(100):
+        navigation = FakeRequest(
+            page, f"https://example.test/{index}", navigation=True
+        )
+        page.emit("request", navigation)
+        page.emit(
+            "request",
+            FakeRequest(page, f"https://example.test/{index}/resource"),
+        )
+        page.emit("console", FakeConsole(f"first-{index}"))
+        page.emit("console", FakeConsole(f"second-{index}"))
+        page.emit("framenavigated", page.main_frame)
+
+    assert registry.navigation_epoch == 100
+    assert len(registry.network_evictions) <= 1
+    assert set(registry.network_evictions) <= {registry.navigation_epoch}
+    assert registry.console_evictions_total > 100
+    assert isinstance(registry.console_evictions_current_epoch, int)
 
 
 def test_dialog_slot_stays_pending_without_automatic_action():

--- a/mcp/tests/test_session.py
+++ b/mcp/tests/test_session.py
@@ -124,7 +124,7 @@ def test_event_records_are_immutable_bounded_and_epoch_indexed():
     page.emit("request", next_epoch)
     assert [(item.epoch, item.index) for item in registry.network_records] == [
         (1, 2),
-        (2, 1),
+        (2, 3),
     ]
 
     chooser = object()
@@ -134,7 +134,7 @@ def test_event_records_are_immutable_bounded_and_epoch_indexed():
     assert registry.downloads[-1].download.__class__ is FakeDownload
 
 
-def test_dialog_slot_preserves_arm_next_behavior():
+def test_dialog_slot_stays_pending_without_automatic_action():
     state = SessionState()
     page = FakePage()
     registry = state.register_page_handlers(page)
@@ -143,11 +143,7 @@ def test_dialog_slot_preserves_arm_next_behavior():
     page.emit("dialog", pending)
     assert registry.pending_dialog is pending
     assert pending.action is None
-
-    state.arm_dialog(page, True, "answer")
-    armed = FakeDialog()
-    page.emit("dialog", armed)
-    assert armed.action == ("accept", "answer")
+    state.clear_pending_dialog(page, pending)
     assert registry.pending_dialog is None
 
 

--- a/mcp/tests/test_session.py
+++ b/mcp/tests/test_session.py
@@ -1,0 +1,171 @@
+"""Unit tests for typed session state and browser event plumbing."""
+
+from dataclasses import FrozenInstanceError
+import threading
+
+import pytest
+
+from rustwright_mcp import server
+from rustwright_mcp.session import SessionState
+
+
+class FakePage:
+    def __init__(self):
+        self.handlers = {}
+        self.main_frame = object()
+
+    def on(self, event, callback):
+        self.handlers.setdefault(event, []).append(callback)
+
+    def emit(self, event, *args):
+        for callback in list(self.handlers.get(event, ())):
+            callback(*args)
+
+
+class FakeConsole:
+    def __init__(self, text):
+        self.type = "log"
+        self.text = text
+        self.location = {"url": "https://example.test", "lineNumber": 4}
+
+
+class FakeRequest:
+    def __init__(self, page, url, *, navigation=False):
+        self.method = "POST"
+        self.url = url
+        self.resource_type = "document" if navigation else "fetch"
+        self.headers = {"accept": "application/json"}
+        self.post_data = "{}"
+        self.failure = None
+        self.frame = page.main_frame
+        self._navigation = navigation
+
+    def is_navigation_request(self):
+        return self._navigation
+
+
+class FakeResponse:
+    def __init__(self, request):
+        self.request = request
+        self.status = 201
+        self.headers = {"content-type": "application/json"}
+
+
+class FakeDownload:
+    url = "https://example.test/file"
+    suggested_filename = "file.txt"
+
+
+class FakeDialog:
+    def __init__(self):
+        self.action = None
+
+    def accept(self, prompt_text=None):
+        self.action = ("accept", prompt_text)
+
+    def dismiss(self):
+        self.action = ("dismiss", None)
+
+
+def test_registrar_is_once_per_page_and_cleanup_is_per_page():
+    state = SessionState()
+    page = FakePage()
+    state.page = page
+
+    first = state.register_page_handlers(page)
+    second = state.register_page_handlers(page)
+
+    assert first is second
+    for event in (
+        "console",
+        "request",
+        "response",
+        "requestfailed",
+        "filechooser",
+        "dialog",
+        "download",
+    ):
+        assert len(page.handlers[event]) == 1
+
+    page.emit("close", page)
+    assert state.registry_for(page) is None
+    assert state.page is None
+
+
+def test_event_records_are_immutable_bounded_and_epoch_indexed():
+    state = SessionState(console_quota=2, network_quota=2, download_quota=1)
+    page = FakePage()
+    registry = state.register_page_handlers(page)
+
+    page.emit("console", FakeConsole("one"))
+    page.emit("console", FakeConsole("two"))
+    page.emit("console", FakeConsole("three"))
+    assert [record.text for record in registry.console_records] == ["two", "three"]
+    with pytest.raises(FrozenInstanceError):
+        registry.console_records[-1].text = "changed"
+
+    navigation = FakeRequest(page, "https://example.test/", navigation=True)
+    request = FakeRequest(page, "https://example.test/api")
+    page.emit("request", navigation)
+    page.emit("request", request)
+    page.emit("response", FakeResponse(request))
+
+    assert [(item.epoch, item.index) for item in registry.network_records] == [
+        (1, 1),
+        (1, 2),
+    ]
+    assert registry.network_records[-1].response_status == 201
+    assert registry.network_records[-1].response is not None
+    assert registry.network_records[-1].headers == (("accept", "application/json"),)
+
+    page.emit("framenavigated", page.main_frame)
+    page.emit("framenavigated", page.main_frame)
+    next_epoch = FakeRequest(page, "https://example.test/next")
+    page.emit("request", next_epoch)
+    assert [(item.epoch, item.index) for item in registry.network_records] == [
+        (1, 2),
+        (2, 1),
+    ]
+
+    chooser = object()
+    page.emit("filechooser", chooser)
+    page.emit("download", FakeDownload())
+    assert registry.pending_file_chooser is chooser
+    assert registry.downloads[-1].download.__class__ is FakeDownload
+
+
+def test_dialog_slot_preserves_arm_next_behavior():
+    state = SessionState()
+    page = FakePage()
+    registry = state.register_page_handlers(page)
+
+    pending = FakeDialog()
+    page.emit("dialog", pending)
+    assert registry.pending_dialog is pending
+    assert pending.action is None
+
+    state.arm_dialog(page, True, "answer")
+    armed = FakeDialog()
+    page.emit("dialog", armed)
+    assert armed.action == ("accept", "answer")
+    assert registry.pending_dialog is None
+
+
+def test_event_callback_never_waits_for_tool_lock(monkeypatch):
+    state = SessionState()
+    page = FakePage()
+    monkeypatch.setattr(server, "_state", state)
+    server._register_page_handlers(page)
+    completed = threading.Event()
+
+    def tool_action():
+        with server._lock:
+            page.emit("console", FakeConsole("during tool"))
+            completed.set()
+
+    worker = threading.Thread(target=tool_action)
+    worker.start()
+    worker.join(timeout=1)
+
+    assert completed.is_set(), "event callback attempted to acquire the tool lock"
+    assert not worker.is_alive()

--- a/mcp/tests/test_smoke.py
+++ b/mcp/tests/test_smoke.py
@@ -58,6 +58,13 @@ async def _call(session, name, **kwargs) -> str:
     return text
 
 
+def _result_section(response: str) -> str:
+    marker = "### Result\n"
+    if marker not in response:
+        return ""
+    return response.split(marker, 1)[1].split("\n\n### ", 1)[0]
+
+
 def test_stdio_form_flow():
     async def checks(session):
         tools = {t.name for t in (await session.list_tools()).tools}
@@ -65,7 +72,9 @@ def test_stdio_form_flow():
                 "browser_type", "browser_close"} <= tools
 
         snap = await _call(session, "browser_navigate", url=FIXTURE.as_uri())
-        assert snap.startswith("Page: Form Test")
+        assert "### Page" in snap
+        assert "- Title: Form Test" in snap
+        assert "### Snapshot" in snap
         name_ref = re.search(r'textbox "Customer name"[^\[]*\[ref=(e\d+)\]', snap).group(1)
 
         snap = await _call(
@@ -81,9 +90,9 @@ def test_stdio_form_flow():
         await _call(session, "browser_click", target=btn_ref)
 
         out = await _call(session, "browser_get_text", selector="#out")
-        assert out == "name=Rustwright Test;size=l"
+        assert _result_section(out) == "name=Rustwright Test;size=l"
 
-        assert await _call(session, "browser_close") == "Browser closed."
+        assert _result_section(await _call(session, "browser_close")) == "Browser closed."
 
     asyncio.run(_run_session(checks))
 
@@ -95,9 +104,10 @@ def test_stdio_evaluate_opt_in():
 
         await _call(session, "browser_navigate", url=FIXTURE.as_uri())
         title = await _call(session, "browser_evaluate", expression="() => document.title")
-        assert title == "Form Test"
+        assert _result_section(title) == '"Form Test"'
+        assert "### Snapshot" in title
 
-        assert await _call(session, "browser_close") == "Browser closed."
+        assert _result_section(await _call(session, "browser_close")) == "Browser closed."
 
     asyncio.run(
         _run_session(checks, {"RUSTWRIGHT_MCP_ALLOW_EVAL": "1"})

--- a/mcp/tests/test_smoke.py
+++ b/mcp/tests/test_smoke.py
@@ -30,7 +30,13 @@ async def _run_session(checks, env_overrides=None) -> None:
 
     command = _server_command()
     env = dict(os.environ)
-    env.pop("RUSTWRIGHT_MCP_ALLOW_EVAL", None)
+    for name in (
+        "RUSTWRIGHT_MCP_ALLOW_EVAL",
+        "RUSTWRIGHT_MCP_CDP_ENDPOINT",
+        "RUSTWRIGHT_MCP_CDP_HEADERS",
+        "RUSTWRIGHT_MCP_CDP_TIMEOUT_MS",
+    ):
+        env.pop(name, None)
     if env_overrides:
         env.update(env_overrides)
     params = StdioServerParameters(

--- a/mcp/tests/validation/test_adversarial_filepolicy.py
+++ b/mcp/tests/validation/test_adversarial_filepolicy.py
@@ -56,28 +56,24 @@ def test_screenshot_escape_variants_are_structured_and_write_nothing(
         assert not escaped_path.exists()
 
 
-def test_screenshot_symlink_swap_cannot_write_outside_root(monkeypatch) -> None:
-    """A swap after exclusive reservation must not turn the write into an escape."""
+def test_finalized_symlink_escape_unlinks_only_in_root_entry() -> None:
+    """Reject an escaped final link without deleting or changing its target."""
     with tempfile.TemporaryDirectory(
         prefix="rustwright-mcp-validation-", dir="/tmp"
     ) as temporary:
         temporary_path = Path(temporary)
         policy = FilePolicy(output_root=temporary_path / "output")
-        escaped = temporary_path / "escaped.png"
-        monkeypatch.setattr(server, "get_file_policy", lambda: policy)
-
-        class RacingPage:
-            def screenshot(self, *, path, full_page, type) -> None:
-                reserved = Path(path)
-                reserved.unlink()
-                reserved.symlink_to(escaped)
-                reserved.write_bytes(b"escaped screenshot bytes")
-
-        monkeypatch.setattr(server, "_page", lambda: RacingPage())
+        escaped = temporary_path / "external-sentinel.png"
+        escaped.write_bytes(b"unchanged external sentinel")
+        reserved = policy.reserve_output("race.png")
+        reserved.unlink()
+        reserved.symlink_to(escaped)
 
         with pytest.raises(FilePolicyError, match="escaped the configured root"):
-            server.browser_take_screenshot(filename="race.png")
-        assert not escaped.exists(), "screenshot bytes escaped through a symlink swap"
+            policy.finalize_output(reserved)
+        assert not reserved.exists()
+        assert escaped.exists()
+        assert escaped.read_bytes() == b"unchanged external sentinel"
 
 
 def test_cap_boundaries_and_oldest_first_eviction(tmp_path) -> None:

--- a/mcp/tests/validation/test_adversarial_filepolicy.py
+++ b/mcp/tests/validation/test_adversarial_filepolicy.py
@@ -1,0 +1,127 @@
+"""Adversarial probes for screenshot confinement and output-cap boundaries."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import tempfile
+import uuid
+
+import pytest
+
+from rustwright_mcp import server
+from rustwright_mcp.filepolicy import FilePolicy, FilePolicyError
+
+
+class ScreenshotMustNotRun:
+    def screenshot(self, *, path, full_page) -> None:  # pragma: no cover
+        raise AssertionError(f"screenshot unexpectedly reached filesystem path {path}")
+
+
+class StaticRoots:
+    def __init__(self, *roots: Path) -> None:
+        self._roots = roots
+
+    def roots(self):
+        return self._roots
+
+
+def test_screenshot_escape_variants_are_structured_and_write_nothing(
+    monkeypatch, tmp_path
+) -> None:
+    root = tmp_path / "output"
+    outside_dir = tmp_path / "outside"
+    outside_dir.mkdir()
+    policy = FilePolicy(output_root=root)
+    monkeypatch.setattr(server, "get_file_policy", lambda: policy)
+    monkeypatch.setattr(server, "_page", lambda: ScreenshotMustNotRun())
+
+    symlink = root / "linked"
+    symlink.symlink_to(outside_dir, target_is_directory=True)
+    absolute_tmp = Path("/tmp") / f"rustwright-validation-{uuid.uuid4().hex}.png"
+    cases = [
+        ("../traversal.png", tmp_path / "traversal.png"),
+        ("linked/symlink.png", outside_dir / "symlink.png"),
+        (str(absolute_tmp), absolute_tmp),
+    ]
+
+    for requested, escaped_path in cases:
+        assert not escaped_path.exists()
+        with pytest.raises(FilePolicyError) as error:
+            server.browser_take_screenshot(path=requested)
+        assert str(error.value) == (
+            "screenshot paths are confined to RUSTWRIGHT_MCP_OUTPUT_DIR "
+            f"({policy.output_root}); got {requested}"
+        )
+        assert not escaped_path.exists()
+
+
+def test_screenshot_symlink_swap_cannot_write_outside_root(monkeypatch) -> None:
+    """A swap after exclusive reservation must not turn the write into an escape."""
+    with tempfile.TemporaryDirectory(
+        prefix="rustwright-mcp-validation-", dir="/tmp"
+    ) as temporary:
+        temporary_path = Path(temporary)
+        policy = FilePolicy(output_root=temporary_path / "output")
+        escaped = temporary_path / "escaped.png"
+        monkeypatch.setattr(server, "get_file_policy", lambda: policy)
+
+        class RacingPage:
+            def screenshot(self, *, path, full_page) -> None:
+                reserved = Path(path)
+                reserved.unlink()
+                reserved.symlink_to(escaped)
+                reserved.write_bytes(b"escaped screenshot bytes")
+
+        monkeypatch.setattr(server, "_page", lambda: RacingPage())
+
+        with pytest.raises(FilePolicyError, match="escaped the configured root"):
+            server.browser_take_screenshot(path="race.png")
+        assert not escaped.exists(), "screenshot bytes escaped through a symlink swap"
+
+
+def test_cap_boundaries_and_oldest_first_eviction(tmp_path) -> None:
+    policy = FilePolicy(
+        output_root=tmp_path / "output",
+        max_file_bytes=4,
+        max_total_bytes=7,
+    )
+    old = policy.reserve_output("old.bin")
+    old.write_bytes(b"old")
+    assert policy.finalize_output(old) == "old.bin"
+    os.utime(old, ns=(1, 1))
+
+    middle = policy.reserve_output("middle.bin")
+    middle.write_bytes(b"mid")
+    assert policy.finalize_output(middle) == "middle.bin"
+    os.utime(middle, ns=(2, 2))
+
+    boundary = policy.reserve_output("boundary.bin")
+    boundary.write_bytes(b"four")
+    assert policy.finalize_output(boundary) == "boundary.bin"
+    assert not old.exists()
+    assert middle.exists()
+    assert boundary.exists()
+
+    oversized = policy.reserve_output("oversized.bin")
+    oversized.write_bytes(b"12345")
+    with pytest.raises(FilePolicyError, match="4-byte per-file cap"):
+        policy.finalize_output(oversized)
+    assert not oversized.exists()
+
+
+def test_artifact_links_are_workspace_relative() -> None:
+    with tempfile.TemporaryDirectory(
+        prefix="rustwright-mcp-validation-", dir="/tmp"
+    ) as temporary:
+        workspace = Path(temporary) / "workspace"
+        output_root = workspace / "artifacts"
+        workspace.mkdir()
+        policy = FilePolicy(
+            output_root=output_root,
+            roots_provider=StaticRoots(workspace),
+        )
+        output = policy.reserve_output("capture.bin")
+        output.write_bytes(b"artifact")
+
+        assert policy.finalize_output(output) == "artifacts/capture.bin"

--- a/mcp/tests/validation/test_adversarial_filepolicy.py
+++ b/mcp/tests/validation/test_adversarial_filepolicy.py
@@ -48,7 +48,7 @@ def test_screenshot_escape_variants_are_structured_and_write_nothing(
     for requested, escaped_path in cases:
         assert not escaped_path.exists()
         with pytest.raises(FilePolicyError) as error:
-            server.browser_take_screenshot(path=requested)
+            server.browser_take_screenshot(filename=requested)
         assert str(error.value) == (
             "screenshot paths are confined to RUSTWRIGHT_MCP_OUTPUT_DIR "
             f"({policy.output_root}); got {requested}"
@@ -67,7 +67,7 @@ def test_screenshot_symlink_swap_cannot_write_outside_root(monkeypatch) -> None:
         monkeypatch.setattr(server, "get_file_policy", lambda: policy)
 
         class RacingPage:
-            def screenshot(self, *, path, full_page) -> None:
+            def screenshot(self, *, path, full_page, type) -> None:
                 reserved = Path(path)
                 reserved.unlink()
                 reserved.symlink_to(escaped)
@@ -76,7 +76,7 @@ def test_screenshot_symlink_swap_cannot_write_outside_root(monkeypatch) -> None:
         monkeypatch.setattr(server, "_page", lambda: RacingPage())
 
         with pytest.raises(FilePolicyError, match="escaped the configured root"):
-            server.browser_take_screenshot(path="race.png")
+            server.browser_take_screenshot(filename="race.png")
         assert not escaped.exists(), "screenshot bytes escaped through a symlink swap"
 
 

--- a/mcp/tests/validation/test_adversarial_resolver.py
+++ b/mcp/tests/validation/test_adversarial_resolver.py
@@ -1,0 +1,106 @@
+"""Hostile ref and selector-race validation."""
+
+from __future__ import annotations
+
+import pytest
+
+from rustwright.sync_api import sync_playwright
+
+from rustwright_mcp import server
+from rustwright_mcp.session import SessionState
+
+
+@pytest.fixture
+def browser_page():
+    with sync_playwright() as runtime:
+        browser = runtime.chromium.launch(headless=True)
+        page = browser.new_page()
+        try:
+            yield page
+        finally:
+            browser.close()
+
+
+def test_ref_shaped_css_never_falls_through_to_selector(monkeypatch, browser_page) -> None:
+    browser_page.set_content("<e999 id='hostile'>hostile selector collision</e999>")
+    assert browser_page.locator("e999").count() == 1
+    state = SessionState()
+    state.record_snapshot(browser_page, [], 1)
+    monkeypatch.setattr(server, "_state", state)
+
+    with pytest.raises(ValueError) as error:
+        server._resolve(browser_page, "e999")
+    assert str(error.value) == (
+        "Ref e999 is not in the current page snapshot; take a fresh snapshot."
+    )
+
+
+def test_selector_race_stays_strict_at_action_time(monkeypatch, browser_page) -> None:
+    browser_page.set_content(
+        "<button class='race' onclick='window.clicks += 1'>first</button>"
+        "<script>window.clicks = 0</script>"
+    )
+
+    class InjectingLocator:
+        def __init__(self, locator) -> None:
+            self._locator = locator
+
+        def count(self) -> int:
+            count = self._locator.count()
+            browser_page.evaluate(
+                """() => document.body.insertAdjacentHTML(
+                'beforeend',
+                '<button class="race" onclick="window.clicks += 1">second</button>'
+                )"""
+            )
+            return count
+
+        def click(self) -> None:
+            self._locator.click()
+
+    class InjectingPage:
+        def locator(self, selector):
+            return InjectingLocator(browser_page.locator(selector))
+
+    resolved = server._resolve(InjectingPage(), ".race")
+    with pytest.raises(Exception, match="strict mode violation.*2 elements"):
+        resolved.locator.click()
+    assert browser_page.evaluate("() => window.clicks") == 0
+
+
+class TruncatedSnapshotPage:
+    def __init__(self, outline: str) -> None:
+        self.outline = outline
+        self.url = "https://snapshot.example.test"
+
+    def wait_for_load_state(self, timeout) -> None:
+        return None
+
+    def evaluate(self, expression, start_ref):
+        return {
+            "outline": self.outline,
+            "refs": ["e1", "e2"],
+            "nextRef": 3,
+        }
+
+    def title(self) -> str:
+        return "Truncation"
+
+
+def test_ref_hidden_by_character_truncation_is_not_invocable(monkeypatch) -> None:
+    outline = "- button visible [ref=e1]\n" + (
+        "x" * server.SNAPSHOT_CHAR_LIMIT
+    ) + "\n- button hidden [ref=e2]"
+    page = TruncatedSnapshotPage(outline)
+    state = SessionState()
+    monkeypatch.setattr(server, "_state", state)
+
+    delivered = server._snapshot(page)
+    assert "[ref=e1]" in delivered
+    assert "[ref=e2]" not in delivered
+    assert state.snapshot_status(page) == (True, frozenset({"e1"}))
+    with pytest.raises(ValueError) as error:
+        server._resolve(page, "e2")
+    assert str(error.value) == (
+        "Ref e2 is not in the current page snapshot; take a fresh snapshot."
+    )

--- a/mcp/tests/validation/test_adversarial_session.py
+++ b/mcp/tests/validation/test_adversarial_session.py
@@ -1,0 +1,219 @@
+"""Adversarial validation of session event plumbing and eviction semantics."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from rustwright_mcp import server
+from rustwright_mcp.session import SessionState
+
+
+class FakePage:
+    def __init__(self) -> None:
+        self.handlers: dict[str, list] = {}
+        self.main_frame = object()
+        self.goto_started = threading.Event()
+        self.allow_goto = threading.Event()
+
+    def on(self, event, callback) -> None:
+        self.handlers.setdefault(event, []).append(callback)
+
+    def remove_listener(self, event, callback) -> None:
+        self.handlers[event].remove(callback)
+
+    def emit(self, event, *args) -> None:
+        for callback in list(self.handlers.get(event, ())):
+            callback(*args)
+
+    def goto(self, url) -> None:
+        self.goto_started.set()
+        assert self.allow_goto.wait(2), f"slow navigation never released: {url}"
+
+
+class MutableConsole:
+    def __init__(self) -> None:
+        self.type = "warning"
+        self.text = "captured"
+        self.location = {
+            "url": "https://example.test",
+            "position": {"line": 7, "columns": [1, 2]},
+        }
+
+
+class MutableRequest:
+    def __init__(self, page: FakePage, url: str) -> None:
+        self.method = "POST"
+        self.url = url
+        self.resource_type = "fetch"
+        self.headers = {
+            "accept": "application/json",
+            "trace": {"parts": ["original"]},
+        }
+        self.post_data = "{}"
+        self.failure = None
+        self.frame = page.main_frame
+
+    def is_navigation_request(self) -> bool:
+        return False
+
+
+class MutableResponse:
+    def __init__(self, request: MutableRequest) -> None:
+        self.request = request
+        self.status = 200
+        self.headers = {"content-type": "application/json"}
+
+
+class FakeDialog:
+    def __init__(self) -> None:
+        self.dismissed = False
+
+    def dismiss(self) -> None:
+        self.dismissed = True
+
+
+def test_event_metadata_is_copied_before_source_mutation() -> None:
+    state = SessionState()
+    page = FakePage()
+    registry = state.register_page_handlers(page)
+    message = MutableConsole()
+    request = MutableRequest(page, "https://example.test/api")
+    response = MutableResponse(request)
+
+    page.emit("console", message)
+    page.emit("request", request)
+    page.emit("response", response)
+
+    message.location["url"] = "https://mutated.invalid"
+    message.location["position"]["line"] = 99
+    message.location["position"]["columns"].append(3)
+    request.headers["accept"] = "text/plain"
+    request.headers["trace"]["parts"].append("mutated")
+    response.headers["content-type"] = "text/plain"
+
+    console = registry.console_records[0]
+    network = registry.network_records[0]
+    assert console.location == (
+        ("position", (("columns", (1, 2)), ("line", 7))),
+        ("url", "https://example.test"),
+    )
+    assert network.headers == (
+        ("accept", "application/json"),
+        ("trace", (("parts", ("original",)),)),
+    )
+    assert network.response_headers == (("content-type", "application/json"),)
+
+
+def test_callback_flood_completes_while_slow_tool_holds_tool_lock(monkeypatch) -> None:
+    state = SessionState(console_quota=200, network_quota=200)
+    page = FakePage()
+    registry = state.register_page_handlers(page)
+    state.arm_dialog(page, False, None)
+    monkeypatch.setattr(server, "_state", state)
+    monkeypatch.setattr(server, "_page", lambda: page)
+    monkeypatch.setattr(server, "_snapshot", lambda current: "snapshot")
+    result: list[str] = []
+    failures: list[BaseException] = []
+
+    def navigate() -> None:
+        try:
+            result.append(server.browser_navigate("https://slow.example.test"))
+        except BaseException as exc:  # pragma: no cover - assertion reports it
+            failures.append(exc)
+
+    worker = threading.Thread(target=navigate)
+    worker.start()
+    assert page.goto_started.wait(1), "tool did not acquire the lock and enter goto"
+
+    dialog = FakeDialog()
+    page.emit("dialog", dialog)
+    for index in range(100):
+        page.emit("console", MutableConsole())
+        page.emit(
+            "request",
+            MutableRequest(page, f"https://example.test/request/{index}"),
+        )
+
+    assert dialog.dismissed
+    assert len(registry.console_records) == 100
+    assert len(registry.network_records) == 100
+
+    page.allow_goto.set()
+    worker.join(timeout=2)
+    assert not worker.is_alive(), "tool/callback lock inversion deadlocked"
+    assert failures == []
+    assert result == ["snapshot"]
+
+
+def test_late_response_does_not_resurrect_an_evicted_network_record() -> None:
+    """An evicted request keeps its original unavailable index and stays evicted."""
+    state = SessionState(network_quota=1)
+    page = FakePage()
+    registry = state.register_page_handlers(page)
+    evicted = MutableRequest(page, "https://example.test/evicted")
+    retained = MutableRequest(page, "https://example.test/retained")
+
+    page.emit("request", evicted)
+    page.emit("request", retained)
+    assert [(record.index, record.url) for record in registry.network_records] == [
+        (2, retained.url)
+    ]
+
+    # The response/body for index 1 arrives after index 1 was quota-evicted.
+    # It must be ignored rather than reappearing under a different stable index.
+    page.emit("response", MutableResponse(evicted))
+    assert [(record.index, record.url) for record in registry.network_records] == [
+        (2, retained.url)
+    ]
+
+
+def test_page_registers_live_remote_once_then_fails_loudly_when_it_dies(
+    monkeypatch,
+) -> None:
+    class RemotePage(FakePage):
+        dead = False
+
+        def evaluate(self, expression):
+            if self.dead:
+                raise RuntimeError("transport closed")
+            return 1
+
+    class Closeable:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    class Stoppable:
+        stopped = False
+
+        def stop(self) -> None:
+            self.stopped = True
+
+    page = RemotePage()
+    browser = Closeable()
+    runtime = Stoppable()
+    state = SessionState(
+        pw=runtime,
+        browser=browser,
+        context=object(),
+        page=page,
+        remote=True,
+    )
+    monkeypatch.setattr(server, "_state", state)
+
+    assert server._page() is page
+    assert server._page() is page
+    assert all(len(callbacks) == 1 for callbacks in page.handlers.values())
+
+    page.dead = True
+    with pytest.raises(RuntimeError) as error:
+        server._page()
+    assert str(error.value) == (
+        "Remote CDP session is no longer reachable — reconnect/restart the MCP server."
+    )
+    assert browser.closed
+    assert runtime.stopped
+    assert state.page is None

--- a/mcp/tests/validation/test_adversarial_session.py
+++ b/mcp/tests/validation/test_adversarial_session.py
@@ -69,6 +69,8 @@ class MutableResponse:
 class FakeDialog:
     def __init__(self) -> None:
         self.dismissed = False
+        self.type = "alert"
+        self.message = "captured"
 
     def dismiss(self) -> None:
         self.dismissed = True
@@ -110,7 +112,6 @@ def test_callback_flood_completes_while_slow_tool_holds_tool_lock(monkeypatch) -
     state = SessionState(console_quota=200, network_quota=200)
     page = FakePage()
     registry = state.register_page_handlers(page)
-    state.arm_dialog(page, False, None)
     monkeypatch.setattr(server, "_state", state)
     monkeypatch.setattr(server, "_page", lambda: page)
     monkeypatch.setattr(server, "_snapshot", lambda current: "snapshot")
@@ -136,7 +137,8 @@ def test_callback_flood_completes_while_slow_tool_holds_tool_lock(monkeypatch) -
             MutableRequest(page, f"https://example.test/request/{index}"),
         )
 
-    assert dialog.dismissed
+    assert not dialog.dismissed
+    assert registry.pending_dialog is dialog
     assert len(registry.console_records) == 100
     assert len(registry.network_records) == 100
 
@@ -146,6 +148,7 @@ def test_callback_flood_completes_while_slow_tool_holds_tool_lock(monkeypatch) -
     assert failures == []
     assert len(result) == 1
     assert "### Snapshot\nsnapshot" in result[0]
+    assert "### Modal" in result[0]
 
 
 def test_late_response_does_not_resurrect_an_evicted_network_record() -> None:

--- a/mcp/tests/validation/test_adversarial_session.py
+++ b/mcp/tests/validation/test_adversarial_session.py
@@ -144,7 +144,8 @@ def test_callback_flood_completes_while_slow_tool_holds_tool_lock(monkeypatch) -
     worker.join(timeout=2)
     assert not worker.is_alive(), "tool/callback lock inversion deadlocked"
     assert failures == []
-    assert result == ["snapshot"]
+    assert len(result) == 1
+    assert "### Snapshot\nsnapshot" in result[0]
 
 
 def test_late_response_does_not_resurrect_an_evicted_network_record() -> None:

--- a/mcp/tests/validation/test_contract_and_identity.py
+++ b/mcp/tests/validation/test_contract_and_identity.py
@@ -1,0 +1,134 @@
+"""Clean-room contract and real-stdio identity/inventory validation."""
+
+from __future__ import annotations
+
+import asyncio
+from importlib import metadata
+import json
+import os
+from pathlib import Path
+import shutil
+import sys
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+import pytest
+
+FIXTURE = Path(__file__).parents[1] / "contract" / "fixtures" / "default_toolset.json"
+FORM_FIXTURE = Path(__file__).parents[1] / "fixtures" / "form.html"
+HARDENING_FIXTURE = Path(__file__).parents[1] / "fixtures" / "hardening.html"
+
+
+def _server_command() -> list[str]:
+    executable = shutil.which("rustwright-mcp")
+    if executable:
+        return [executable]
+    return [sys.executable, "-m", "rustwright_mcp"]
+
+
+async def _call(session, name: str, **arguments) -> str:
+    result = await session.call_tool(name, arguments)
+    text = "\n".join(item.text for item in result.content if item.type == "text")
+    if result.isError:
+        if "Failed to launch chromium" in text:
+            pytest.skip("no Chromium available for regression smoke")
+        raise AssertionError(f"{name} failed: {text}")
+    return text
+
+
+def test_contract_fixture_contains_only_neutral_schema_fields() -> None:
+    raw = json.loads(FIXTURE.read_text())
+    assert isinstance(raw, dict)
+    for tool_name, tool in raw.items():
+        assert isinstance(tool_name, str)
+        assert set(tool) == {"params"}
+        for param in tool["params"]:
+            assert set(param) <= {"name", "type", "enum", "default", "required"}
+            assert {"name", "type", "required"} <= set(param)
+
+
+def test_real_stdio_identity_and_complete_tool_inventory() -> None:
+    expected_tools = {
+        "browser_navigate",
+        "browser_snapshot",
+        "browser_click",
+        "browser_type",
+        "browser_select_option",
+        "browser_hover",
+        "browser_press_key",
+        "browser_navigate_back",
+        "browser_reload",
+        "browser_tabs",
+        "browser_handle_dialog",
+        "browser_wait_for",
+        "browser_get_text",
+        "browser_evaluate",
+        "browser_take_screenshot",
+        "browser_close",
+    }
+
+    async def checks() -> None:
+        command = _server_command()
+        env = dict(os.environ)
+        env["RUSTWRIGHT_MCP_ALLOW_EVAL"] = "1"
+        params = StdioServerParameters(command=command[0], args=command[1:], env=env)
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                initialized = await session.initialize()
+                assert initialized.serverInfo.name == "rustwright-mcp"
+                assert initialized.serverInfo.version == metadata.version(
+                    "rustwright-mcp"
+                )
+                assert {tool.name for tool in (await session.list_tools()).tools} == (
+                    expected_tools
+                )
+
+    asyncio.run(checks())
+
+
+def test_real_stdio_less_traveled_tool_regressions() -> None:
+    """Exercise the five tools/branches not covered by the original form flow."""
+
+    async def checks() -> None:
+        command = _server_command()
+        params = StdioServerParameters(
+            command=command[0],
+            args=command[1:],
+            env=dict(os.environ),
+        )
+        async with stdio_client(params) as (read, write):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+                await _call(session, "browser_navigate", url=FORM_FIXTURE.as_uri())
+                waited = await _call(session, "browser_wait_for", text="Order form")
+                assert waited.startswith("Page: Form Test")
+                hovered = await _call(session, "browser_hover", target="#name")
+                assert hovered.startswith("Page: Form Test")
+                await _call(session, "browser_click", target="#name")
+                keyed = await _call(session, "browser_press_key", key="A")
+                assert '[value="A"]' in keyed
+
+                opened = await _call(
+                    session,
+                    "browser_tabs",
+                    action="new",
+                    url=HARDENING_FIXTURE.as_uri(),
+                )
+                assert opened.startswith("Page: Hardening Test")
+                selected = await _call(
+                    session, "browser_tabs", action="select", index=0
+                )
+                assert selected.startswith("Page: Form Test")
+                selected = await _call(
+                    session, "browser_tabs", action="select", index=1
+                )
+                assert selected.startswith("Page: Hardening Test")
+
+                await _call(
+                    session, "browser_navigate", url=FORM_FIXTURE.as_uri()
+                )
+                backed = await _call(session, "browser_navigate_back")
+                assert backed.startswith("Page: Hardening Test")
+                assert await _call(session, "browser_close") == "Browser closed."
+
+    asyncio.run(checks())

--- a/mcp/tests/validation/test_contract_and_identity.py
+++ b/mcp/tests/validation/test_contract_and_identity.py
@@ -14,6 +14,8 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 import pytest
 
+from test_smoke import _result_section
+
 FIXTURE = Path(__file__).parents[1] / "contract" / "fixtures" / "default_toolset.json"
 FORM_FIXTURE = Path(__file__).parents[1] / "fixtures" / "form.html"
 HARDENING_FIXTURE = Path(__file__).parents[1] / "fixtures" / "hardening.html"
@@ -101,9 +103,9 @@ def test_real_stdio_less_traveled_tool_regressions() -> None:
                 await session.initialize()
                 await _call(session, "browser_navigate", url=FORM_FIXTURE.as_uri())
                 waited = await _call(session, "browser_wait_for", text="Order form")
-                assert waited.startswith("Page: Form Test")
+                assert "- Title: Form Test" in waited
                 hovered = await _call(session, "browser_hover", target="#name")
-                assert hovered.startswith("Page: Form Test")
+                assert "- Title: Form Test" in hovered
                 await _call(session, "browser_click", target="#name")
                 keyed = await _call(session, "browser_press_key", key="A")
                 assert '[value="A"]' in keyed
@@ -114,21 +116,23 @@ def test_real_stdio_less_traveled_tool_regressions() -> None:
                     action="new",
                     url=HARDENING_FIXTURE.as_uri(),
                 )
-                assert opened.startswith("Page: Hardening Test")
+                assert "- Title: Hardening Test" in opened
                 selected = await _call(
                     session, "browser_tabs", action="select", index=0
                 )
-                assert selected.startswith("Page: Form Test")
+                assert "- Title: Form Test" in selected
                 selected = await _call(
                     session, "browser_tabs", action="select", index=1
                 )
-                assert selected.startswith("Page: Hardening Test")
+                assert "- Title: Hardening Test" in selected
 
                 await _call(
                     session, "browser_navigate", url=FORM_FIXTURE.as_uri()
                 )
                 backed = await _call(session, "browser_navigate_back")
-                assert backed.startswith("Page: Hardening Test")
-                assert await _call(session, "browser_close") == "Browser closed."
+                assert "- Title: Hardening Test" in backed
+                assert _result_section(await _call(session, "browser_close")) == (
+                    "Browser closed."
+                )
 
     asyncio.run(checks())

--- a/mcp/tests/validation/test_contract_and_identity.py
+++ b/mcp/tests/validation/test_contract_and_identity.py
@@ -67,6 +67,14 @@ def test_real_stdio_identity_and_complete_tool_inventory() -> None:
         "browser_evaluate",
         "browser_take_screenshot",
         "browser_close",
+        "browser_console_messages",
+        "browser_drag",
+        "browser_file_upload",
+        "browser_fill_form",
+        "browser_find",
+        "browser_network_request",
+        "browser_network_requests",
+        "browser_resize",
     }
 
     async def checks() -> None:

--- a/mcp/tests/validation/test_contract_and_identity.py
+++ b/mcp/tests/validation/test_contract_and_identity.py
@@ -39,14 +39,27 @@ async def _call(session, name: str, **arguments) -> str:
 
 
 def test_contract_fixture_contains_only_neutral_schema_fields() -> None:
+    def assert_shape(shape: dict, *, parameter: bool) -> None:
+        structural = {"type", "enum", "default", "items", "params", "additionalProperties"}
+        allowed = structural | ({"name", "required"} if parameter else set())
+        assert set(shape) <= allowed
+        assert "type" in shape
+        if parameter:
+            assert {"name", "required"} <= set(shape)
+        if "items" in shape:
+            assert_shape(shape["items"], parameter=False)
+        if "additionalProperties" in shape:
+            assert_shape(shape["additionalProperties"], parameter=False)
+        for nested in shape.get("params", []):
+            assert_shape(nested, parameter=True)
+
     raw = json.loads(FIXTURE.read_text())
     assert isinstance(raw, dict)
     for tool_name, tool in raw.items():
         assert isinstance(tool_name, str)
         assert set(tool) == {"params"}
         for param in tool["params"]:
-            assert set(param) <= {"name", "type", "enum", "default", "required"}
-            assert {"name", "type", "required"} <= set(param)
+            assert_shape(param, parameter=True)
 
 
 def test_real_stdio_identity_and_complete_tool_inventory() -> None:

--- a/mcp/tests/validation/test_contract_and_identity.py
+++ b/mcp/tests/validation/test_contract_and_identity.py
@@ -69,6 +69,7 @@ def test_real_stdio_identity_and_complete_tool_inventory() -> None:
         "browser_close",
         "browser_console_messages",
         "browser_drag",
+        "browser_drop",
         "browser_file_upload",
         "browser_fill_form",
         "browser_find",

--- a/mcp/tests/validation/test_pr2_adversarial_compatibility.py
+++ b/mcp/tests/validation/test_pr2_adversarial_compatibility.py
@@ -1,0 +1,476 @@
+"""Independent adversarial validation for the Phase-A compatibility surface."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+import re
+import sys
+
+from mcp.server.fastmcp.exceptions import ToolError
+import pytest
+
+from rustwright_mcp import server
+from rustwright_mcp.filepolicy import FilePolicy
+from rustwright_mcp.session import SessionState
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+from test_pr2_compatibility import FakePage, _stdio_tools, _tool_call
+from test_smoke import FIXTURE, _call, _result_section, _run_session
+
+
+ADAPTED_CONTRACT = {
+    "browser_click": [
+        {"name": "element", "type": "string", "required": False},
+        {"name": "target", "type": "string", "required": True},
+        {
+            "name": "doubleClick",
+            "type": "boolean",
+            "required": False,
+            "default": False,
+        },
+        {
+            "name": "button",
+            "type": "string",
+            "required": False,
+            "enum": ["left", "right", "middle"],
+            "default": "left",
+        },
+        {
+            "name": "modifiers",
+            "type": "array",
+            "required": False,
+            "enum": ["Alt", "Control", "ControlOrMeta", "Meta", "Shift"],
+        },
+    ],
+    "browser_type": [
+        {"name": "element", "type": "string", "required": False},
+        {"name": "target", "type": "string", "required": True},
+        {"name": "text", "type": "string", "required": True},
+        {"name": "submit", "type": "boolean", "required": False, "default": False},
+        {"name": "slowly", "type": "boolean", "required": False, "default": False},
+    ],
+    "browser_select_option": [
+        {"name": "element", "type": "string", "required": False},
+        {"name": "target", "type": "string", "required": True},
+        {"name": "values", "type": "array", "required": True},
+    ],
+    "browser_hover": [
+        {"name": "element", "type": "string", "required": False},
+        {"name": "target", "type": "string", "required": True},
+    ],
+    "browser_snapshot": [
+        {"name": "target", "type": "string", "required": False},
+        {"name": "filename", "type": "string", "required": False},
+        {"name": "depth", "type": "number", "required": False},
+        {"name": "boxes", "type": "boolean", "required": False},
+    ],
+    "browser_take_screenshot": [
+        {"name": "element", "type": "string", "required": False},
+        {"name": "target", "type": "string", "required": False},
+        {
+            "name": "type",
+            "type": "string",
+            "required": False,
+            "enum": ["png", "jpeg"],
+            "default": "png",
+        },
+        {"name": "filename", "type": "string", "required": False},
+        {
+            "name": "fullPage",
+            "type": "boolean",
+            "required": False,
+            "default": False,
+        },
+        {
+            "name": "scale",
+            "type": "string",
+            "required": False,
+            "enum": ["css", "device"],
+            "default": "css",
+        },
+    ],
+    "browser_evaluate": [
+        {"name": "element", "type": "string", "required": False},
+        {"name": "target", "type": "string", "required": False},
+        {"name": "function", "type": "string", "required": True},
+        {"name": "filename", "type": "string", "required": False},
+    ],
+    "browser_handle_dialog": [
+        {"name": "accept", "type": "boolean", "required": True},
+        {"name": "promptText", "type": "string", "required": False},
+    ],
+    "browser_wait_for": [
+        {"name": "time", "type": "number", "required": False},
+        {"name": "text", "type": "string", "required": False},
+        {"name": "textGone", "type": "string", "required": False},
+    ],
+    "browser_tabs": [
+        {
+            "name": "action",
+            "type": "string",
+            "required": True,
+            "enum": ["list", "new", "close", "select"],
+        },
+        {"name": "index", "type": "integer", "required": False},
+        {"name": "url", "type": "string", "required": False},
+    ],
+}
+
+
+@pytest.fixture
+def fake_runtime(monkeypatch, tmp_path) -> tuple[FakePage, SessionState, FilePolicy]:
+    page = FakePage()
+    state = SessionState(page=page)
+    policy = FilePolicy(output_root=tmp_path / "output")
+    monkeypatch.setattr(server, "_state", state)
+    monkeypatch.setattr(server, "_page", lambda: state.page)
+    monkeypatch.setattr(server, "_snapshot", lambda *args, **kwargs: "- snapshot")
+    monkeypatch.setattr(server, "get_file_policy", lambda: policy)
+    return page, state, policy
+
+
+def test_fixture_exactly_matches_the_ten_audited_schemas_and_has_no_prose() -> None:
+    fixture_path = (
+        Path(__file__).parents[1] / "contract" / "fixtures" / "default_toolset.json"
+    )
+    raw = json.loads(fixture_path.read_text())
+
+    for tool_name, params in ADAPTED_CONTRACT.items():
+        assert raw[tool_name] == {"params": params}
+    for tool in raw.values():
+        assert set(tool) == {"params"}
+        for param in tool["params"]:
+            assert set(param) <= {"name", "type", "required", "enum", "default"}
+
+
+def test_alias_conflicts_always_prefer_the_canonical_spelling(fake_runtime) -> None:
+    page, state, policy = fake_runtime
+    _tool_call(
+        "browser_click",
+        {"target": "#click", "doubleClick": True, "double_click": False},
+    )
+    _tool_call(
+        "browser_select_option",
+        {"target": "#select", "values": ["canonical"], "value": "legacy"},
+    )
+    _tool_call(
+        "browser_take_screenshot",
+        {
+            "filename": "capture.png",
+            "fullPage": True,
+            "full_page": False,
+        },
+    )
+    evaluate = _tool_call(
+        "browser_evaluate",
+        {"function": "canonical", "expression": "legacy"},
+    )
+    _tool_call(
+        "browser_handle_dialog",
+        {"accept": True, "promptText": "canonical", "prompt_text": "legacy"},
+    )
+    _tool_call(
+        "browser_wait_for",
+        {"textGone": "canonical", "text_gone": "legacy"},
+    )
+
+    click = next(event for event in page.events if event[0] == "click")
+    selected = next(event for event in page.events if event[0] == "select")
+    screenshot = next(event for event in page.events if event[0] == "page-screenshot")
+    waits = [event for event in page.events if event[0] == "text-wait"]
+    assert click[2]["click_count"] == 2
+    assert selected[2] == ["canonical"]
+    assert screenshot[-1] is True
+    assert (policy.output_root / "capture.png").exists()
+    assert "canonical" in evaluate and "legacy" not in evaluate
+    assert state.dialog_intent is not None
+    assert state.dialog_intent.prompt_text == "canonical"
+    assert waits == [("text-wait", "canonical", "hidden", 10_000)]
+
+
+def test_advertised_schemas_are_canonical_and_exact(fake_runtime) -> None:
+    del fake_runtime
+    schemas = {
+        tool.name: tool.inputSchema for tool in asyncio.run(server.mcp.list_tools())
+    }
+    extension_names = {
+        "browser_type": {"clear"},
+        "browser_wait_for": {"timeout_ms"},
+    }
+    hidden_aliases = {
+        "double_click",
+        "value",
+        "path",
+        "full_page",
+        "expression",
+        "prompt_text",
+        "text_gone",
+    }
+
+    for tool_name, contract in ADAPTED_CONTRACT.items():
+        schema = schemas[tool_name]
+        expected = {param["name"] for param in contract}
+        expected |= extension_names.get(tool_name, set())
+        assert set(schema["properties"]) == expected
+        assert not hidden_aliases & set(schema["properties"])
+        assert set(schema.get("required", ())) == {
+            param["name"] for param in contract if param["required"]
+        }
+
+        for param in contract:
+            advertised = schema["properties"][param["name"]]
+            if "default" in param:
+                assert advertised["default"] == param["default"]
+            if "enum" in param:
+                candidate = advertised
+                if "enum" not in candidate:
+                    candidate = next(
+                        option
+                        for option in advertised.get("anyOf", ())
+                        if "enum" in option or "items" in option
+                    )
+                actual_enum = candidate.get("enum", candidate.get("items", {}).get("enum"))
+                assert actual_enum == param["enum"]
+
+
+UNKNOWN_CASES = [
+    ("browser_click", {"target": "#x"}),
+    ("browser_type", {"target": "#x", "text": "value"}),
+    ("browser_select_option", {"target": "#x", "values": ["value"]}),
+    ("browser_hover", {"target": "#x"}),
+    ("browser_snapshot", {}),
+    ("browser_take_screenshot", {"filename": "unknown.png"}),
+    ("browser_evaluate", {"function": "() => 1"}),
+    ("browser_handle_dialog", {"accept": True}),
+    ("browser_wait_for", {"time": 0}),
+    ("browser_tabs", {"action": "list"}),
+]
+
+
+@pytest.mark.parametrize(("tool_name", "valid"), UNKNOWN_CASES)
+def test_unknown_parameters_are_structured_rejections(
+    fake_runtime, tool_name: str, valid: dict
+) -> None:
+    del fake_runtime
+    with pytest.raises(ToolError, match="validation error"):
+        _tool_call(tool_name, {**valid, "semantic_change": True})
+
+
+def test_wait_cap_missing_condition_and_hidden_state(fake_runtime) -> None:
+    page, _, _ = fake_runtime
+    _tool_call("browser_wait_for", {"time": 31, "textGone": "departed"})
+    assert ("time-wait", 30_000) in page.events
+    assert ("text-wait", "departed", "hidden", 10_000) in page.events
+
+    with pytest.raises(ToolError, match="At least one"):
+        _tool_call("browser_wait_for", {})
+
+
+def test_tabs_close_current_middle_and_every_action_returns_tabs(fake_runtime) -> None:
+    first, state, _ = fake_runtime
+    second = first.context.new_page()
+    third = first.context.new_page()
+    state.page = second
+
+    listed = _tool_call("browser_tabs", {"action": "list"})
+    selected = _tool_call("browser_tabs", {"action": "select", "index": 1})
+    closed = _tool_call("browser_tabs", {"action": "close"})
+    opened = _tool_call("browser_tabs", {"action": "new"})
+
+    assert second not in first.context.pages
+    assert state.page is first.context.pages[-1]
+    assert first in first.context.pages and third in first.context.pages
+    assert all("### Tabs" in response for response in (listed, selected, closed, opened))
+    with pytest.raises(ToolError, match="Invalid tab index"):
+        _tool_call("browser_tabs", {"action": "select", "index": 99})
+
+
+def test_envelope_order_and_one_snapshot_per_mutating_adapter(
+    fake_runtime, monkeypatch
+) -> None:
+    _, state, _ = fake_runtime
+    snapshot_calls: list[object] = []
+
+    def counted_snapshot(page, **kwargs):
+        snapshot_calls.append(page)
+        return "- counted snapshot"
+
+    monkeypatch.setattr(server, "_snapshot", counted_snapshot)
+    cases = [
+        ("browser_click", {"target": "#x"}, False),
+        ("browser_type", {"target": "#x", "text": "value"}, False),
+        ("browser_select_option", {"target": "#x", "values": ["value"]}, False),
+        ("browser_hover", {"target": "#x"}, False),
+        ("browser_wait_for", {"time": 0}, False),
+        ("browser_evaluate", {"function": "() => 1"}, False),
+        ("browser_tabs", {"action": "new"}, True),
+        ("browser_tabs", {"action": "select", "index": 0}, True),
+        ("browser_tabs", {"action": "close"}, True),
+    ]
+
+    for tool_name, arguments, has_tabs in cases:
+        before = len(snapshot_calls)
+        response = _tool_call(tool_name, arguments)
+        assert len(snapshot_calls) == before + 1, tool_name
+        expected = ["### Result", "### Page"]
+        if has_tabs:
+            expected.append("### Tabs")
+        expected.append("### Snapshot")
+        assert re.findall(r"(?m)^### [^\n]+$", response) == expected
+        assert state.page is not None
+
+
+def test_caps_environment_precedence_and_eval_startup_warning_once() -> None:
+    tools, stderr = asyncio.run(
+        _stdio_tools(
+            env_overrides={"RUSTWRIGHT_MCP_CAPS": "network"},
+            extra_args=["--caps=storage,bogus"],
+        )
+    )
+    assert "browser_navigate" in tools
+    assert "capability group 'network' is not implemented" in stderr
+    assert "capability group 'storage'" not in stderr
+    assert "capability group 'bogus'" not in stderr
+    assert stderr.count("warning: browser_evaluate is enabled") == 1
+
+    for profile in ("mirror", "lean"):
+        disabled, disabled_stderr = asyncio.run(
+            _stdio_tools(
+                env_overrides={
+                    "RUSTWRIGHT_MCP_TOOLSET": profile,
+                    "RUSTWRIGHT_MCP_ALLOW_EVAL": "0",
+                }
+            )
+        )
+        assert "browser_evaluate" not in disabled
+        assert "warning: browser_evaluate is enabled" not in disabled_stderr
+
+
+def test_real_browser_adversarial_schema_semantics(tmp_path) -> None:
+    output_root = tmp_path / "output"
+    escaped = tmp_path / "escaped.jpeg"
+    invalid_boxes: list[str] = []
+
+    async def checks(session) -> None:
+        await _call(session, "browser_navigate", url=FIXTURE.as_uri())
+
+        depth_zero = await _call(session, "browser_snapshot", target="#f", depth=0)
+        depth_one = await _call(session, "browser_snapshot", target="#f", depth=1)
+        boxes = await _call(session, "browser_snapshot", target="#f", boxes=True)
+        assert "- form" in depth_zero
+        assert "textbox" not in depth_zero
+        assert 'textbox "Customer name"' in depth_one
+        assert 'option "Small"' not in depth_one
+        box_values = re.findall(r"\[box=([^\]]+)\]", boxes)
+        assert box_values
+        for raw_box in box_values:
+            parts = raw_box.split(",")
+            if len(parts) != 4 or not all(
+                re.fullmatch(r"-?\d+", part) for part in parts
+            ):
+                invalid_boxes.append(raw_box)
+                continue
+            x, y, width, height = map(int, parts)
+            if not (
+                -2000 <= x <= 4000
+                and -2000 <= y <= 4000
+                and 0 < width <= 4000
+                and 0 < height <= 4000
+            ):
+                invalid_boxes.append(raw_box)
+
+        negative_depth = await session.call_tool(
+            "browser_snapshot", {"target": "#f", "depth": -1}
+        )
+        assert negative_depth.isError
+        assert "depth must be non-negative" in "\n".join(
+            item.text for item in negative_depth.content if item.type == "text"
+        )
+
+        evaluated = await _call(
+            session,
+            "browser_evaluate",
+            function="el => el.tagName",
+            element="Customer name",
+            target="#name",
+        )
+        assert json.loads(_result_section(evaluated)) == "INPUT"
+
+        conflict = await session.call_tool(
+            "browser_take_screenshot",
+            {"element": "Form", "target": "#f", "fullPage": True},
+        )
+        assert conflict.isError
+        assert "mutually exclusive" in "\n".join(
+            item.text for item in conflict.content if item.type == "text"
+        )
+
+        traversal = await session.call_tool(
+            "browser_take_screenshot",
+            {"type": "jpeg", "filename": "../escaped.jpeg"},
+        )
+        assert traversal.isError
+        assert "confined to RUSTWRIGHT_MCP_OUTPUT_DIR" in "\n".join(
+            item.text for item in traversal.content if item.type == "text"
+        )
+        assert not escaped.exists()
+
+        await _call(
+            session,
+            "browser_take_screenshot",
+            type="png",
+            filename="device.png",
+            scale="device",
+        )
+        assert (output_root / "device.png").read_bytes().startswith(b"\x89PNG")
+        await _call(
+            session,
+            "browser_take_screenshot",
+            type="jpeg",
+            filename="capture.jpeg",
+        )
+        assert (output_root / "capture.jpeg").read_bytes().startswith(b"\xff\xd8\xff")
+
+        tab_responses = []
+        tab_responses.append(
+            await _call(
+                session,
+                "browser_tabs",
+                action="new",
+                url="data:text/html,<title>Middle</title><p>middle</p>",
+            )
+        )
+        tab_responses.append(
+            await _call(
+                session,
+                "browser_tabs",
+                action="new",
+                url="data:text/html,<title>Last</title><p>last</p>",
+            )
+        )
+        tab_responses.append(await _call(session, "browser_tabs", action="select", index=1))
+        tab_responses.append(await _call(session, "browser_tabs", action="close"))
+        tab_responses.append(await _call(session, "browser_tabs", action="list"))
+        assert all("### Tabs" in response for response in tab_responses)
+        assert "Middle" not in tab_responses[-1]
+        assert "Form Test" in tab_responses[-1]
+        assert "Last" in tab_responses[-1]
+
+        out_of_bounds = await session.call_tool(
+            "browser_tabs", {"action": "select", "index": 99}
+        )
+        assert out_of_bounds.isError
+        assert "Invalid tab index" in "\n".join(
+            item.text for item in out_of_bounds.content if item.type == "text"
+        )
+        await _call(session, "browser_close")
+        assert invalid_boxes == [], f"non-integer or implausible boxes: {invalid_boxes}"
+
+    asyncio.run(
+        _run_session(
+            checks,
+            {"RUSTWRIGHT_MCP_OUTPUT_DIR": str(output_root)},
+        )
+    )

--- a/mcp/tests/validation/test_pr2_adversarial_compatibility.py
+++ b/mcp/tests/validation/test_pr2_adversarial_compatibility.py
@@ -41,7 +41,10 @@ ADAPTED_CONTRACT = {
             "name": "modifiers",
             "type": "array",
             "required": False,
-            "enum": ["Alt", "Control", "ControlOrMeta", "Meta", "Shift"],
+            "items": {
+                "type": "string",
+                "enum": ["Alt", "Control", "ControlOrMeta", "Meta", "Shift"],
+            },
         },
     ],
     "browser_type": [
@@ -50,11 +53,17 @@ ADAPTED_CONTRACT = {
         {"name": "text", "type": "string", "required": True},
         {"name": "submit", "type": "boolean", "required": False, "default": False},
         {"name": "slowly", "type": "boolean", "required": False, "default": False},
+        {"name": "clear", "type": "boolean", "required": False, "default": True},
     ],
     "browser_select_option": [
         {"name": "element", "type": "string", "required": False},
         {"name": "target", "type": "string", "required": True},
-        {"name": "values", "type": "array", "required": True},
+        {
+            "name": "values",
+            "type": "array",
+            "required": True,
+            "items": {"type": "string"},
+        },
     ],
     "browser_hover": [
         {"name": "element", "type": "string", "required": False},
@@ -64,7 +73,12 @@ ADAPTED_CONTRACT = {
         {"name": "target", "type": "string", "required": False},
         {"name": "filename", "type": "string", "required": False},
         {"name": "depth", "type": "number", "required": False},
-        {"name": "boxes", "type": "boolean", "required": False},
+        {
+            "name": "boxes",
+            "type": "boolean",
+            "required": False,
+            "default": False,
+        },
     ],
     "browser_take_screenshot": [
         {"name": "element", "type": "string", "required": False},
@@ -105,6 +119,12 @@ ADAPTED_CONTRACT = {
         {"name": "time", "type": "number", "required": False},
         {"name": "text", "type": "string", "required": False},
         {"name": "textGone", "type": "string", "required": False},
+        {
+            "name": "timeout_ms",
+            "type": "number",
+            "required": False,
+            "default": 10000,
+        },
     ],
     "browser_tabs": [
         {
@@ -132,6 +152,17 @@ def fake_runtime(monkeypatch, tmp_path) -> tuple[FakePage, SessionState, FilePol
 
 
 def test_fixture_exactly_matches_the_ten_audited_schemas_and_has_no_prose() -> None:
+    def assert_neutral(shape: dict, *, parameter: bool) -> None:
+        structural = {"type", "enum", "default", "items", "params", "additionalProperties"}
+        allowed = structural | ({"name", "required"} if parameter else set())
+        assert set(shape) <= allowed
+        if "items" in shape:
+            assert_neutral(shape["items"], parameter=False)
+        if "additionalProperties" in shape:
+            assert_neutral(shape["additionalProperties"], parameter=False)
+        for nested in shape.get("params", []):
+            assert_neutral(nested, parameter=True)
+
     fixture_path = (
         Path(__file__).parents[1] / "contract" / "fixtures" / "default_toolset.json"
     )
@@ -142,7 +173,7 @@ def test_fixture_exactly_matches_the_ten_audited_schemas_and_has_no_prose() -> N
     for tool in raw.values():
         assert set(tool) == {"params"}
         for param in tool["params"]:
-            assert set(param) <= {"name", "type", "required", "enum", "default"}
+            assert_neutral(param, parameter=True)
 
 
 def test_alias_conflicts_always_prefer_the_canonical_spelling(fake_runtime) -> None:

--- a/mcp/tests/validation/test_pr2_adversarial_compatibility.py
+++ b/mcp/tests/validation/test_pr2_adversarial_compatibility.py
@@ -147,6 +147,13 @@ def test_fixture_exactly_matches_the_ten_audited_schemas_and_has_no_prose() -> N
 
 def test_alias_conflicts_always_prefer_the_canonical_spelling(fake_runtime) -> None:
     page, state, policy = fake_runtime
+
+    class Dialog:
+        prompt_text = None
+
+        def accept(self, prompt_text=None) -> None:
+            self.prompt_text = prompt_text
+
     _tool_call(
         "browser_click",
         {"target": "#click", "doubleClick": True, "double_click": False},
@@ -167,6 +174,8 @@ def test_alias_conflicts_always_prefer_the_canonical_spelling(fake_runtime) -> N
         "browser_evaluate",
         {"function": "canonical", "expression": "legacy"},
     )
+    dialog = Dialog()
+    state.registry_for(page, create=True).pending_dialog = dialog
     _tool_call(
         "browser_handle_dialog",
         {"accept": True, "promptText": "canonical", "prompt_text": "legacy"},
@@ -185,8 +194,7 @@ def test_alias_conflicts_always_prefer_the_canonical_spelling(fake_runtime) -> N
     assert screenshot[-1] is True
     assert (policy.output_root / "capture.png").exists()
     assert "canonical" in evaluate and "legacy" not in evaluate
-    assert state.dialog_intent is not None
-    assert state.dialog_intent.prompt_text == "canonical"
+    assert dialog.prompt_text == "canonical"
     assert waits == [("text-wait", "canonical", "hidden", 10_000)]
 
 

--- a/mcp/tests/validation/test_pr3_adversarial_validation.py
+++ b/mcp/tests/validation/test_pr3_adversarial_validation.py
@@ -39,7 +39,32 @@ AUDITED_PR3_CONTRACT = {
         {"name": "endTarget", "type": "string", "required": True},
     ],
     "browser_fill_form": [
-        {"name": "fields", "type": "array", "required": True},
+        {
+            "name": "fields",
+            "type": "array",
+            "required": True,
+            "items": {
+                "type": "object",
+                "params": [
+                    {"name": "element", "type": "string", "required": False},
+                    {"name": "target", "type": "string", "required": True},
+                    {"name": "name", "type": "string", "required": True},
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "required": True,
+                        "enum": [
+                            "textbox",
+                            "checkbox",
+                            "radio",
+                            "combobox",
+                            "slider",
+                        ],
+                    },
+                    {"name": "value", "type": "string", "required": True},
+                ],
+            },
+        },
     ],
     "browser_find": [
         {"name": "text", "type": "string", "required": False},
@@ -77,7 +102,12 @@ AUDITED_PR3_CONTRACT = {
         {"name": "filename", "type": "string", "required": False},
     ],
     "browser_file_upload": [
-        {"name": "paths", "type": "array", "required": False},
+        {
+            "name": "paths",
+            "type": "array",
+            "required": False,
+            "items": {"type": "string"},
+        },
     ],
 }
 

--- a/mcp/tests/validation/test_pr3_adversarial_validation.py
+++ b/mcp/tests/validation/test_pr3_adversarial_validation.py
@@ -1,0 +1,485 @@
+"""Independent adversarial validation for the PR-3 MCP compatibility slice."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+from pathlib import Path
+import re
+from types import SimpleNamespace
+import sys
+
+import pytest
+
+from rustwright_mcp import server
+from rustwright_mcp.filepolicy import FilePolicy
+from rustwright_mcp.session import (
+    ConsoleRecord,
+    DownloadRecord,
+    NetworkRecord,
+    SessionState,
+)
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+from contract.contract_schema import ToolContract, compare_tool_schema
+from test_pr3_compatibility import fixture_server
+from test_smoke import _call, _run_session
+
+
+AUDITED_PR3_CONTRACT = {
+    "browser_resize": [
+        {"name": "width", "type": "number", "required": True},
+        {"name": "height", "type": "number", "required": True},
+    ],
+    "browser_drag": [
+        {"name": "startElement", "type": "string", "required": False},
+        {"name": "startTarget", "type": "string", "required": True},
+        {"name": "endElement", "type": "string", "required": False},
+        {"name": "endTarget", "type": "string", "required": True},
+    ],
+    "browser_fill_form": [
+        {"name": "fields", "type": "array", "required": True},
+    ],
+    "browser_find": [
+        {"name": "text", "type": "string", "required": False},
+        {"name": "regex", "type": "string", "required": False},
+    ],
+    "browser_console_messages": [
+        {
+            "name": "level",
+            "type": "string",
+            "required": False,
+            "enum": ["error", "warning", "info", "debug"],
+            "default": "info",
+        },
+        {"name": "all", "type": "boolean", "required": False, "default": False},
+        {"name": "filename", "type": "string", "required": False},
+    ],
+    "browser_network_requests": [
+        {"name": "static", "type": "boolean", "required": False, "default": False},
+        {"name": "filter", "type": "string", "required": False},
+        {"name": "filename", "type": "string", "required": False},
+    ],
+    "browser_network_request": [
+        {"name": "index", "type": "integer", "required": True},
+        {
+            "name": "part",
+            "type": "string",
+            "required": False,
+            "enum": [
+                "request-headers",
+                "request-body",
+                "response-headers",
+                "response-body",
+            ],
+        },
+        {"name": "filename", "type": "string", "required": False},
+    ],
+    "browser_file_upload": [
+        {"name": "paths", "type": "array", "required": False},
+    ],
+}
+
+
+class FakePage:
+    def __init__(self, title: str = "Adversarial fixture") -> None:
+        self.handlers: dict[str, list] = {}
+        self.url = "https://example.test/"
+        self._title = title
+        self.context = SimpleNamespace(pages=[self])
+
+    def on(self, event, callback) -> None:
+        self.handlers.setdefault(event, []).append(callback)
+
+    def title(self) -> str:
+        return self._title
+
+    def emit(self, event, value) -> None:
+        for callback in self.handlers.get(event, ()):
+            callback(value)
+
+
+def _error_text(result) -> str:
+    return "\n".join(item.text for item in result.content if item.type == "text")
+
+
+def test_fixture_and_advertised_schemas_match_all_eight_audited_contracts() -> None:
+    fixture_path = (
+        Path(__file__).parents[1] / "contract" / "fixtures" / "default_toolset.json"
+    )
+    fixture = json.loads(fixture_path.read_text())
+    schemas = {
+        tool.name: tool.inputSchema for tool in asyncio.run(server.mcp.list_tools())
+    }
+    errors: list[str] = []
+
+    for name, params in AUDITED_PR3_CONTRACT.items():
+        expected = {"params": params}
+        if fixture.get(name) != expected:
+            errors.append(
+                f"{name} fixture differs: expected {expected!r}, got {fixture.get(name)!r}"
+            )
+        contract = ToolContract.from_mapping(name, expected)
+        for mismatch in compare_tool_schema(schemas[name], contract):
+            errors.append(f"{name} advertised schema: {mismatch}")
+
+    assert errors == []
+
+
+def test_network_static_set_body_modes_and_full_filename(monkeypatch, tmp_path) -> None:
+    records = [
+        SimpleNamespace(
+            index=index,
+            url=f"https://example.test/{resource_type}",
+            resource_type=resource_type,
+            response_status=status,
+        )
+        for index, (resource_type, status) in enumerate(
+            [
+                ("image", 200),
+                ("media", 204),
+                ("font", 304),
+                ("stylesheet", 200),
+                ("script", 200),
+                ("image", 404),
+            ],
+            start=1,
+        )
+    ]
+    visible = server._filter_network_records(
+        records, include_static=False, pattern=None
+    )
+    assert [(record.resource_type, record.response_status) for record in visible] == [
+        ("script", 200),
+        ("image", 404),
+    ]
+
+    page = FakePage()
+    state = SessionState(page=page)
+    registry = state.register_page_handlers(page)
+    policy = FilePolicy(output_root=tmp_path / "output")
+    monkeypatch.setattr(server, "_state", state)
+    monkeypatch.setattr(server, "_page", lambda: page)
+    monkeypatch.setattr(server, "get_file_policy", lambda: policy)
+
+    large_body = b"x" * (server.NETWORK_BODY_INLINE_BYTES + 4096)
+    large_record = NetworkRecord(
+        epoch=0,
+        index=7,
+        method="GET",
+        url="https://example.test/large",
+        resource_type="fetch",
+        headers=(),
+        post_data=None,
+        request=object(),
+        response_status=200,
+        response_headers=(("content-type", "text/plain"),),
+        response=SimpleNamespace(body=lambda: large_body),
+    )
+    registry.network_records.append(large_record)
+
+    inline = server.browser_network_request(7, part="response-body")
+    assert f"truncated to {server.NETWORK_BODY_INLINE_BYTES} bytes inline" in inline
+    assert inline.count("x") >= server.NETWORK_BODY_INLINE_BYTES
+    written = server.browser_network_request(
+        7, part="response-body", filename="large-response.txt"
+    )
+    assert "large-response.txt" in written
+    saved = (policy.output_root / "large-response.txt").read_bytes()
+    assert large_body in saved
+    assert b"truncated" not in saved
+
+    binary = SimpleNamespace(
+        response=SimpleNamespace(body=lambda: b"\x00\x01\xfe\xff"),
+        response_headers=(("content-type", "application/octet-stream"),),
+    )
+    binary_text = server._response_body_text(binary, byte_limit=64)
+    assert base64.b64encode(b"\x00\x01\xfe\xff").decode() in binary_text
+    assert "base64-encoded non-text" in binary_text
+    aborted = SimpleNamespace(response=None, response_headers=())
+    assert server._response_body_text(aborted, byte_limit=64) == "(response not received)"
+
+
+def test_old_network_index_is_invalid_after_navigation_epoch_reset(tmp_path) -> None:
+    with fixture_server() as url:
+        async def checks(session) -> None:
+            try:
+                await _call(session, "browser_navigate", url=url)
+                first = await _call(session, "browser_network_requests", static=True)
+                old_index = int(
+                    re.search(r"\[(\d+)\] .* \(document\)", first).group(1)
+                )
+
+                await _call(session, "browser_navigate", url=url + "?epoch=2")
+                current = await _call(
+                    session, "browser_network_requests", static=True
+                )
+                current_document_index = int(
+                    re.search(r"\[(\d+)\] .* \(document\)", current).group(1)
+                )
+                assert current_document_index != old_index, (
+                    "request indices were reused across navigation epochs, so an old "
+                    "integer can silently select a different request"
+                )
+                old_detail = await session.call_tool(
+                    "browser_network_request", {"index": old_index}
+                )
+                assert old_detail.isError
+                assert "current navigation epoch" in _error_text(old_detail)
+            finally:
+                await session.call_tool("browser_close", {})
+
+        asyncio.run(
+            _run_session(
+                checks,
+                {"RUSTWRIGHT_MCP_OUTPUT_DIR": str(tmp_path / "output")},
+            )
+        )
+
+
+def test_background_tab_dialog_is_reported_while_acting_on_first_tab(
+    monkeypatch,
+) -> None:
+    first = FakePage("First")
+    second = FakePage("Second")
+    context = SimpleNamespace(pages=[first, second])
+    first.context = context
+    second.context = context
+    state = SessionState(page=first)
+    state.register_page_handlers(first)
+    second_registry = state.register_page_handlers(second)
+    second_registry.pending_dialog = SimpleNamespace(
+        type="alert", message="second-tab alert"
+    )
+    monkeypatch.setattr(server, "_state", state)
+    monkeypatch.setattr(server, "_page", lambda: first)
+    monkeypatch.setattr(server, "_snapshot", lambda page, **kwargs: "- fresh")
+
+    response = server.browser_snapshot()
+    assert "### Modal" in response
+    assert "second-tab alert" in response
+    assert "### Snapshot" not in response
+
+
+def test_download_cap_failure_collision_and_response_cursor(monkeypatch, tmp_path) -> None:
+    page = FakePage()
+    state = SessionState(page=page)
+    state.register_page_handlers(page)
+    capped_policy = FilePolicy(
+        output_root=tmp_path / "capped",
+        max_file_bytes=4,
+        max_total_bytes=100,
+    )
+    monkeypatch.setattr(server, "_state", state)
+    monkeypatch.setattr(server, "get_file_policy", lambda: capped_policy)
+    state.download_saver = server._save_download
+
+    class Download:
+        url = "https://example.test/download"
+
+        def __init__(self, payload: bytes, suggested_filename: str) -> None:
+            self.payload = payload
+            self.suggested_filename = suggested_filename
+
+        def save_as(self, path: str) -> None:
+            Path(path).write_bytes(self.payload)
+
+    page.emit("download", Download(b"oversize", "oversize.txt"))
+    capped = server._render_response("clicked", page=page)
+    assert capped.count("### Downloads") == 1
+    assert "oversize.txt" in capped
+    assert "save failed" in capped and "per-file cap" in capped
+    assert list(capped_policy.output_root.iterdir()) == []
+    assert "### Downloads" not in server._render_response("next", page=page)
+
+    collision_page = FakePage()
+    collision_state = SessionState(page=collision_page)
+    collision_state.register_page_handlers(collision_page)
+    collision_policy = FilePolicy(output_root=tmp_path / "collisions")
+    monkeypatch.setattr(server, "_state", collision_state)
+    monkeypatch.setattr(server, "get_file_policy", lambda: collision_policy)
+    collision_state.download_saver = server._save_download
+    collision_page.emit("download", Download(b"first", "../unsafe name.txt"))
+    collision_page.emit("download", Download(b"second", "../unsafe name.txt"))
+    collisions = server._render_response("clicked", page=collision_page)
+    artifacts = re.findall(r"`([^`]+)`", collisions.split("### Downloads", 1)[1])
+    assert len(artifacts) == 2
+    assert len(set(artifacts)) == 2
+    assert all("/" not in artifact and " " not in artifact for artifact in artifacts)
+    assert {path.read_bytes() for path in collision_policy.output_root.iterdir()} == {
+        b"first",
+        b"second",
+    }
+    assert "### Downloads" not in server._render_response(
+        "unrelated", page=collision_page
+    )
+
+
+def test_download_cursor_does_not_skip_an_earlier_unfinished_download() -> None:
+    page = FakePage()
+    state = SessionState(page=page)
+    registry = state.register_page_handlers(page)
+    first = DownloadRecord(
+        sequence=1,
+        epoch=0,
+        url="https://example.test/first",
+        suggested_filename="first.txt",
+        download=object(),
+    )
+    second = DownloadRecord(
+        sequence=2,
+        epoch=0,
+        url="https://example.test/second",
+        suggested_filename="second.txt",
+        download=object(),
+        artifact="second.txt",
+        finished=True,
+    )
+    registry.downloads.extend([first, second])
+    state.next_download_sequence = 3
+
+    assert [record.sequence for record in state.response_events()[2]] == [2]
+    registry.downloads[0] = DownloadRecord(
+        sequence=1,
+        epoch=0,
+        url=first.url,
+        suggested_filename=first.suggested_filename,
+        download=first.download,
+        artifact="first.txt",
+        finished=True,
+    )
+    assert [record.sequence for record in state.response_events()[2]] == [1]
+
+
+def test_find_cap_fill_rejections_and_empty_upload_cancel(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    first_upload = workspace / "first.txt"
+    second_upload = workspace / "second.txt"
+    first_upload.write_text("first")
+    second_upload.write_text("second")
+
+    with fixture_server() as url:
+        async def checks(session) -> None:
+            try:
+                await _call(session, "browser_navigate", url=url)
+                missing = await session.call_tool("browser_find", {})
+                assert missing.isError and "Exactly one" in _error_text(missing)
+                checkbox = await session.call_tool(
+                    "browser_fill_form",
+                    {
+                        "fields": [
+                            {
+                                "target": "#check-field",
+                                "name": "uncertain checkbox",
+                                "type": "checkbox",
+                                "value": "maybe",
+                            }
+                        ]
+                    },
+                )
+                assert checkbox.isError
+                assert "uncertain checkbox" in _error_text(checkbox)
+                assert "'true' or 'false'" in _error_text(checkbox)
+
+                await _call(
+                    session,
+                    "browser_evaluate",
+                    function="() => { const root = document.querySelector('#find-root'); for (let i = 0; i < 25; i++) { const b = document.createElement('button'); b.textContent = 'cap match ' + i; root.appendChild(b); } return true; }",
+                )
+                found = await _call(session, "browser_find", text="cap match")
+                assert found.count("Match ") == server.FIND_MATCH_LIMIT
+                overflow = re.search(
+                    r"(\d+) additional matches truncated", found
+                )
+                assert overflow is not None and int(overflow.group(1)) >= 5
+
+                await _call(session, "browser_click", target="#upload")
+                cancelled = await _call(session, "browser_file_upload", paths=[])
+                assert "Cancelled" in cancelled
+                await _call(session, "browser_click", target="#upload")
+                multiple = await session.call_tool(
+                    "browser_file_upload",
+                    {"paths": [str(first_upload), str(second_upload)]},
+                )
+                assert multiple.isError
+                assert "only one file" in _error_text(multiple)
+            finally:
+                await session.call_tool("browser_close", {})
+
+        asyncio.run(
+            _run_session(
+                checks,
+                {
+                    "RUSTWRIGHT_MCP_OUTPUT_DIR": str(tmp_path / "output"),
+                    "RUSTWRIGHT_MCP_WORKSPACE": str(workspace),
+                },
+            )
+        )
+
+
+def test_e2_section_order_applicability_and_new_console_semantics(monkeypatch) -> None:
+    page = FakePage()
+    state = SessionState(page=page)
+    registry = state.register_page_handlers(page)
+    monkeypatch.setattr(server, "_state", state)
+
+    for index in range(7):
+        registry.console_records.append(
+            ConsoleRecord(
+                sequence=index + 1,
+                epoch=0,
+                message_type="warning",
+                text=f"warning-{index}",
+                location=(),
+            )
+        )
+    state.next_console_sequence = 8
+    registry.pending_dialog = SimpleNamespace(type="alert", message="pending")
+    registry.downloads.append(
+        DownloadRecord(
+            sequence=1,
+            epoch=0,
+            url="https://example.test/download",
+            suggested_filename="artifact.txt",
+            download=object(),
+            artifact="artifact.txt",
+            finished=True,
+        )
+    )
+    state.next_download_sequence = 2
+
+    first = server._render_response(
+        "done", page=page, snapshot="- current", include_tabs=True
+    )
+    section_names = re.findall(r"^### (\w+)", first, flags=re.MULTILINE)
+    assert section_names == [
+        "Result",
+        "Page",
+        "Tabs",
+        "Snapshot",
+        "Console",
+        "Modal",
+        "Downloads",
+    ]
+    assert first.count("WARNING ") == 5
+    assert "(and 2 more)" in first
+    assert first.count("### Downloads") == 1
+
+    second = server._render_response("next", page=page)
+    assert "### Console" not in second
+    assert "### Downloads" not in second
+    registry.console_records.append(
+        ConsoleRecord(
+            sequence=8,
+            epoch=0,
+            message_type="error",
+            text="new-only",
+            location=(),
+        )
+    )
+    state.next_console_sequence = 9
+    third = server._render_response("third", page=page)
+    assert "new-only" in third
+    assert "warning-" not in third

--- a/mcp/tests/validation/test_pr4_adversarial_drop.py
+++ b/mcp/tests/validation/test_pr4_adversarial_drop.py
@@ -1,0 +1,419 @@
+"""Independent adversarial validation for PR-4 browser_drop."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import copy
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+from rustwright_mcp import server
+
+sys.path.insert(0, str(Path(__file__).parents[1]))
+from contract.contract_schema import ToolContract, compare_tool_schema
+from test_pr2_compatibility import _stdio_tools
+from test_smoke import _call, _result_section, _run_session
+
+
+# Independently transcribed from the audited compatibility surface, not loaded
+# from the repository contract fixture under test.
+AUDITED_BROWSER_DROP = {
+    "params": [
+        {"name": "element", "type": "string", "required": False},
+        {"name": "target", "type": "string", "required": True},
+        {"name": "paths", "type": "array", "required": False},
+        {"name": "data", "type": "object", "required": False},
+    ]
+}
+
+
+ADVERSARIAL_PAGE = """<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Adversarial Drop Validation</title></head>
+<body>
+  <div id="standard">standard</div>
+  <div id="requires-over">requires dragover cancellation</div>
+  <div id="reject-untrusted">reject untrusted</div>
+  <div id="security">security</div>
+  <pre id="standard-result"></pre>
+  <pre id="over-result">idle</pre>
+  <pre id="reject-result">idle</pre>
+  <pre id="security-result">[]</pre>
+  <pre id="frame-result">idle</pre>
+  <iframe id="embedded"></iframe>
+  <script>
+    const standard = {
+      events: [],
+      files: [],
+      data: {},
+      types: [],
+      items: [],
+      isTrusted: {},
+      status: "idle",
+    };
+    const standardResult = document.querySelector("#standard-result");
+    const renderStandard = () => {
+      standardResult.textContent = JSON.stringify(standard);
+    };
+    const fileAsBase64 = (file) => new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = () => reject(reader.error);
+      reader.onload = () => {
+        const bytes = new Uint8Array(reader.result);
+        let binary = "";
+        for (const byte of bytes) binary += String.fromCharCode(byte);
+        resolve(btoa(binary));
+      };
+      reader.readAsArrayBuffer(file);
+    });
+
+    const standardZone = document.querySelector("#standard");
+    for (const type of ["dragenter", "dragover"]) {
+      standardZone.addEventListener(type, (event) => {
+        if (type === "dragover") event.preventDefault();
+        standard.events.push(type);
+        standard.isTrusted[type] = event.isTrusted;
+        renderStandard();
+      });
+    }
+    standardZone.addEventListener("drop", async (event) => {
+      event.preventDefault();
+      standard.events.push("drop");
+      standard.isTrusted.drop = event.isTrusted;
+      standard.types = Array.from(event.dataTransfer.types);
+      standard.items = Array.from(event.dataTransfer.items, (item) => ({
+        kind: item.kind,
+        type: item.type,
+      }));
+      standard.data = {
+        text: event.dataTransfer.getData("text/plain"),
+        custom: event.dataTransfer.getData("application/x-adversarial"),
+      };
+      standard.files = await Promise.all(
+        Array.from(event.dataTransfer.files, async (file) => ({
+          name: file.name,
+          size: file.size,
+          type: file.type,
+          base64: await fileAsBase64(file),
+        }))
+      );
+      standard.status = "done";
+      renderStandard();
+    });
+    renderStandard();
+
+    let overArmed = false;
+    const overZone = document.querySelector("#requires-over");
+    overZone.addEventListener("dragover", (event) => {
+      event.preventDefault();
+      overArmed = event.defaultPrevented;
+    });
+    overZone.addEventListener("drop", (event) => {
+      document.querySelector("#over-result").textContent = JSON.stringify({
+        accepted: overArmed,
+        isTrusted: event.isTrusted,
+        value: overArmed ? event.dataTransfer.getData("text/plain") : null,
+      });
+    });
+
+    document.querySelector("#reject-untrusted").addEventListener("dragover", (event) => {
+      event.preventDefault();
+    });
+    document.querySelector("#reject-untrusted").addEventListener("drop", (event) => {
+      document.querySelector("#reject-result").textContent =
+        event.isTrusted ? "accepted" : "rejected-untrusted";
+    });
+
+    const securityEvents = [];
+    const securityZone = document.querySelector("#security");
+    const renderSecurity = () => {
+      document.querySelector("#security-result").textContent =
+        JSON.stringify(securityEvents);
+    };
+    securityZone.addEventListener("dragover", (event) => event.preventDefault());
+    securityZone.addEventListener("drop", async (event) => {
+      const record = {
+        files: [],
+        items: Array.from(event.dataTransfer.items, (item) => ({
+          kind: item.kind,
+          type: item.type,
+        })),
+        plain: event.dataTransfer.getData("text/plain"),
+        uri: event.dataTransfer.getData("text/uri-list"),
+      };
+      record.files = await Promise.all(
+        Array.from(event.dataTransfer.files, async (file) => ({
+          name: file.name,
+          base64: await fileAsBase64(file),
+        }))
+      );
+      securityEvents.push(record);
+      renderSecurity();
+    });
+
+    window.addEventListener("message", (event) => {
+      if (event.data === "frame-drop") {
+        document.querySelector("#frame-result").textContent = "dropped";
+      }
+    });
+    document.querySelector("#embedded").srcdoc = `
+      <div id="frame-zone">frame dropzone</div>
+      <script>
+        const zone = document.querySelector("#frame-zone");
+        zone.addEventListener("dragover", (event) => event.preventDefault());
+        zone.addEventListener("drop", () => parent.postMessage("frame-drop", "*"));
+      <\\/script>`;
+  </script>
+</body>
+</html>
+"""
+
+
+def _error_text(result) -> str:
+    return "\n".join(item.text for item in result.content if item.type == "text")
+
+
+def _write_page(tmp_path: Path) -> Path:
+    page = tmp_path / "adversarial_drop.html"
+    page.write_text(ADVERSARIAL_PAGE)
+    return page
+
+
+def test_schema_fixture_comparator_description_and_mirror_registration() -> None:
+    listed = {tool.name: tool for tool in asyncio.run(server.mcp.list_tools())}
+    tool = listed["browser_drop"]
+    schema = tool.inputSchema
+    assert set(schema["properties"]) == {"element", "target", "paths", "data"}
+    assert schema["required"] == ["target"]
+    assert schema["additionalProperties"] is False
+    assert "synthetic DataTransfer semantics" in tool.description
+    assert "sites checking event trust or native drag sessions may behave differently" in (
+        tool.description
+    )
+
+    fixture_path = (
+        Path(__file__).parents[1] / "contract" / "fixtures" / "default_toolset.json"
+    )
+    fixture = json.loads(fixture_path.read_text())
+    assert fixture["browser_drop"] == AUDITED_BROWSER_DROP
+    contract = ToolContract.from_mapping("browser_drop", AUDITED_BROWSER_DROP)
+    assert compare_tool_schema(schema, contract) == []
+    incompatible = copy.deepcopy(schema)
+    incompatible["properties"]["paths"] = {"type": "object"}
+    assert compare_tool_schema(incompatible, contract) == [
+        "type mismatch for paths: expected array"
+    ]
+
+    mirror, _ = asyncio.run(
+        _stdio_tools(env_overrides={"RUSTWRIGHT_MCP_ALLOW_EVAL": "0"})
+    )
+    lean, _ = asyncio.run(
+        _stdio_tools(
+            env_overrides={
+                "RUSTWRIGHT_MCP_ALLOW_EVAL": "0",
+                "RUSTWRIGHT_MCP_TOOLSET": "lean",
+            }
+        )
+    )
+    assert "browser_drop" in mirror
+    assert "browser_drop" not in lean
+
+
+def test_real_browser_files_data_order_trust_dragover_iframe_and_rejection(
+    tmp_path,
+) -> None:
+    page = _write_page(tmp_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    source_bytes = b"\x00adversarial-drop\xff\n"
+    source = workspace / "payload.bin"
+    source.write_bytes(source_bytes)
+
+    async def checks(session) -> None:
+        tools = {tool.name: tool for tool in (await session.list_tools()).tools}
+        description = tools["browser_drop"].description
+        assert "synthetic DataTransfer semantics" in description
+        assert "event trust or native drag sessions may behave differently" in description
+
+        await _call(session, "browser_navigate", url=page.as_uri())
+        response = await _call(
+            session,
+            "browser_drop",
+            target="#standard",
+            paths=[str(source)],
+            data={
+                "text/plain": "mixed text",
+                "application/x-adversarial": "custom value",
+            },
+        )
+        assert "Synthesized a drop of 1 file(s) and 2 data item(s)" in response
+        await _call(session, "browser_wait_for", time=0.1)
+        observed = json.loads(
+            _result_section(
+                await _call(session, "browser_get_text", selector="#standard-result")
+            )
+        )
+        assert observed == {
+            "events": ["dragenter", "dragover", "drop"],
+            "files": [
+                {
+                    "name": "payload.bin",
+                    "size": len(source_bytes),
+                    "type": "application/octet-stream",
+                    "base64": base64.b64encode(source_bytes).decode("ascii"),
+                }
+            ],
+            "data": {"text": "mixed text", "custom": "custom value"},
+            "types": ["text/plain", "application/x-adversarial", "Files"],
+            "items": [
+                {"kind": "file", "type": "application/octet-stream"},
+                {"kind": "string", "type": "text/plain"},
+                {"kind": "string", "type": "application/x-adversarial"},
+            ],
+            "isTrusted": {"dragenter": False, "dragover": False, "drop": False},
+            "status": "done",
+        }
+
+        await _call(
+            session,
+            "browser_drop",
+            target="#requires-over",
+            data={"text/plain": "dragover-gated"},
+        )
+        over = json.loads(
+            _result_section(
+                await _call(session, "browser_get_text", selector="#over-result")
+            )
+        )
+        assert over == {
+            "accepted": True,
+            "isTrusted": False,
+            "value": "dragover-gated",
+        }
+
+        frame = await session.call_tool(
+            "browser_drop",
+            {"target": "#frame-zone", "data": {"text/plain": "frame"}},
+        )
+        assert frame.isError
+        assert "matched no elements" in _error_text(frame)
+        assert _result_section(
+            await _call(session, "browser_get_text", selector="#frame-result")
+        ) == "idle"
+
+        rejected = await _call(
+            session,
+            "browser_drop",
+            target="#reject-untrusted",
+            data={"text/plain": "untrusted"},
+        )
+        assert "Synthesized a drop" in rejected
+        assert _result_section(
+            await _call(session, "browser_get_text", selector="#reject-result")
+        ) == "rejected-untrusted"
+        assert "Adversarial Drop Validation" in await _call(
+            session, "browser_snapshot"
+        )
+
+    asyncio.run(
+        _run_session(
+            checks,
+            {
+                "RUSTWRIGHT_MCP_ALLOW_EVAL": "0",
+                "RUSTWRIGHT_MCP_WORKSPACE": str(workspace),
+            },
+        )
+    )
+
+
+def test_rejected_paths_never_reach_page_and_data_paths_remain_strings(
+    tmp_path,
+) -> None:
+    page = _write_page(tmp_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    outside = tmp_path / "outside.txt"
+    escape_marker = "ESCAPE-CONTENT-MUST-NOT-REACH-PAGE"
+    outside.write_text(escape_marker)
+    symlink_target = workspace / "symlink-target.txt"
+    symlink_marker = "SYMLINK-CONTENT-MUST-NOT-REACH-PAGE"
+    symlink_target.write_text(symlink_marker)
+    symlink = workspace / "symlink.txt"
+    try:
+        symlink.symlink_to(symlink_target)
+    except OSError:
+        pytest.skip("symlinks are unavailable")
+    oversized = workspace / "oversized.bin"
+    oversize_marker = "OVERSIZE-CONTENT-MUST-NOT-REACH-PAGE"
+    oversized.write_text(oversize_marker)
+
+    async def checks(session) -> None:
+        await _call(session, "browser_navigate", url=page.as_uri())
+        rejected = [
+            (
+                {"target": "#security", "paths": [str(outside)]},
+                "outside the allowed workspace",
+            ),
+            (
+                {"target": "#security", "paths": [str(symlink)]},
+                "must not be a symlink",
+            ),
+            (
+                {"target": "#security", "paths": [str(oversized)]},
+                "8-byte per-file cap",
+            ),
+        ]
+        for arguments, expected_error in rejected:
+            result = await session.call_tool("browser_drop", arguments)
+            assert result.isError
+            assert expected_error in _error_text(result)
+            page_state = _result_section(
+                await _call(session, "browser_get_text", selector="#security-result")
+            )
+            assert page_state == "[]"
+            assert escape_marker not in page_state
+            assert symlink_marker not in page_state
+            assert oversize_marker not in page_state
+
+        await _call(
+            session,
+            "browser_drop",
+            target="#security",
+            data={
+                "text/plain": str(outside),
+                "text/uri-list": outside.as_uri(),
+            },
+        )
+        data_only = json.loads(
+            _result_section(
+                await _call(session, "browser_get_text", selector="#security-result")
+            )
+        )
+        assert data_only == [
+            {
+                "files": [],
+                "items": [
+                    {"kind": "string", "type": "text/plain"},
+                    {"kind": "string", "type": "text/uri-list"},
+                ],
+                "plain": str(outside),
+                "uri": outside.as_uri(),
+            }
+        ]
+        assert escape_marker not in json.dumps(data_only)
+
+    asyncio.run(
+        _run_session(
+            checks,
+            {
+                "RUSTWRIGHT_MCP_ALLOW_EVAL": "0",
+                "RUSTWRIGHT_MCP_OUTPUT_MAX_FILE_BYTES": "8",
+                "RUSTWRIGHT_MCP_OUTPUT_MAX_TOTAL_BYTES": "16",
+                "RUSTWRIGHT_MCP_WORKSPACE": str(workspace),
+            },
+        )
+    )

--- a/mcp/tests/validation/test_pr4_adversarial_drop.py
+++ b/mcp/tests/validation/test_pr4_adversarial_drop.py
@@ -25,8 +25,18 @@ AUDITED_BROWSER_DROP = {
     "params": [
         {"name": "element", "type": "string", "required": False},
         {"name": "target", "type": "string", "required": True},
-        {"name": "paths", "type": "array", "required": False},
-        {"name": "data", "type": "object", "required": False},
+        {
+            "name": "paths",
+            "type": "array",
+            "required": False,
+            "items": {"type": "string"},
+        },
+        {
+            "name": "data",
+            "type": "object",
+            "required": False,
+            "additionalProperties": {"type": "string"},
+        },
     ]
 }
 
@@ -205,7 +215,8 @@ def test_schema_fixture_comparator_description_and_mirror_registration() -> None
     incompatible = copy.deepcopy(schema)
     incompatible["properties"]["paths"] = {"type": "object"}
     assert compare_tool_schema(incompatible, contract) == [
-        "type mismatch for paths: expected array"
+        "type mismatch for paths: expected array, got ['object']",
+        "missing items schema for paths",
     ]
 
     mirror, _ = asyncio.run(


### PR DESCRIPTION
Builds the MCP server's default-toolset compatibility (stacked on the remote-CDP branch of #93 — that commit appears here until #93 merges):

1. **Foundations** — typed session state with an exactly-once per-page handler registrar (console/network/filechooser/dialog/download), a dedicated event lock, navigation epochs, bounded immutable event records; a safe file policy (`RUSTWRIGHT_MCP_OUTPUT_DIR` confinement, 0700/0600, byte caps, post-write integrity checks — screenshot paths outside the root now return a structured error, a documented breaking change); a strict ref-or-selector resolver (refs never fall through to CSS; selectors must match exactly one element); `serverInfo` now reports the package name/version; a clean-room contract-comparator harness.
2. **Canonical schemas** — the ten schema-divergent default tools advertise canonical camelCase parameters with snake_case accepted as hidden aliases (canonical wins on conflict); every advertised tool rejects unknown parameters (`additionalProperties: false`); a sectioned response envelope (Result/Page/Tabs/Snapshot); `--caps`/env acceptance (warn, never crash); `RUSTWRIGHT_MCP_TOOLSET=mirror|lean` profiles; `browser_evaluate` is registered by default with a `RUSTWRIGHT_MCP_ALLOW_EVAL=0` opt-out (SECURITY note in mcp/README.md).
3. **Docs** — copy-paste installs per client (Claude Code / Claude Desktop / any MCP client), a decision table, and a 60-second CLI quickstart.
4. **Default toolset completion** — resize, drag, fill_form, find, console_messages, network_requests/network_request (session-monotonic indices), file_upload; dialogs use pending-modal semantics across all tabs with a no-hang guarantee; automatic downloads are reported exactly once; envelope Console/Modal/Downloads sections; the contract fixture covers the full default set.

## Verification

**120 tests, run twice, all green** — covering cross-tab modal handling, index stability across navigations, out-of-order download completion, path-escape and symlink-swap attempts, alias-conflict resolution, and exact fixture-vs-schema checks. The adversarial regression suites are retained under `mcp/tests/validation/`.

## Review updates

Addressed review feedback: the file-chooser retry now binds to the originating input element's identity (no double-executing an unrelated click); symlink-escape cleanup removes only the in-root link, never the resolved external target (a sentinel test asserts the external file survives); the file policy tracks only paths it creates, so a user-configured output dir's pre-existing files are never chmodded or evicted; a context-level page handler covers `window.open` popups from birth; `RUSTWRIGHT_MCP_ALLOW_EVAL` parses strictly and fails loudly on unknown values; the contract comparator now pins the exact normalized `tools/list` (all 25 tools + full schemas + required sets) with an explicit additions allow-list; navigation eviction counters are bounded.

## Notes for reviewers

- The screenshot path confinement and the eval default are deliberate, documented behavior changes (see mcp/README.md SECURITY + File outputs sections).
- The contract fixture (`mcp/tests/contract/fixtures/default_toolset.json`) is clean-room: names/types/enums/defaults/required flags only.
