### PR TITLE
sync: back-sync the language bindings and their shared contract

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -32,6 +32,27 @@ Skyvern-AI/rustwright-cloud:
   - source: rust-native/
     dest: rust-native/
     deleteOrphaned: true
+  # Cross-language binding packages and their shared contract; mapped so
+  # external contributions to any binding back-sync to the cloud repo. Every
+  # directory exists on this repo's main (a deleteOrphaned prerequisite).
+  - source: bindings/
+    dest: bindings/
+    deleteOrphaned: true
+  - source: go/
+    dest: go/
+    deleteOrphaned: true
+  - source: java/
+    dest: java/
+    deleteOrphaned: true
+  - source: csharp/
+    dest: csharp/
+    deleteOrphaned: true
+  - source: ruby/
+    dest: ruby/
+    deleteOrphaned: true
+  - source: php/
+    dest: php/
+    deleteOrphaned: true
   - source: docs/
     dest: docs/
     deleteOrphaned: true


### PR DESCRIPTION
## Summary

Completes the back-sync map: `bindings/`, `go/`, `java/`, `csharp/`, `ruby/`, and `php/` now sync from this repo to the development repo, so external contributions to the language bindings flow back like the rest of the shared tree (the same gap #154 closed for `cli/` and `mcp-rs/`). All six directories exist on main — the precondition for `deleteOrphaned` mappings.

Sync-map edit applied with explicit maintainer approval.

## Smoke test

PyYAML parse: 36 entries, all six new sources present exactly once, no duplicates across the map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
