### PR TITLE
docs: point MCP references at the native mcp-rs server

### DIFF
--- a/CODE_ARCHITECTURE.md
+++ b/CODE_ARCHITECTURE.md
@@ -72,7 +72,6 @@ C-ABI bindings.
 | `python/playwright/*`, `python/patchright/*`, `python/cloakbrowser/*` | Compatibility import packages. Public alpha compatibility imports should be enabled only through opt-in compatibility mode. |
 | `rust-native/` | Native Rust facade crate over `rustwright-core` (crates.io `rustwright`); also the facade `mcp-rs/` consumes. |
 | `mcp-rs/` | `rustwright-mcp`: the canonical native Rust MCP stdio server on the promoted engine facade, with its npm packaging under `mcp-rs/npm/`. |
-| `mcp/` | Deprecated Python MCP server (present in the public tree only, outside the sync map); superseded by `mcp-rs/` and removed once the native tool set reaches parity. |
 | `node/` | napi-rs binding (in-process, links `rustwright-core` directly). |
 | `capi/` | Shared C ABI (`librustwright_capi`) over `rustwright-core`; the boundary for the Go/Java/C#/Ruby/PHP bindings. |
 | `go/`, `java/`, `csharp/`, `ruby/`, `php/` | C-ABI language bindings (alpha surface) + per-language conformance runners. |

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ See [`LIMITATIONS.md`](LIMITATIONS.md) for detail.
 
 - [ ] **Kotlin binding** — idiomatic Kotlin wrapper (Kotlin/JVM can already consume the Java FFM binding)
 - [ ] Grow the new language bindings beyond the alpha subset (contexts, routing, locators)
-- [x] **Rustwright MCP server** — expose browser automation as tools for MCP-compatible AI agents ([mcp/](mcp/))
+- [x] **Rustwright MCP server** — expose browser automation as tools for MCP-compatible AI agents ([mcp-rs/](mcp-rs/))
 - [ ] CI / Testbox-backed benchmark evidence
 - [ ] Broaden the Node.js surface (contexts, routing, locators)
 - [ ] Close remaining OOPIF gaps


### PR DESCRIPTION
https://github.com/Skyvern-AI/rustwright-cloud/pull/157