### PR TITLE
chore(rust-native): crates.io release prep — published as rustwright 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,7 +1024,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustwright"
-version = "0.1.0-alpha.4"
+version = "0.1.1"
 dependencies = [
  "rustwright-core",
  "serde",

--- a/rust-native/Cargo.toml
+++ b/rust-native/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "rustwright"
-version = "0.1.0-alpha.4"
+version = "0.1.1"
 edition = "2021"
-publish = false
+description = "Idiomatic native Rust API for the Rustwright Chromium CDP engine (a Rust rewrite of Playwright)."
+license = "MIT"
+repository = "https://github.com/Skyvern-AI/rustwright"
+homepage = "https://github.com/Skyvern-AI/rustwright"
+readme = "README.md"
+keywords = ["browser", "automation", "cdp", "chromium", "playwright"]
+categories = ["web-programming"]
 
 [dependencies]
-rustwright_core = { package = "rustwright-core", path = "..", default-features = false }
+rustwright_core = { package = "rustwright-core", path = "..", version = "0.1.1", default-features = false }
 serde = { version = "=1.0.188", features = ["derive"] }
 serde_json = "=1.0.107"

--- a/rust-native/README.md
+++ b/rust-native/README.md
@@ -1,0 +1,29 @@
+# rustwright
+
+Idiomatic **native Rust API** for the [Rustwright](https://github.com/Skyvern-AI/rustwright)
+Chromium CDP engine — a Rust rewrite of Playwright that drives Chromium from an
+in-process async CDP client (no Node driver subprocess).
+
+This crate is a thin, ergonomic wrapper over `rustwright-core`. It runs the engine
+in-process; there is no separate binding library to load.
+
+```rust
+use rustwright::{chromium, LaunchOptions};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let browser = chromium().launch(LaunchOptions::default())?;
+    let page = browser.new_page()?;
+    page.goto("https://example.com", None)?;
+    println!("{}", page.title(None)?);
+    browser.close()?;
+    Ok(())
+}
+```
+
+Alpha; Chromium-only. See the [main project](https://github.com/Skyvern-AI/rustwright)
+for the full API surface, the shared binding contract, and the other language
+bindings (Python, Node, Go, Java, C#/.NET, Ruby, PHP).
+
+## License
+
+[MIT](https://github.com/Skyvern-AI/rustwright/blob/main/LICENSE)


### PR DESCRIPTION
https://github.com/Skyvern-AI/rustwright-cloud/pull/103