### PR TITLE
build: update serde to 1.0.228

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1101,18 +1101,28 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ futures-sink = "=0.3.31"
 futures-task = "=0.3.31"
 pyo3 = { version = "0.29", features = ["abi3-py38"], optional = true }
 reqwest = { version = "=0.12.28", default-features = false, features = ["json", "rustls-tls"] }
-serde = { version = "=1.0.188", features = ["derive"] }
+serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.107"
 itoa = "=1.0.9"
 ryu = "=1.0.15"

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 libc = "=0.2.186"
 rustwright_core = { package = "rustwright-core", path = "..", default-features = false }
-serde = { version = "=1.0.188", features = ["derive"] }
+serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.107"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 napi = { version = "=2.16.17", features = ["tokio_rt"] }
 napi-derive = "=2.16.13"
 rustwright_core = { package = "rustwright-core", path = "..", default-features = false }
-serde = { version = "=1.0.188", features = ["derive"] }
+serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.107"
 tokio = { version = "=1.52.3", features = ["rt-multi-thread"] }
 unicode-segmentation = "=1.10.1"

--- a/rust-native/Cargo.toml
+++ b/rust-native/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["web-programming"]
 
 [dependencies]
 rustwright_core = { package = "rustwright-core", path = "..", version = "0.1.1", default-features = false }
-serde = { version = "=1.0.188", features = ["derive"] }
+serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.107"


### PR DESCRIPTION
## Summary
- update the exact serde pin from 1.0.188 to 1.0.228 across all workspace manifests
- refresh the lockfile, including serde_core

## Validation
- `cargo check --locked`
- `cargo test --locked` (41 passed)

The existing unused `Read`/`Write` import warnings remain unchanged.

Closes #107