### PR TITLE
mcp: add browser_session_state (save/load cookies + localStorage)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -97,6 +97,7 @@ Ask your agent to “take a browser snapshot of example.com”.
 | `browser_get_text(selector?)` | Visible text of a selector |
 | `browser_evaluate(function, element?, target?, filename?)` | Run page-world JavaScript and return JSON plus a fresh snapshot |
 | `browser_take_screenshot(element?, target?, type?, filename?, fullPage?, scale?)` | Save a confined page or element image |
+| `browser_session_state(action, path)` | Save or load cookies + localStorage (a Playwright storage state) under the output dir, so an agent can authenticate once and resume later |
 | `browser_close()` | End the browser session |
 
 ## Configuration

--- a/mcp/rustwright_mcp/filepolicy.py
+++ b/mcp/rustwright_mcp/filepolicy.py
@@ -256,6 +256,55 @@ class FilePolicy:
             self._evict_to_total_cap(protected=resolved)
             return self._artifact_link(resolved)
 
+    def read_output(self, requested: str | Path) -> bytes:
+        """Read a file confined to the output root without following a symlink.
+
+        Symmetric with :meth:`reserve_output`: artifacts written under
+        ``RUSTWRIGHT_MCP_OUTPUT_DIR`` (session state, dumps) can be read back
+        through the same confinement, independent of the input workspace. A
+        relative ``requested`` resolves beneath the output root; an absolute
+        path must already be within it. The final component must be a regular,
+        non-symlink file within the per-file byte cap.
+        """
+        with self._lock:
+            raw_path = Path(requested).expanduser()
+            candidate = (
+                raw_path if raw_path.is_absolute() else self.output_root / raw_path
+            )
+            try:
+                info = candidate.lstat()
+            except FileNotFoundError:
+                raise FilePolicyError(
+                    f"output file does not exist: {candidate}"
+                ) from None
+            if stat.S_ISLNK(info.st_mode):
+                raise FilePolicyError(
+                    f"output file must not be a symlink: {candidate}"
+                )
+            resolved = candidate.resolve(strict=True)
+            if not _is_within(resolved, self.output_root):
+                raise FilePolicyError(
+                    "output paths are confined to RUSTWRIGHT_MCP_OUTPUT_DIR "
+                    f"({self.output_root}); got {candidate}"
+                )
+            flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(resolved, flags)
+            try:
+                fd_info = os.fstat(descriptor)
+                if not stat.S_ISREG(fd_info.st_mode):
+                    raise FilePolicyError(
+                        f"output path is not a regular file: {candidate}"
+                    )
+                if fd_info.st_size > self.max_file_bytes:
+                    raise FilePolicyError(
+                        f"output file exceeds the {self.max_file_bytes}-byte "
+                        "per-file cap"
+                    )
+                with os.fdopen(descriptor, "rb", closefd=False) as handle:
+                    return handle.read()
+            finally:
+                os.close(descriptor)
+
     def _artifact_files(self) -> list[tuple[int, Path, int]]:
         artifacts: list[tuple[int, Path, int]] = []
         for path in tuple(self._created_outputs):

--- a/mcp/rustwright_mcp/server.py
+++ b/mcp/rustwright_mcp/server.py
@@ -48,7 +48,7 @@ from pydantic import (
     model_validator,
 )
 
-from rustwright_mcp.filepolicy import get_file_policy
+from rustwright_mcp.filepolicy import FilePolicyError, get_file_policy
 from rustwright_mcp.session import SessionState
 from rustwright_mcp.snapshot import SNAPSHOT_JS, TARGET_SNAPSHOT_JS
 
@@ -644,6 +644,82 @@ def _write_text_output(content: str, filename: str, *, purpose: str) -> str:
         raise
 
 
