### PR TITLE
build(deps): bump base64 from 0.21.7 to 0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,12 +37,6 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -391,7 +385,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -916,7 +910,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-core",
  "http",
@@ -1045,7 +1039,7 @@ dependencies = [
 name = "rustwright-core"
 version = "0.1.1"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ name = "_rustwright"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-base64 = "0.21.7"
+base64 = "0.22.1"
 futures-util = "0.3.31"
 futures-channel = "0.3.31"
 futures-core = "0.3.31"


### PR DESCRIPTION
https://github.com/Skyvern-AI/rustwright-cloud/pull/126