+_LOCAL_STORAGE_APPLY_JS = """(entries) => {
+  for (const item of entries) {
+    if (item && typeof item.name === 'string') {
+      try { window.localStorage.setItem(item.name, String(item.value)); }
+      catch (error) {}
+    }
+  }
+}"""
+
+
+def _local_storage_init_script(origin: str, entries: list[Any]) -> str:
+    """Seed localStorage on the next navigation to ``origin`` (Playwright's
+    own storage-state restore mechanism), guarded by an origin check so it
+    only fires on the matching origin."""
+    return (
+        "(() => {\n"
+        f"  if (location.origin !== {json.dumps(origin)}) return;\n"
+        f"  const entries = {json.dumps(entries)};\n"
+        "  for (const item of entries) {\n"
+        "    if (item && typeof item.name === 'string') {\n"
+        "      try { window.localStorage.setItem(item.name, String(item.value)); }\n"
+        "      catch (error) {}\n"
+        "    }\n"
+        "  }\n"
+        "})();"
+    )
+
+
+def _apply_storage_state(
+    context: Any, page: Any, state: Any
+) -> tuple[int, int, str | None]:
+    """Restore cookies context-wide and localStorage per origin.
+
+    Cookies apply immediately across every origin. localStorage is applied to
+    the current origin right away and registered via an init script for every
+    origin so a later navigation restores it, matching how a Playwright context
+    created with ``storage_state`` behaves. Returns
+    ``(cookie_count, origin_count, origin_applied_now)``.
+    """
+    if not isinstance(state, dict):
+        raise ValueError("session-state must be a JSON object")
+    cookies = state.get("cookies")
+    origins = state.get("origins")
+    if cookies is None:
+        cookies = []
+    if origins is None:
+        origins = []
+    # A present-but-wrong-typed value (e.g. an object) is a corrupt file, not
+    # an absent field; validate the type rather than coercing it away.
+    if not isinstance(cookies, list) or not isinstance(origins, list):
+        raise ValueError("session-state 'cookies' and 'origins' must be arrays")
+
+    context.clear_cookies()
+    if cookies:
+        context.add_cookies(cookies)
+
+    try:
+        current_origin = page.evaluate("() => location.origin")
+    except Exception:
+        current_origin = None
+
+    applied_now: str | None = None
+    for origin_entry in origins:
+        if not isinstance(origin_entry, dict):
+            continue
+        origin = origin_entry.get("origin")
+        entries = origin_entry.get("localStorage") or []
+        if not isinstance(origin, str) or not isinstance(entries, list):
+            continue
+        context.add_init_script(_local_storage_init_script(origin, entries))
+        if current_origin is not None and origin == current_origin:
+            page.evaluate(_LOCAL_STORAGE_APPLY_JS, entries)
+            applied_now = origin
+    return len(cookies), len(origins), applied_now
+
+
 def _teardown() -> None:
     # For remote sessions, closing the connected Browser detaches this client;
     # Rustwright leaves the remotely owned browser running.
@@ -746,6 +822,10 @@ Function = Annotated[
 PositiveDimension = Annotated[float, Field(gt=0, allow_inf_nan=False)]
 NetworkIndex = Annotated[int, Field(ge=1)]
 UploadPaths = Annotated[list[str], Field(max_length=50)]
+SessionStatePath = Annotated[
+    str,
+    Field(validation_alias=AliasChoices("path", "filename")),
+]
 
 
 _SYNTHETIC_DROP_JS = """async (target, payload) => {
@@ -1855,6 +1935,62 @@ def browser_take_screenshot(
         policy.discard_output(output_path)
         raise
     return _render_response(f"Screenshot written to `{artifact}`.", page=page)
+
+
+@_tool()
+def browser_session_state(
+    action: Literal["save", "load"],
+    path: SessionStatePath,
+) -> str:
+    """Save or load the session's cookies and localStorage.
+
+    `action="save"` writes a Playwright storage-state document (cookies plus
+    per-origin localStorage) as JSON to `path` beneath the configured output
+    directory. `action="load"` reads that JSON back, restoring cookies
+    context-wide and localStorage per origin (applied immediately for the
+    current origin, and on the next navigation to any other origin). This lets
+    an agent authenticate once and resume in a later session instead of
+    logging in again.
+    """
+    page = _page()
+    context = _state.context
+    if context is None:  # pragma: no cover - _page always attaches a context
+        raise RuntimeError("no browser context is available")
+
+    if action == "save":
+        state = context.storage_state()
+        content = json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True)
+        artifact = _write_text_output(content, path, purpose="session-state")
+        cookies = state.get("cookies") or []
+        origins = state.get("origins") or []
+        return _render_response(
+            f"Saved session state to `{artifact}` "
+            f"({len(cookies)} cookies, {len(origins)} origins).",
+            page=page,
+        )
+
+    policy = get_file_policy()
+    try:
+        raw = policy.read_output(path)
+    except FilePolicyError as error:
+        raise ValueError(str(error)) from None
+    try:
+        state = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"session-state file is not valid JSON: {error}") from None
+
+    cookie_count, origin_count, applied_now = _apply_storage_state(
+        context, page, state
+    )
+    detail = (
+        f"Restored {cookie_count} cookies and localStorage for "
+        f"{origin_count} origin(s)."
+    )
+    if applied_now is not None:
+        detail += f" localStorage for {applied_now} applied to the current page."
+    if origin_count:
+        detail += " Other origins restore on the next navigation to them."
+    return _render_response(detail, page=page)
 
 
 @_tool()

--- a/mcp/tests/contract/fixtures/default_toolset.json
+++ b/mcp/tests/contract/fixtures/default_toolset.json
@@ -125,6 +125,12 @@
       {"name": "values", "type": "array", "required": true, "items": {"type": "string"}}
     ]
   },
+  "browser_session_state": {
+    "params": [
+      {"name": "action", "type": "string", "required": true, "enum": ["save", "load"]},
+      {"name": "path", "type": "string", "required": true}
+    ]
+  },
   "browser_snapshot": {
     "params": [
       {"name": "target", "type": "string", "required": false},

--- a/mcp/tests/test_pr2_compatibility.py
+++ b/mcp/tests/test_pr2_compatibility.py
@@ -517,7 +517,7 @@ def test_caps_argv_and_env_warn_without_blocking_tools_list() -> None:
 
 def test_mirror_and_lean_tool_profiles_with_eval_default_on() -> None:
     mirror, _ = asyncio.run(_stdio_tools())
-    assert len(mirror) == 25
+    assert len(mirror) == 26
     assert {
         "browser_evaluate",
         "browser_get_text",

--- a/mcp/tests/test_session_state.py
+++ b/mcp/tests/test_session_state.py
@@ -1,0 +1,248 @@
+"""Tests for browser_session_state and the confined output-read path.
+
+Three layers:
+  * FilePolicy.read_output adversarial cases (symlink, traversal, cap, missing).
+  * _apply_storage_state input validation and restore behavior, with fakes.
+  * A real cross-session round trip: save cookies + localStorage in one server
+    process, then restore them in a second process sharing the output dir.
+"""
+
+import asyncio
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+from rustwright_mcp.filepolicy import FilePolicy, FilePolicyError
+from rustwright_mcp import server
+from test_smoke import _call, _run_session, _result_section
+
+
+# --- FilePolicy.read_output ------------------------------------------------
+
+
+def test_read_output_reads_confined_file(tmp_path):
+    root = tmp_path / "output"
+    policy = FilePolicy(output_root=root)
+    target = root / "state.json"
+    target.write_text('{"ok": true}', encoding="utf-8")
+
+    assert policy.read_output("state.json") == b'{"ok": true}'
+    # An absolute path already inside the root is accepted too.
+    assert policy.read_output(str(target)) == b'{"ok": true}'
+
+
+def test_read_output_missing_file(tmp_path):
+    policy = FilePolicy(output_root=tmp_path / "output")
+    with pytest.raises(FilePolicyError, match="does not exist"):
+        policy.read_output("nope.json")
+
+
+def test_read_output_rejects_symlink(tmp_path):
+    root = tmp_path / "output"
+    policy = FilePolicy(output_root=root)
+    secret = tmp_path / "secret.json"
+    secret.write_text("secret", encoding="utf-8")
+    link = root / "link.json"
+    link.symlink_to(secret)
+
+    with pytest.raises(FilePolicyError, match="must not be a symlink"):
+        policy.read_output("link.json")
+
+
+def test_read_output_rejects_traversal(tmp_path):
+    root = tmp_path / "output"
+    policy = FilePolicy(output_root=root)
+    outside = tmp_path / "outside.json"
+    outside.write_text("outside", encoding="utf-8")
+
+    with pytest.raises(FilePolicyError, match="confined to"):
+        policy.read_output("../outside.json")
+    with pytest.raises(FilePolicyError, match="confined to"):
+        policy.read_output(str(outside))
+
+
+def test_read_output_enforces_byte_cap(tmp_path):
+    root = tmp_path / "output"
+    policy = FilePolicy(output_root=root, max_file_bytes=16, max_total_bytes=1024)
+    (root / "big.json").write_bytes(b"x" * 17)
+
+    with pytest.raises(FilePolicyError, match="per-file cap"):
+        policy.read_output("big.json")
+
+
+# --- _apply_storage_state --------------------------------------------------
+
+
+class _FakeContext:
+    def __init__(self):
+        self.cleared = False
+        self.added_cookies = None
+        self.init_scripts = []
+
+    def clear_cookies(self):
+        self.cleared = True
+
+    def add_cookies(self, cookies):
+        self.added_cookies = cookies
+
+    def add_init_script(self, script=None, *, path=None):
+        self.init_scripts.append(script)
+
+
+class _FakePage:
+    def __init__(self, origin):
+        self._origin = origin
+        self.applied = []
+
+    def evaluate(self, expression, arg=None):
+        if "location.origin" in expression:
+            return self._origin
+        self.applied.append((expression, arg))
+        return None
+
+
+def test_apply_storage_state_rejects_non_object():
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        server._apply_storage_state(_FakeContext(), _FakePage(None), ["nope"])
+
+
+def test_apply_storage_state_rejects_non_array_members():
+    with pytest.raises(ValueError, match="must be arrays"):
+        server._apply_storage_state(
+            _FakeContext(), _FakePage(None), {"cookies": {}, "origins": []}
+        )
+
+
+def test_apply_storage_state_restores_cookies_and_current_origin():
+    context = _FakeContext()
+    page = _FakePage("https://example.com")
+    state = {
+        "cookies": [{"name": "sid", "value": "1", "domain": "example.com", "path": "/"}],
+        "origins": [
+            {"origin": "https://example.com", "localStorage": [{"name": "t", "value": "v"}]},
+            {"origin": "https://other.test", "localStorage": [{"name": "x", "value": "y"}]},
+        ],
+    }
+
+    cookie_count, origin_count, applied_now = server._apply_storage_state(
+        context, page, state
+    )
+
+    assert (cookie_count, origin_count, applied_now) == (1, 2, "https://example.com")
+    assert context.cleared is True
+    assert context.added_cookies == state["cookies"]
+    # Both origins get an init script; the current origin is applied immediately.
+    assert len(context.init_scripts) == 2
+    assert len(page.applied) == 1
+    assert page.applied[0][1] == [{"name": "t", "value": "v"}]
+
+
+def test_apply_storage_state_skips_when_no_current_origin():
+    context = _FakeContext()
+    page = _FakePage(None)
+    state = {
+        "cookies": [],
+        "origins": [
+            {"origin": "https://example.com", "localStorage": [{"name": "t", "value": "v"}]},
+        ],
+    }
+
+    cookie_count, origin_count, applied_now = server._apply_storage_state(
+        context, page, state
+    )
+
+    assert (cookie_count, origin_count, applied_now) == (0, 1, None)
+    assert context.cleared is True
+    assert context.added_cookies is None  # no cookies to add
+    assert len(context.init_scripts) == 1
+    assert page.applied == []  # nothing applied without a matching current origin
+
+
+# --- cross-session round trip ---------------------------------------------
+
+
+class _StateHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802 - required name
+        body = b"<!doctype html><html><body><h1>State Fixture</h1></body></html>"
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):  # silence server logging
+        pass
+
+
+@pytest.fixture(scope="module")
+def http_origin():
+    server_obj = ThreadingHTTPServer(("127.0.0.1", 0), _StateHandler)
+    thread = threading.Thread(target=server_obj.serve_forever, daemon=True)
+    thread.start()
+    host, port = server_obj.server_address
+    try:
+        yield f"http://{host}:{port}"
+    finally:
+        server_obj.shutdown()
+        server_obj.server_close()
+
+
+def test_session_state_round_trip_across_processes(tmp_path, http_origin):
+    output_dir = tmp_path / "mcp-output"
+    output_dir.mkdir()
+    env = {
+        "RUSTWRIGHT_MCP_OUTPUT_DIR": str(output_dir),
+    }
+    channel = os.environ.get("RUSTWRIGHT_MCP_CHANNEL")
+    if channel:
+        env["RUSTWRIGHT_MCP_CHANNEL"] = channel
+
+    # Session 1: seed a cookie + localStorage, then save the state.
+    async def save_session(session):
+        await _call(session, "browser_navigate", url=f"{http_origin}/")
+        await _call(
+            session,
+            "browser_evaluate",
+            function=(
+                "() => { document.cookie = 'sid=abc123; path=/'; "
+                "localStorage.setItem('token', 'secret-token'); }"
+            ),
+        )
+        result = await _call(
+            session, "browser_session_state", action="save", path="state.json"
+        )
+        assert "Saved session state" in result
+        assert "1 cookies" in result
+
+    asyncio.run(_run_session(save_session, env))
+
+    assert (output_dir / "state.json").exists()
+    saved = json.loads((output_dir / "state.json").read_text())
+    assert any(c["name"] == "sid" for c in saved["cookies"])
+
+    # Session 2: a fresh server process, same output dir. Load, then verify
+    # the cookie and localStorage were restored on the target origin.
+    async def load_session(session):
+        loaded = await _call(
+            session, "browser_session_state", action="load", path="state.json"
+        )
+        assert "Restored 1 cookies" in _result_section(loaded)
+        await _call(session, "browser_navigate", url=f"{http_origin}/")
+        state = await _call(
+            session,
+            "browser_evaluate",
+            function=(
+                "() => 'cookie=' + document.cookie + "
+                "' token=' + localStorage.getItem('token')"
+            ),
+        )
+        # Assert on the raw response text so the check does not depend on the
+        # exact response-envelope formatting.
+        assert "sid=abc123" in state, state
+        assert "secret-token" in state, state
+
+    asyncio.run(_run_session(load_session, env))

--- a/mcp/tests/validation/test_contract_and_identity.py
+++ b/mcp/tests/validation/test_contract_and_identity.py
@@ -89,6 +89,7 @@ def test_real_stdio_identity_and_complete_tool_inventory() -> None:
         "browser_network_request",
         "browser_network_requests",
         "browser_resize",
+        "browser_session_state",
     }
 
     async def checks() -> None:


### PR DESCRIPTION
Adds session persistence to the MCP server: an agent can authenticate once, save the session, and resume in a later run instead of logging in again. This is the biggest friction point in multi-step agent workflows.

## What

- **`browser_session_state(action, path)`** tool:
  - `action="save"` writes `context.storage_state()` (cookies + per-origin localStorage) as JSON beneath the configured output directory.
  - `action="load"` restores cookies context-wide and localStorage per origin. localStorage for the current origin is applied immediately; other origins are restored on the next navigation to them via a guarded `add_init_script`, exactly how a Playwright context created with `storage_state` behaves. No upfront navigation to every origin.
- **`FilePolicy.read_output`**: a symmetric confined read for the output root (final-component symlink rejection, lexical + resolved containment, `O_NOFOLLOW`, per-file byte cap), so saved state round-trips through the same confinement that `reserve_output` writes, independent of the input workspace.

Built entirely on existing, verified primitives (`storage_state`, `add_cookies`/`clear_cookies`, `add_init_script`); no engine changes.

## Testing

`mcp/tests/test_session_state.py` (10 tests):
- `read_output` adversarial: symlink rejection, path traversal / absolute-outside, missing file, per-file byte cap, and the happy path.
- `_apply_storage_state`: rejects a non-object document and present-but-wrong-typed `cookies`/`origins`; verifies cookie restore, per-origin init scripts, and immediate application only for the matching current origin.
- A real **cross-process round trip** over a local HTTP origin: seed a cookie + localStorage and save in one server process, then load in a second process sharing the output dir and confirm both are restored after navigating back.

Two bugs were caught and fixed by these tests before pushing (a truthiness check that coerced a wrong-typed `{}` to `[]`, and a brittle envelope-parsing assertion). Full suite green: `130 passed`.

The new tool is pinned in the contract fixture (`default_toolset.json`) and both inventory suites, so the zero-drift contract test stays authoritative.

## Note

The originally-scoped Python `local_storage`/`session_storage` helpers are intentionally **not** in this PR: editing `sync_api.py` trips the async-generation freshness gate (its committed fingerprint is a sha256 of that file, and regeneration is CPython-version-sensitive), so that belongs in a dedicated PR that handles the async-generation machinery. This PR is self-contained in `mcp/`.