### PR TITLE
mcp-rs: harden input tools — committed-action semantics, budgets, schema duality

### DIFF
--- a/mcp-rs/src/actor.rs
+++ b/mcp-rs/src/actor.rs
@@ -54,15 +54,6 @@ const ELEMENT_EVALUATE_JS: &str = r#"async (input) => {
   const callable = (0, eval)(`(${input.function})`);
   return await callable(target);
 }"#;
-const SELECT_LABELS_JS: &str = r#"(input) => {
-  const target = document.querySelector(input.selector);
-  if (!(target instanceof HTMLSelectElement)) throw new Error('target is not a select element');
-  return input.labels.map((label) => {
-    const option = Array.from(target.options).find((candidate) => candidate.label === label);
-    if (!option) throw new Error(`option label not found: ${label}`);
-    return option.value;
-  });
-}"#;
 const SYNTHETIC_DROP_JS: &str = r#"async (input) => {
   const target = document.querySelector(input.selector);
   if (!target) throw new Error(`target not found: ${input.selector}`);
@@ -143,7 +134,10 @@ pub(crate) enum BrowserOp {
     },
     FillForm(Vec<FillField>),
     Hover(String),
-    PressKey(String),
+    PressKey {
+        target: Option<String>,
+        key: String,
+    },
     Drag {
         start_target: String,
         end_target: String,
@@ -450,7 +444,12 @@ impl ActorShared {
         {
             queue.in_flight.take();
         }
-        if request.cancellation.is_committed() {
+        // A successful type owns its result without claiming request-level
+        // physical commitment: the dispatched type path remains cancellable
+        // between characters, but returns `Ok` only after delivering them all.
+        if request.cancellation.is_committed()
+            || (result.is_ok() && matches!(&request.op, BrowserOp::Type { .. }))
+        {
             result
         } else {
             request
@@ -1168,6 +1167,20 @@ impl BrowserState {
         self.snapshot_options(request, None, None, false, cancel)
     }
 
+    // The post-action snapshot of a committed physical action is an OBSERVATION,
+    // not part of the action. Passing `None` for the cancel token keeps a late
+    // cancel from killing it, but the snapshot still consults the request
+    // deadline, so an action that commits just before the deadline would report
+    // `Timeout` for a key press the page has already processed -- exactly the
+    // failure mode committed-action semantics exist to prevent, arriving through
+    // the deadline instead of through cancellation. Callers reach the
+    // post-snapshot only after the action returned `Ok`, so the degradation in
+    // `committed_snapshot_result` is always applied to an action that already
+    // succeeded.
+    fn committed_post_action_snapshot(&mut self, request: &ActorRequest) -> TextResult {
+        committed_snapshot_result(self.snapshot_with_cancel(request, None))
+    }
+
     fn snapshot_options(
         &mut self,
         request: &ActorRequest,
@@ -1389,7 +1402,7 @@ impl BrowserState {
             },
             // The physical click has committed, so cancellation is too late:
             // finish the post-click snapshot and preserve its owned result.
-            |state| state.snapshot_with_cancel(request, None),
+            |state| state.committed_post_action_snapshot(request),
         )
     }
 
@@ -1456,7 +1469,11 @@ impl BrowserState {
                     }
                 }
             },
-            |state| state.snapshot_with_cancel(request, None),
+            // Drag commits physical pointer input: by the time this post-action
+            // snapshot runs the drop has already landed, so route it through the
+            // committed-action helper. A failed observation must degrade to a
+            // truthful success instead of reporting the committed drag as failed.
+            |state| state.committed_post_action_snapshot(request),
         )?;
         Ok(render_drag_result(&start_display, &end_display, &snapshot))
     }
@@ -1544,10 +1561,12 @@ impl BrowserState {
                             )
                         })?;
                     }
-                    page.type_text_with_cancel(
+                    let typing_budget = Self::remaining(request)?;
+                    page.type_text_with_options_and_cancel(
                         &selector,
                         text,
                         slowly.then_some(Duration::from_millis(50)),
+                        ActionOptions::timeout(Self::engine_timeout(typing_budget)),
                         Some(&request.cancellation.engine),
                     )
                 };
@@ -1560,9 +1579,15 @@ impl BrowserState {
                     )
                 })?;
                 if submit {
+                    let submit_budget = Self::remaining(request)?;
                     state
                         .ensure_page(request)?
-                        .press_key(Some(&selector), "Enter")
+                        .press_key_with_options_and_cancel(
+                            Some(&selector),
+                            "Enter",
+                            ActionOptions::timeout(Self::engine_timeout(submit_budget)),
+                            Some(&request.cancellation.engine),
+                        )
                         .map_err(|error| {
                             state.operation_error(
                                 &format!("submit failed for {target}"),
@@ -1574,47 +1599,11 @@ impl BrowserState {
                 }
                 Ok(())
             },
-            |state| state.snapshot_with_cancel(request, None),
+            // Reaching the post-action snapshot proves that fill/type and the
+            // optional submit all returned `Ok`; cancellation after that point
+            // is too late to relabel the completed type as failed.
+            |state| state.committed_post_action_snapshot(request),
         )
-    }
-
-    fn resolve_select_values(
-        &mut self,
-        selector: &str,
-        labels: &[String],
-        request: &ActorRequest,
-    ) -> Result<Vec<String>, BrowserError> {
-        let remaining = Self::remaining(request)?;
-        let value = self.ensure_page(request)?.evaluate_with_cancel(
-            SELECT_LABELS_JS,
-            Some(&json!({"selector": selector, "labels": labels})),
-            ActionOptions::timeout(Self::engine_timeout(remaining)),
-            Some(&request.cancellation.engine),
-        );
-        value
-            .map_err(|error| {
-                self.operation_error(
-                    "select option label resolution failed",
-                    error,
-                    &request.cancellation,
-                    request.timeout_ms,
-                )
-            })?
-            .as_array()
-            .ok_or_else(|| {
-                BrowserError::Message(
-                    "select option label resolution returned no values".to_owned(),
-                )
-            })?
-            .iter()
-            .map(|value| {
-                value.as_str().map(ToOwned::to_owned).ok_or_else(|| {
-                    BrowserError::Message(
-                        "select option label resolution returned a non-string".to_owned(),
-                    )
-                })
-            })
-            .collect()
     }
 
     fn select_option(
@@ -1627,20 +1616,11 @@ impl BrowserState {
         self.dispatch_ref_action(
             target,
             |state| {
-                let first = state.ensure_page(request)?.select_options_with_cancel(
-                    &selector,
-                    values,
-                    Some(&request.cancellation.engine),
-                );
-                if first.is_ok() {
-                    return Ok(());
-                }
-                let resolved = state.resolve_select_values(&selector, values, request)?;
                 state
                     .ensure_page(request)?
-                    .select_options_with_cancel(
+                    .select_options_by_value_or_label_with_cancel(
                         &selector,
-                        &resolved,
+                        values,
                         Some(&request.cancellation.engine),
                     )
                     .map_err(|error| {
@@ -1716,23 +1696,13 @@ impl BrowserState {
                 }
                 FillFieldKind::Combobox => {
                     let values = [field.value.clone()];
-                    let first = self.ensure_page(request)?.select_options_with_cancel(
-                        &selector,
-                        &values,
-                        Some(&request.cancellation.engine),
-                    );
-                    if first.is_ok() {
-                        Ok(())
-                    } else {
-                        let resolved = self.resolve_select_values(&selector, &values, request)?;
-                        self.ensure_page(request)?
-                            .select_options_with_cancel(
-                                &selector,
-                                &resolved,
-                                Some(&request.cancellation.engine),
-                            )
-                            .map(|_| ())
-                    }
+                    self.ensure_page(request)?
+                        .select_options_by_value_or_label_with_cancel(
+                            &selector,
+                            &values,
+                            Some(&request.cancellation.engine),
+                        )
+                        .map(|_| ())
                 }
             };
             result.map_err(|error| {
@@ -1765,23 +1735,55 @@ impl BrowserState {
                         )
                     })
             },
-            |state| state.snapshot(request),
+            // Hover dispatches committed physical pointer input; like click,
+            // its post-action snapshot must survive cancellation.
+            |state| state.committed_post_action_snapshot(request),
         )
     }
 
-    fn press_key(&mut self, key: &str, request: &ActorRequest) -> TextResult {
+    fn press_key_on_page(
+        &mut self,
+        selector: Option<&str>,
+        key: &str,
+        context: &str,
+        request: &ActorRequest,
+    ) -> Result<(), BrowserError> {
+        let remaining = Self::remaining(request)?;
+        let result = self
+            .ensure_page(request)?
+            .press_key_with_options_and_cancel(
+                selector,
+                key,
+                ActionOptions::timeout(Self::engine_timeout(remaining)),
+                Some(&request.cancellation.engine),
+            );
+        result.map_err(|error| {
+            self.operation_error(context, error, &request.cancellation, request.timeout_ms)
+        })
+    }
+
+    fn press_key(&mut self, target: Option<&str>, key: &str, request: &ActorRequest) -> TextResult {
+        if let Some(target) = target {
+            let selector = format!(r#"[data-mcp-ref="{target}"]"#);
+            return self.dispatch_ref_action(
+                target,
+                |state| {
+                    state.press_key_on_page(
+                        Some(&selector),
+                        key,
+                        &format!("key press failed for {target}"),
+                        request,
+                    )
+                },
+                // The key-down dispatch has committed, so cancellation is too
+                // late for both the key-up cleanup and post-action snapshot.
+                |state| state.committed_post_action_snapshot(request),
+            );
+        }
+
         self.current_refs.clear();
-        self.ensure_page(request)?
-            .press_key(None, key)
-            .map_err(|error| {
-                self.operation_error(
-                    "key press failed",
-                    error,
-                    &request.cancellation,
-                    request.timeout_ms,
-                )
-            })?;
-        self.snapshot_with_cancel(request, None)
+        self.press_key_on_page(None, key, "key press failed", request)?;
+        self.committed_post_action_snapshot(request)
     }
 
     fn drop_data(
@@ -2627,7 +2629,9 @@ impl BrowserState {
                 .map(BrowserOutput::Text),
             BrowserOp::FillForm(fields) => self.fill_form(fields, request).map(BrowserOutput::Text),
             BrowserOp::Hover(target) => self.hover(target, request).map(BrowserOutput::Text),
-            BrowserOp::PressKey(key) => self.press_key(key, request).map(BrowserOutput::Text),
+            BrowserOp::PressKey { target, key } => self
+                .press_key(target.as_deref(), key, request)
+                .map(BrowserOutput::Text),
             BrowserOp::Drag {
                 start_target,
                 end_target,
@@ -2745,6 +2749,25 @@ impl BrowserState {
     }
 }
 
+/// Degrade a failed post-action observation into a successful response.
+///
+/// A committed physical action has already changed the page by the time its
+/// post-action snapshot runs, so reporting the snapshot's error as the action's
+/// error would tell the caller a key press or click failed when the page has
+/// already processed it. The caller learns the state is unavailable instead,
+/// and `dispatch_ref_action` has already cleared `current_refs`, so the stale
+/// refs cannot be reused -- the response fails closed on refs while staying
+/// truthful about the action.
+fn committed_snapshot_result(snapshot: TextResult) -> TextResult {
+    match snapshot {
+        Ok(text) => Ok(text),
+        Err(error) => Ok(format!(
+            "Action completed, but the page state could not be captured: {error}\n\
+             Call browser_snapshot for the current page state."
+        )),
+    }
+}
+
 fn render_drag_result(start_display: &str, end_display: &str, snapshot: &str) -> String {
     format!("### Result\nDragged {start_display} to {end_display}.\n\n### Snapshot\n{snapshot}")
 }
@@ -2764,7 +2787,7 @@ fn browser_op_name(op: &BrowserOp) -> &'static str {
         BrowserOp::SelectOption { .. } => "browser_select_option",
         BrowserOp::FillForm(_) => "browser_fill_form",
         BrowserOp::Hover(_) => "browser_hover",
-        BrowserOp::PressKey(_) => "browser_press_key",
+        BrowserOp::PressKey { .. } => "browser_press_key",
         BrowserOp::Drag { .. } => "browser_drag",
         BrowserOp::Drop { .. } => "browser_drop",
         BrowserOp::ConsoleMessages { .. } => "browser_console_messages",
@@ -3994,6 +4017,17 @@ mod tests {
         RequestId::Number(value)
     }
 
+    fn snapshot_ref(snapshot: &str, role: &str, name: &str) -> String {
+        let line = snapshot
+            .lines()
+            .find(|line| line.contains(&format!("- {role}")) && line.contains(name))
+            .unwrap_or_else(|| panic!("{role} {name:?} missing from snapshot:\n{snapshot}"));
+        let marker = "[ref=";
+        let start = line.find(marker).expect("snapshot ref start") + marker.len();
+        let end = line[start..].find(']').expect("snapshot ref end") + start;
+        line[start..end].to_owned()
+    }
+
     fn output_text(output: &BrowserOutput) -> &str {
         match output {
             BrowserOutput::Text(text) => text,
@@ -4241,6 +4275,14 @@ mod tests {
     }
 
     #[test]
+    fn engine_timeout_preserves_request_budget_above_thirty_seconds() {
+        assert_eq!(
+            BrowserState::engine_timeout(Duration::from_secs(45)),
+            46_000.0
+        );
+    }
+
+    #[test]
     fn failed_post_click_snapshot_leaves_old_ref_stale() {
         let mut state = BrowserState::default();
         state.current_refs.insert("e7".to_owned());
@@ -4282,6 +4324,96 @@ mod tests {
             dispatches.get(),
             1,
             "stale retry must not re-dispatch click"
+        );
+    }
+
+    #[test]
+    fn committed_action_survives_a_failed_post_action_snapshot() {
+        assert_eq!(
+            committed_snapshot_result(Ok("- page snapshot".to_owned())),
+            Ok("- page snapshot".to_owned()),
+            "a successful observation must pass through untouched"
+        );
+
+        // `Timeout` is the failure this exists for. The post-action snapshot
+        // passes `None` for the cancel token, so a late cancel cannot reach it,
+        // but `BrowserState::remaining` still turns an elapsed request budget
+        // into `Timeout` -- so a key press that commits microseconds before the
+        // deadline used to be reported as a failed key press.
+        let degraded = committed_snapshot_result(Err(BrowserError::Timeout(5_000)))
+            .expect("a committed action must not fail because its observation did");
+        assert!(
+            degraded.contains("Action completed"),
+            "response must say the action succeeded: {degraded}"
+        );
+        assert!(
+            degraded.contains("browser command timed out after 5000 ms"),
+            "response must keep the observation's cause: {degraded}"
+        );
+        assert!(
+            degraded.contains("browser_snapshot"),
+            "response must tell the caller how to recover state: {degraded}"
+        );
+
+        assert!(
+            committed_snapshot_result(Err(BrowserError::Cancelled)).is_ok(),
+            "cancellation is equally too late once the action has committed"
+        );
+    }
+
+    #[test]
+    fn every_committed_input_tool_takes_its_post_action_snapshot_through_the_helper() {
+        // `committed_snapshot_result` is only worth anything if the committed
+        // tools actually route through it, and that wiring is what a later
+        // refactor would quietly undo -- the degradation itself would keep
+        // passing its own test while a key press committing just before its
+        // deadline went back to reporting `Timeout`. Asserting over the source
+        // pins the wiring without a browser.
+        //
+        // Split at the test module so the literals below -- which live in it --
+        // cannot match themselves. That self-match is exactly what made an
+        // earlier attempt at this test count two phantom call sites.
+        //
+        // Match the whole unindented module header, not a bare `#[cfg(test)]`:
+        // there is a test-only field earlier in the file carrying that
+        // attribute, and splitting on it silently truncated production to a
+        // prefix holding none of the call sites -- which reads as "zero
+        // bypasses" for the assertion below rather than as a broken test.
+        const TEST_MODULE: &str = "\n#[cfg(test)]\nmod tests {";
+        let source = include_str!("actor.rs");
+        assert_eq!(
+            source.matches(TEST_MODULE).count(),
+            1,
+            "the production/test split point must be unambiguous"
+        );
+        let production = source
+            .split_once(TEST_MODULE)
+            .expect("actor.rs must have a test module to split on")
+            .0;
+
+        // Only the helper is allowed to take a post-action snapshot that ignores
+        // the cancel token. A tool that reached past it would have to spell this
+        // out itself, which shows up here as a second occurrence.
+        assert_eq!(
+            production
+                .matches("snapshot_with_cancel(request, None)")
+                .count(),
+            1,
+            "an uncancellable post-action snapshot must only be taken inside \
+             committed_post_action_snapshot"
+        );
+
+        // The other way to bypass the helper is to call the cancellable snapshot
+        // directly, which leaves this count short instead. Six committed
+        // physical actions: click, type-with-submit, hover, drag, and press_key
+        // in both its targeted and untargeted forms. A seventh committed tool
+        // should fail here until someone confirms it wants the same treatment.
+        assert_eq!(
+            production
+                .matches("committed_post_action_snapshot(request)")
+                .count(),
+            6,
+            "every committed physical action must observe through the helper"
         );
     }
 
@@ -5088,6 +5220,7 @@ mod tests {
         let body = match path {
             "/actionability" => actionability_fixture(),
             "/cancel" => cancellation_fixture(),
+            "/input" => input_fixture(),
             "/atomic-click" => atomic_click_fixture(),
             "/physical" => physical_fixture(),
             "/oopif-top" => oopif_top_fixture(port),
@@ -5270,6 +5403,125 @@ mod tests {
     }));
   }
   fetch('/capture?events=physical-ready');
+</script>"#
+            .to_owned()
+    }
+
+    fn input_fixture() -> String {
+        r#"<!doctype html>
+<label for="type-target">Type target</label>
+<input id="type-target" value="old value">
+<label for="secret-target">Secret input</label>
+<input id="secret-target" type="password">
+<div id="secret-length-readout" role="status">Secret length: 0</div>
+<div id="type-readout" role="status">Typed value: old value</div>
+<div id="type-change-readout" role="status">Type change value: none</div>
+<div id="key-readout" role="status">Key pressed: none</div>
+<div id="submit-readout" role="status">Submit effects: 0</div>
+<button id="hover-target">Hover target</button>
+<div id="hover-readout" role="status">Hover observed: false</div>
+<label for="select-target">Select target</label>
+<select id="select-target">
+  <option value="alpha">Alpha</option>
+  <option value="beta">Beta</option>
+</select>
+<div id="select-readout" role="status">Selected value: alpha; changes: 0</div>
+<label for="multi-select-target">Multi select target</label>
+<select id="multi-select-target" multiple>
+  <option value="alpha" selected>Alpha</option>
+  <option value="beta" selected>Beta</option>
+</select>
+<div id="multi-select-readout" role="status">Selected values: alpha,beta; changes: 0</div>
+<label for="ambiguous-select-target">Ambiguous select target</label>
+<select id="ambiguous-select-target">
+  <option value="other">X</option>
+  <option value="X">Y</option>
+</select>
+<div id="ambiguous-select-readout" role="status">Ambiguous selected value: other; changes: 0</div>
+<label for="ambiguous-multi-select-target">Ambiguous multi select target</label>
+<select id="ambiguous-multi-select-target" multiple>
+  <option value="other">X</option>
+  <option value="X">Y</option>
+</select>
+<div id="ambiguous-multi-select-readout" role="status">Ambiguous selected values: none; changes: 0</div>
+<script>
+  const typeTarget = document.querySelector('#type-target');
+  const secretTarget = document.querySelector('#secret-target');
+  const typeReadout = document.querySelector('#type-readout');
+  const typeChangeReadout = document.querySelector('#type-change-readout');
+  const keyReadout = document.querySelector('#key-readout');
+  const submitReadout = document.querySelector('#submit-readout');
+  const updateSecretLength = () => {
+    document.querySelector('#secret-length-readout').textContent =
+      `Secret length: ${secretTarget.value.length}`;
+  };
+  secretTarget.addEventListener('input', updateSecretLength);
+  secretTarget.addEventListener('change', updateSecretLength);
+  typeTarget.addEventListener('input', () => {
+    typeReadout.textContent = `Typed value: ${typeTarget.value}`;
+  });
+  typeTarget.addEventListener('change', () => {
+    typeChangeReadout.textContent =
+      `Type change value: ${typeTarget.value || '(empty)'}`;
+  });
+  let keyEffects = 0;
+  let submitEffects = 0;
+  typeTarget.addEventListener('keydown', event => {
+    keyEffects += 1;
+    if (event.key === 'Enter') {
+      submitEffects += 1;
+      submitReadout.textContent = `Submit effects: ${submitEffects}`;
+    }
+    keyReadout.textContent = `Key pressed: ${event.key}; trusted: ${event.isTrusted}`;
+    const signal = new XMLHttpRequest();
+    signal.open('GET', '/capture?events=input-keydown', false);
+    signal.send();
+    const releaseWindow = performance.now() + 500;
+    while (performance.now() < releaseWindow) {}
+  });
+  typeTarget.addEventListener('keyup', event => {
+    keyReadout.textContent =
+      `Key pressed: ${event.key}; trusted: ${event.isTrusted}; state: up; effects: ${keyEffects}`;
+  });
+  document.querySelector('#hover-target').addEventListener('mouseover', event => {
+    document.querySelector('#hover-readout').textContent =
+      `Hover observed: true; trusted: ${event.isTrusted}`;
+  });
+  let changes = 0;
+  const selectTarget = document.querySelector('#select-target');
+  selectTarget.addEventListener('change', () => {
+    changes += 1;
+    document.querySelector('#select-readout').textContent =
+      `Selected value: ${selectTarget.value}; changes: ${changes}`;
+  });
+  let multiChanges = 0;
+  const multiSelectTarget = document.querySelector('#multi-select-target');
+  multiSelectTarget.addEventListener('change', () => {
+    multiChanges += 1;
+    const selected = Array.from(multiSelectTarget.selectedOptions)
+      .map(option => option.value)
+      .join(',') || 'none';
+    document.querySelector('#multi-select-readout').textContent =
+      `Selected values: ${selected}; changes: ${multiChanges}`;
+  });
+  let ambiguousChanges = 0;
+  const ambiguousSelectTarget = document.querySelector('#ambiguous-select-target');
+  ambiguousSelectTarget.addEventListener('change', () => {
+    ambiguousChanges += 1;
+    document.querySelector('#ambiguous-select-readout').textContent =
+      `Ambiguous selected value: ${ambiguousSelectTarget.value}; changes: ${ambiguousChanges}`;
+  });
+  let ambiguousMultiChanges = 0;
+  const ambiguousMultiSelectTarget =
+    document.querySelector('#ambiguous-multi-select-target');
+  ambiguousMultiSelectTarget.addEventListener('change', () => {
+    ambiguousMultiChanges += 1;
+    const selected = Array.from(ambiguousMultiSelectTarget.selectedOptions)
+      .map(option => option.value)
+      .join(',') || 'none';
+    document.querySelector('#ambiguous-multi-select-readout').textContent =
+      `Ambiguous selected values: ${selected}; changes: ${ambiguousMultiChanges}`;
+  });
 </script>"#
             .to_owned()
     }
@@ -5574,6 +5826,655 @@ mod tests {
             "the post-click snapshot must observe exactly one effect: {result}"
         );
         assert!(!actor.cancel(&click_id));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn input_tool_type_password_snapshot_masks_new_sentinel() {
+        let _guard = browser_test_lock().lock().await;
+        let Some(actor) = actor().await else {
+            return;
+        };
+        let server = ActionFixtureServer::start();
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(61_000),
+                BrowserOp::Navigate(server.url("/input")),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("navigate actor to input fixture");
+        let snapshot_text = output_text(&snapshot);
+        assert!(!snapshot_text.contains("[value=••••••]"), "{snapshot_text}");
+        assert!(
+            snapshot_text.contains("Secret length: 0"),
+            "{snapshot_text}"
+        );
+        let target = snapshot_ref(snapshot_text, "textbox", "Secret input");
+        let sentinel = "actor-password-sentinel-61001";
+
+        let typed = actor
+            .execute_with_timeout(
+                request_id(61_001),
+                BrowserOp::Type {
+                    target,
+                    text: sentinel.to_owned(),
+                    submit: false,
+                    slowly: false,
+                    clear: true,
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("type into snapshot ref");
+        let typed = output_text(&typed);
+        assert!(typed.contains("[value=••••••]"), "{typed}");
+        assert!(
+            typed.contains(&format!("Secret length: {}", sentinel.chars().count())),
+            "{typed}"
+        );
+        assert!(!typed.contains(sentinel), "{typed}");
+        assert!(!typed.contains("do-not-render"), "{typed}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn input_tool_default_clear_type_fills_without_empty_change() {
+        let _guard = browser_test_lock().lock().await;
+        let Some(actor) = actor().await else {
+            return;
+        };
+        let server = ActionFixtureServer::start();
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(61_100),
+                BrowserOp::Navigate(server.url("/input")),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("navigate actor to input fixture");
+        let target = snapshot_ref(output_text(&snapshot), "textbox", "Type target");
+
+        let typed = actor
+            .execute_with_timeout(
+                request_id(61_101),
+                BrowserOp::Type {
+                    target,
+                    text: "typed value".to_owned(),
+                    submit: false,
+                    slowly: false,
+                    clear: true,
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("fill snapshot ref");
+        let typed = output_text(&typed);
+        assert!(typed.contains(r#"[value="typed value"]"#), "{typed}");
+        assert!(typed.contains("Typed value: typed value"), "{typed}");
+        assert!(typed.contains("Type change value: typed value"), "{typed}");
+        assert!(!typed.contains("Type change value: (empty)"), "{typed}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancel_during_slow_type_stops_between_characters_and_before_submit() {
+        let _guard = browser_test_lock().lock().await;
+        let Some(actor) = actor().await else {
+            return;
+        };
+        let server = ActionFixtureServer::start();
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(61_200),
+                BrowserOp::Navigate(server.url("/input")),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("navigate actor to input fixture");
+        let target = snapshot_ref(output_text(&snapshot), "textbox", "Type target");
+
+        let type_id = request_id(61_201);
+        let type_actor = Arc::clone(&actor);
+        let type_request_id = type_id.clone();
+        let typed = tokio::spawn(async move {
+            type_actor
+                .execute_with_timeout(
+                    type_request_id,
+                    BrowserOp::Type {
+                        target,
+                        text: "slow".to_owned(),
+                        submit: true,
+                        slowly: true,
+                        clear: true,
+                    },
+                    Duration::from_secs(5),
+                )
+                .await
+        });
+        wait_until_in_flight(&actor, &type_id).await;
+        assert_eq!(server.capture(), "input-keydown");
+        assert!(
+            actor.cancel(&type_id),
+            "typing characters must not claim request-level commitment"
+        );
+        assert_eq!(
+            typed.await.expect("join cancelled slow type"),
+            Err(BrowserError::Cancelled)
+        );
+
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(61_202),
+                BrowserOp::Snapshot {
+                    target: None,
+                    depth: None,
+                    boxes: false,
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("snapshot after cancelled slow type");
+        let snapshot = output_text(&snapshot);
+        assert!(snapshot.contains(r#"[value="s"]"#), "{snapshot}");
+        assert!(snapshot.contains("Typed value: s"), "{snapshot}");
+        assert!(snapshot.contains("Submit effects: 0"), "{snapshot}");
+    }
+
+    #[test]
+    fn cancel_during_final_type_character_reports_success_without_commit() {
+        let shared = Arc::new(ActorShared::new());
+        let type_id = request_id(61_251);
+        let (reply, _response) = oneshot::channel();
+        shared
+            .submit(ActorRequest {
+                request_id: type_id.clone(),
+                op: BrowserOp::Type {
+                    target: "e1".to_owned(),
+                    text: "z".to_owned(),
+                    submit: false,
+                    slowly: true,
+                    clear: true,
+                },
+                cancellation: Arc::new(CommandCancellation::new()),
+                deadline: Instant::now() + Duration::from_secs(5),
+                timeout_ms: 5_000,
+                reply,
+            })
+            .expect("submit final-character type");
+        let request = shared.next().expect("take final-character type");
+        let mut state = BrowserState::default();
+        state.current_refs.insert("e1".to_owned());
+        let full_text_delivered = std::cell::Cell::new(false);
+        let cancellation_won = std::cell::Cell::new(false);
+
+        let result = state.dispatch_ref_action(
+            "e1",
+            |_| {
+                full_text_delivered.set(true);
+                Ok(())
+            },
+            |state| {
+                assert!(
+                    full_text_delivered.get(),
+                    "post-action snapshot must follow the completed type"
+                );
+                cancellation_won.set(shared.cancel(&type_id, CancellationReason::Cancelled));
+                state.committed_post_action_snapshot(&request)
+            },
+        );
+        assert!(
+            cancellation_won.get(),
+            "the final typing character must not claim request-level commitment"
+        );
+        assert!(
+            !request.cancellation.is_committed(),
+            "typing must not set request-level physical commitment"
+        );
+
+        let completed = shared.complete(&request, result);
+        assert!(
+            completed.is_ok(),
+            "a fully delivered type must not report cancellation: {completed:?}"
+        );
+
+        const TEST_MODULE: &str = "\n#[cfg(test)]\nmod tests {";
+        let production = include_str!("actor.rs")
+            .split_once(TEST_MODULE)
+            .expect("actor.rs must have a test module")
+            .0;
+        let type_path = production
+            .split_once("    fn type_text(")
+            .expect("actor type path must exist")
+            .1
+            .split_once("    fn select_option(")
+            .expect("actor type path must end before select_option")
+            .0;
+        assert!(
+            type_path.contains("|state| state.committed_post_action_snapshot(request)"),
+            "completed typing must use the completed-action snapshot path"
+        );
+        assert!(
+            !type_path.contains("state.snapshot(request)"),
+            "completed typing must not return to a cancellable snapshot"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancel_during_append_type_stops_between_characters() {
+        let _guard = browser_test_lock().lock().await;
+        let Some(actor) = actor().await else {
+            return;
+        };
+        let server = ActionFixtureServer::start();
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(61_300),
+                BrowserOp::Navigate(server.url("/input")),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("navigate actor to input fixture");
+        let target = snapshot_ref(output_text(&snapshot), "textbox", "Type target");
+
+        let type_id = request_id(61_301);
+        let type_actor = Arc::clone(&actor);
+        let type_request_id = type_id.clone();
+        let typed = tokio::spawn(async move {
+            type_actor
+                .execute_with_timeout(
+                    type_request_id,
+                    BrowserOp::Type {
+                        target,
+                        text: "append".to_owned(),
+                        submit: false,
+                        slowly: false,
+                        clear: false,
+                    },
+                    Duration::from_secs(5),
+                )
+                .await
+        });
+        wait_until_in_flight(&actor, &type_id).await;
+        assert_eq!(server.capture(), "input-keydown");
+        assert!(
+            actor.cancel(&type_id),
+            "append typing must remain request-cancellable"
+        );
+        assert_eq!(
+            typed.await.expect("join cancelled append type"),
+            Err(BrowserError::Cancelled)
+        );
+
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(61_302),
+                BrowserOp::Snapshot {
+                    target: None,
+                    depth: None,
+                    boxes: false,
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("snapshot after cancelled append type");
+        let snapshot = output_text(&snapshot);
+        // Cancellation between characters must leave exactly the one key
+        // effect that had already dispatched; caret placement after focus is
+        // engine behavior this test does not pin down.
+        assert!(
+            snapshot.contains("Key pressed: a; trusted: true; state: up; effects: 1"),
+            "{snapshot}"
+        );
+        assert!(!snapshot.contains(r#"[value="old value"]"#), "{snapshot}");
+        assert!(snapshot.contains("Submit effects: 0"), "{snapshot}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn input_tool_press_key_targets_ref_and_snapshot_observes_trusted_listener() {
+        let _guard = browser_test_lock().lock().await;
+        let Some(actor) = actor().await else {
+            return;
+        };
+        let server = ActionFixtureServer::start();
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(62_000),
+                BrowserOp::Navigate(server.url("/input")),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("navigate actor to input fixture");
+        let target = snapshot_ref(output_text(&snapshot), "textbox", "Type target");
+
+        let pressed = actor
+            .execute_with_timeout(
+                request_id(62_001),
+                BrowserOp::PressKey {
+                    target: Some(target),
+                    key: "Enter".to_owned(),
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("press key on snapshot ref");
+        let pressed = output_text(&pressed);
+        assert!(
+            pressed.contains("Key pressed: Enter; trusted: true"),
+            "{pressed}"
+        );
+        assert!(pressed.contains("state: up; effects: 1"), "{pressed}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancel_after_committed_key_press_reports_success_and_releases_key() {
+        let _guard = browser_test_lock().lock().await;
+        let Some(actor) = actor().await else {
+            return;
+        };
+        let server = ActionFixtureServer::start();
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(62_100),
+                BrowserOp::Navigate(server.url("/input")),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("navigate actor to input fixture");
+        let target = snapshot_ref(output_text(&snapshot), "textbox", "Type target");
+
+        let press_id = request_id(62_101);
+        let press_actor = Arc::clone(&actor);
+        let press_request_id = press_id.clone();
+        let press = tokio::spawn(async move {
+            press_actor
+                .execute_with_timeout(
+                    press_request_id,
+                    BrowserOp::PressKey {
+                        target: Some(target),
+                        key: "Enter".to_owned(),
+                    },
+                    Duration::from_secs(5),
+                )
+                .await
+        });
+        wait_until_in_flight(&actor, &press_id).await;
+        assert_eq!(server.capture(), "input-keydown");
+        assert!(
+            !actor.cancel(&press_id),
+            "cancellation after key-down must be a no-op-too-late"
+        );
+
+        let pressed = press
+            .await
+            .expect("join committed actor key press")
+            .expect("a committed key press must not report cancellation");
+        let pressed = output_text(&pressed);
+        assert!(pressed.contains("state: up; effects: 1"), "{pressed}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancel_after_committed_type_submit_reports_success_once() {
+        let _guard = browser_test_lock().lock().await;
+        let Some(actor) = actor().await else {
+            return;
+        };
+        let server = ActionFixtureServer::start();
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(62_200),
+                BrowserOp::Navigate(server.url("/input")),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("navigate actor to input fixture");
+        let target = snapshot_ref(output_text(&snapshot), "textbox", "Type target");
+
+        let type_id = request_id(62_201);
+        let type_actor = Arc::clone(&actor);
+        let type_request_id = type_id.clone();
+        let typed = tokio::spawn(async move {
+            type_actor
+                .execute_with_timeout(
+                    type_request_id,
+                    BrowserOp::Type {
+                        target,
+                        text: "submit once".to_owned(),
+                        submit: true,
+                        slowly: false,
+                        clear: true,
+                    },
+                    Duration::from_secs(5),
+                )
+                .await
+        });
+        wait_until_in_flight(&actor, &type_id).await;
+        assert_eq!(server.capture(), "input-keydown");
+        assert!(
+            !actor.cancel(&type_id),
+            "cancellation after submit key-down must be a no-op-too-late"
+        );
+
+        let typed = typed
+            .await
+            .expect("join committed actor type submit")
+            .expect("a committed type submit must not report cancellation");
+        let typed = output_text(&typed);
+        assert!(typed.contains(r#"[value="submit once"]"#), "{typed}");
+        assert!(typed.contains("state: up; effects: 1"), "{typed}");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn input_tool_hover_snapshot_observes_mouseover_listener() {
+        let _guard = browser_test_lock().lock().await;
+        let Some(actor) = actor().await else {
+            return;
+        };
+        let server = ActionFixtureServer::start();
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(63_000),
+                BrowserOp::Navigate(server.url("/input")),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("navigate actor to input fixture");
+        let target = snapshot_ref(output_text(&snapshot), "button", "Hover target");
+
+        let hovered = actor
+            .execute_with_timeout(
+                request_id(63_001),
+                BrowserOp::Hover(target),
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("hover snapshot ref");
+        let hovered = output_text(&hovered);
+        assert!(
+            hovered.contains("Hover observed: true; trusted: true"),
+            "{hovered}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn input_tool_select_option_matches_visible_label() {
+        let _guard = browser_test_lock().lock().await;
+        let Some(actor) = actor().await else {
+            return;
+        };
+        let server = ActionFixtureServer::start();
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(64_000),
+                BrowserOp::Navigate(server.url("/input")),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("navigate actor to input fixture");
+        let target = snapshot_ref(output_text(&snapshot), "combobox", "Select target");
+
+        let selected = actor
+            .execute_with_timeout(
+                request_id(64_001),
+                BrowserOp::SelectOption {
+                    target,
+                    values: vec!["Beta".to_owned()],
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("select option by snapshot ref");
+        let selected = output_text(&selected);
+        assert!(
+            selected.contains("Selected value: beta; changes: 1"),
+            "{selected}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn input_tool_single_select_ambiguity_uses_first_dom_value_or_label_match() {
+        let _guard = browser_test_lock().lock().await;
+        let Some(actor) = actor().await else {
+            return;
+        };
+        let server = ActionFixtureServer::start();
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(64_100),
+                BrowserOp::Navigate(server.url("/input")),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("navigate actor to input fixture");
+        let target = snapshot_ref(
+            output_text(&snapshot),
+            "combobox",
+            "Ambiguous select target",
+        );
+
+        let selected = actor
+            .execute_with_timeout(
+                request_id(64_101),
+                BrowserOp::SelectOption {
+                    target,
+                    values: vec!["X".to_owned()],
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("select ambiguous single option");
+        let selected = output_text(&selected);
+        assert!(
+            selected.contains("Ambiguous selected value: other; changes: 1"),
+            "{selected}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn input_tool_multiple_select_ambiguity_selects_all_dom_value_or_label_matches() {
+        let _guard = browser_test_lock().lock().await;
+        let Some(actor) = actor().await else {
+            return;
+        };
+        let server = ActionFixtureServer::start();
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(64_200),
+                BrowserOp::Navigate(server.url("/input")),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("navigate actor to input fixture");
+        let target = snapshot_ref(
+            output_text(&snapshot),
+            "combobox",
+            "Ambiguous multi select target",
+        );
+
+        let selected = actor
+            .execute_with_timeout(
+                request_id(64_201),
+                BrowserOp::SelectOption {
+                    target,
+                    values: vec!["X".to_owned()],
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("select ambiguous multiple options");
+        let selected = output_text(&selected);
+        assert!(
+            selected.contains("Ambiguous selected values: other,X; changes: 1"),
+            "{selected}"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn input_tool_empty_values_clear_multi_select() {
+        let _guard = browser_test_lock().lock().await;
+        let Some(actor) = actor().await else {
+            return;
+        };
+        let server = ActionFixtureServer::start();
+        let snapshot = actor
+            .execute_with_timeout(
+                request_id(64_300),
+                BrowserOp::Navigate(server.url("/input")),
+                Duration::from_secs(10),
+            )
+            .await
+            .expect("navigate actor to input fixture");
+        let target = snapshot_ref(output_text(&snapshot), "combobox", "Multi select target");
+
+        let selected = actor
+            .execute_with_timeout(
+                request_id(64_301),
+                BrowserOp::SelectOption {
+                    target,
+                    values: Vec::new(),
+                },
+                Duration::from_secs(5),
+            )
+            .await
+            .expect("clear multi-select by snapshot ref");
+        let selected = output_text(&selected);
+        assert!(
+            selected.contains("Selected values: none; changes: 1"),
+            "{selected}"
+        );
+    }
+
+    #[test]
+    fn input_tool_type_rejects_unknown_and_stale_refs() {
+        let mut state = BrowserState::default();
+        state.current_refs.insert("e1".to_owned());
+        let (reply, _response) = oneshot::channel();
+        let request = ActorRequest {
+            request_id: request_id(65_000),
+            op: BrowserOp::Type {
+                target: "e1".to_owned(),
+                text: "not typed".to_owned(),
+                submit: false,
+                slowly: false,
+                clear: true,
+            },
+            cancellation: Arc::new(CommandCancellation::new()),
+            deadline: Instant::now() + Duration::from_secs(5),
+            timeout_ms: 5_000,
+            reply,
+        };
+
+        let unknown = state.type_text("e999999", "not typed", false, false, true, &request);
+        assert!(matches!(
+            unknown,
+            Err(BrowserError::Message(message))
+                if message.contains("unknown or stale ref e999999")
+        ));
+
+        state.current_refs = HashSet::from(["e2".to_owned()]);
+        let stale = state.type_text("e1", "not typed", false, false, true, &request);
+        assert!(matches!(
+            stale,
+            Err(BrowserError::Message(message))
+                if message.contains("unknown or stale ref e1")
+        ));
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/mcp-rs/src/tools.rs
+++ b/mcp-rs/src/tools.rs
@@ -113,7 +113,7 @@ pub(crate) const TOOL_SPECS: &[ToolSpec] = &[
     ToolSpec {
         kind: ToolKind::PressKey,
         name: "browser_press_key",
-        description: "Press a native browser key on the active page and return a fresh snapshot.",
+        description: "Press a native browser key, optionally focusing a snapshot ref first, and return a fresh snapshot.",
     },
     ToolSpec {
         kind: ToolKind::Drag,
@@ -348,6 +348,8 @@ struct TargetArgs {
 #[serde(deny_unknown_fields)]
 struct PressKeyArgs {
     key: String,
+    #[serde(default)]
+    target: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -708,10 +710,9 @@ pub(crate) fn parse_op(
         ToolKind::SelectOption => {
             let args: SelectOptionArgs = decode(arguments)?;
             validate_ref(&args.target)?;
+            // An empty list is a deliberate request: it clears every selected
+            // option, which is the only way to deselect a multi-select.
             let values = args.values.into_vec();
-            if values.is_empty() {
-                return Err("values must contain at least one string".to_owned());
-            }
             let _ = args.element;
             Ok(BrowserOp::SelectOption {
                 target: args.target,
@@ -756,7 +757,13 @@ pub(crate) fn parse_op(
             if args.key.is_empty() {
                 return Err("key must be a non-empty string".to_owned());
             }
-            Ok(BrowserOp::PressKey(args.key))
+            if let Some(target) = &args.target {
+                validate_ref(target)?;
+            }
+            Ok(BrowserOp::PressKey {
+                target: args.target,
+                key: args.key,
+            })
         }
         ToolKind::Drag => {
             let args: DragArgs = decode(arguments)?;
@@ -1068,12 +1075,22 @@ fn schema(kind: ToolKind) -> JsonObject {
                 "values": {
                     "oneOf": [
                         {"type": "string"},
-                        {"type": "array", "items": {"type": "string"}, "minItems": 1}
+                        {"type": "array", "items": {"type": "string"}}
+                    ]
+                },
+                "value": {
+                    "oneOf": [
+                        {"type": "string"},
+                        {"type": "array", "items": {"type": "string"}}
                     ]
                 },
                 "element": {"type": "string"}
             },
-            "required": ["target", "values"],
+            "required": ["target"],
+            "oneOf": [
+                {"required": ["values"], "not": {"required": ["value"]}},
+                {"required": ["value"], "not": {"required": ["values"]}}
+            ],
             "additionalProperties": false
         }),
         ToolKind::FillForm => json!({
@@ -1108,7 +1125,10 @@ fn schema(kind: ToolKind) -> JsonObject {
         }),
         ToolKind::PressKey => json!({
             "type": "object",
-            "properties": {"key": {"type": "string"}},
+            "properties": {
+                "key": {"type": "string"},
+                "target": ref_property()
+            },
             "required": ["key"],
             "additionalProperties": false
         }),

--- a/mcp-rs/tests/stdio_e2e.rs
+++ b/mcp-rs/tests/stdio_e2e.rs
@@ -82,6 +82,69 @@ const PARITY_PAGE_HTML: &str = r#"<!doctype html>
   </script>
 </body></html>"#;
 
+const INPUT_PAGE_HTML: &str = r#"<!doctype html>
+<html><head><title>Input controls</title></head>
+<body>
+  <label for="name">Test input</label>
+  <input id="name" value="sample value">
+  <input id="secret" aria-label="Secret input" type="password">
+  <div id="password-length-readout" role="status">Password length: 0</div>
+  <div id="input-readout" role="status">Input value: sample value</div>
+  <div id="key-readout" role="status">Key pressed: none</div>
+  <div id="focus-readout" role="status">Focused: none; focus changes: 0</div>
+  <label for="choice">Test choice</label>
+  <select id="choice">
+    <option value="alpha">Alpha</option>
+    <option value="beta">Beta</option>
+  </select>
+  <div id="select-readout" role="status">Selected value: alpha; changes: 0</div>
+  <script>
+    const input = document.getElementById('name');
+    const secret = document.getElementById('secret');
+    const updatePasswordLength = () => {
+      document.getElementById('password-length-readout').textContent =
+        `Password length: ${secret.value.length}`;
+    };
+    secret.addEventListener('input', updatePasswordLength);
+    secret.addEventListener('change', updatePasswordLength);
+    input.addEventListener('input', () => {
+      document.getElementById('input-readout').textContent = `Input value: ${input.value}`;
+    });
+    document.addEventListener('keydown', (event) => {
+      // The listener is on document, so it fires wherever the key lands. Recording
+      // the target is what makes the readout target-sensitive: without it a key
+      // delivered to the body or the wrong field is indistinguishable from a key
+      // delivered to the element the test aimed at.
+      const node = event.target;
+      const target = node instanceof Element
+        ? (node.id || node.tagName.toLowerCase())
+        : 'none';
+      document.getElementById('key-readout').textContent =
+        `Key pressed: ${event.key}; trusted: ${event.isTrusted}; target: ${target}`;
+    });
+    let focusChanges = 0;
+    // Focus is the page state a rejected key press must not disturb. Counting
+    // the changes as well as naming the focused element makes a spurious focus
+    // observable even when it lands back on the element that already had it.
+    document.addEventListener('focusin', (event) => {
+      focusChanges += 1;
+      const node = event.target;
+      const id = node instanceof Element
+        ? (node.id || node.tagName.toLowerCase())
+        : 'none';
+      document.getElementById('focus-readout').textContent =
+        `Focused: ${id}; focus changes: ${focusChanges}`;
+    });
+    let changes = 0;
+    const choice = document.getElementById('choice');
+    choice.addEventListener('change', () => {
+      changes += 1;
+      document.getElementById('select-readout').textContent =
+        `Selected value: ${choice.value}; changes: ${changes}`;
+    });
+  </script>
+</body></html>"#;
+
 const DRAG_PAGE_HTML: &str = r#"<!doctype html>
 <html><head><title>Physical drag</title>
 <style>
@@ -442,6 +505,10 @@ impl PageServer {
         format!("http://{}/parity", self.addr)
     }
 
+    fn input_url(&self) -> String {
+        format!("http://{}/input", self.addr)
+    }
+
     fn network_url(&self) -> String {
         format!("http://{}/network", self.addr)
     }
@@ -566,6 +633,12 @@ fn serve_connection(mut stream: TcpStream) {
             "text/html; charset=utf-8",
             "",
             PARITY_PAGE_HTML.as_bytes().to_vec(),
+        )
+    } else if path == "/input" {
+        (
+            "text/html; charset=utf-8",
+            "",
+            INPUT_PAGE_HTML.as_bytes().to_vec(),
         )
     } else if path == "/network" {
         (
@@ -796,6 +869,41 @@ impl Drop for ServerProcess {
     }
 }
 
+fn role_ref(snapshot: &str, role: &str, name: &str) -> String {
+    let line = snapshot
+        .lines()
+        .find(|line| line.contains(&format!("- {role}")) && line.contains(name))
+        .unwrap_or_else(|| panic!("{role} {name:?} missing from snapshot:\n{snapshot}"));
+    let marker = "[ref=";
+    let start = line.find(marker).expect("role ref start") + marker.len();
+    let end = line[start..].find(']').expect("role ref end") + start;
+    line[start..end].to_owned()
+}
+
+// Extract a rendered readout's full text so two snapshots can be compared for
+// equality. `prefix` starts with the opening quote the renderer wraps names in;
+// returning the text up to the closing quote keeps ref markers -- whose numbers
+// are reassigned on every snapshot -- out of the comparison.
+fn status_text(snapshot: &str, prefix: &str) -> String {
+    assert!(
+        prefix.starts_with('"'),
+        "prefix must start at the renderer's opening quote: {prefix:?}"
+    );
+    let mut matches = snapshot.match_indices(prefix);
+    let (start, _) = matches
+        .next()
+        .unwrap_or_else(|| panic!("{prefix:?} missing from snapshot:\n{snapshot}"));
+    assert!(
+        matches.next().is_none(),
+        "{prefix:?} matched more than once, so equality would be ambiguous:\n{snapshot}"
+    );
+    let rest = &snapshot[start + 1..];
+    let end = rest
+        .find('"')
+        .unwrap_or_else(|| panic!("unterminated readout for {prefix:?}:\n{snapshot}"));
+    rest[..end].to_owned()
+}
+
 fn result_text(message: &Value) -> &str {
     assert_eq!(
         message["result"]["isError"], false,
@@ -883,6 +991,88 @@ fn button_ref(snapshot: &str, name: &str) -> String {
     let start = line.find(marker).expect("button ref start") + marker.len();
     let end = line[start..].find(']').expect("button ref end") + start;
     line[start..end].to_owned()
+}
+
+fn poll_snapshot_until(
+    server: &mut ServerProcess,
+    latest: String,
+    next_id: &mut i64,
+    needle: &str,
+) -> String {
+    poll_snapshot_state(
+        server,
+        latest,
+        next_id,
+        &format!("{needle:?}"),
+        |snapshot| snapshot.contains(needle),
+    )
+}
+
+// Masking is a property of EVERY snapshot, not just the one a poll settles on.
+// Checking only the returned snapshot would let a plaintext leak in the tool's
+// immediate response or in any intermediate poll pass unnoticed, because a later
+// masked snapshot would overwrite it. `poll_snapshot_state` runs its predicate on
+// the initial value and on each snapshot it fetches, so asserting inside the
+// predicate covers every snapshot this poll observes.
+fn poll_snapshot_until_never_leaking(
+    server: &mut ServerProcess,
+    latest: String,
+    next_id: &mut i64,
+    needle: &str,
+    secret: &str,
+) -> String {
+    poll_snapshot_state(
+        server,
+        latest,
+        next_id,
+        &format!("{needle:?}"),
+        |snapshot| {
+            assert!(
+                !snapshot.contains(secret),
+                "snapshot leaked the secret {secret:?}:\n{snapshot}"
+            );
+            // The positive complement of the leak check: absence of the plaintext
+            // is also satisfied by a snapshot that dropped the field entirely, so
+            // any snapshot still rendering the password row has to render it
+            // masked. Responses that carry no snapshot mention neither string and
+            // pass, which is what lets the poll keep going instead of failing on
+            // an intermediate tool reply.
+            assert!(
+                !snapshot.contains("Secret input") || snapshot.contains("[value=••••••]"),
+                "snapshot rendered the password row unmasked:\n{snapshot}"
+            );
+            snapshot.contains(needle)
+        },
+    )
+}
+
+// Page-side readouts are written by the page's own event listeners at the
+// renderer's next rendering step, so a tool response's snapshot cannot promise
+// they are already current; converge on the expected state instead of
+// asserting one unguaranteed interleaving.
+fn poll_snapshot_state(
+    server: &mut ServerProcess,
+    mut latest: String,
+    next_id: &mut i64,
+    what: &str,
+    predicate: impl Fn(&str) -> bool,
+) -> String {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while !predicate(&latest) {
+        assert!(
+            Instant::now() < deadline,
+            "snapshot did not converge on {what}:\n{latest}"
+        );
+        let id = *next_id;
+        *next_id += 1;
+        server.send(json!({
+            "jsonrpc":"2.0","id":id,"method":"tools/call",
+            "params":{"name":"browser_snapshot","arguments":{}}
+        }));
+        latest = result_text(&server.receive()).to_owned();
+        thread::sleep(Duration::from_millis(20));
+    }
+    latest
 }
 
 fn scroll_y(snapshot: &str) -> u64 {
@@ -1056,6 +1246,46 @@ fn real_stdio_snapshot_click_monotonic_refs_and_clean_shutdown() {
         "^e[1-9][0-9]*$"
     );
     assert_eq!(
+        tool("browser_press_key")["inputSchema"]["required"],
+        json!(["key"])
+    );
+    // The optional target is a snapshot ref, constrained exactly like every
+    // other ref-taking tool so a caller cannot smuggle a selector through it.
+    assert_eq!(
+        tool("browser_press_key")["inputSchema"]["properties"]["target"]["pattern"],
+        "^e[1-9][0-9]*$"
+    );
+    assert_eq!(
+        tool("browser_hover")["inputSchema"]["required"],
+        json!(["target"])
+    );
+    assert_eq!(
+        tool("browser_select_option")["inputSchema"]["required"],
+        json!(["target"])
+    );
+    for field in ["values", "value"] {
+        assert_eq!(
+            tool("browser_select_option")["inputSchema"]["properties"][field]["oneOf"],
+            json!([
+                {"type": "string"},
+                {"type": "array", "items": {"type": "string"}}
+            ])
+        );
+    }
+    assert_eq!(
+        tool("browser_select_option")["inputSchema"]["oneOf"],
+        json!([
+            {
+                "required": ["values"],
+                "not": {"required": ["value"]}
+            },
+            {
+                "required": ["value"],
+                "not": {"required": ["values"]}
+            }
+        ])
+    );
+    assert_eq!(
         tool("browser_scroll")["inputSchema"]["properties"]["direction"]["enum"],
         json!(["up", "down"])
     );
@@ -1219,6 +1449,249 @@ fn real_stdio_tool_profiles_and_evaluation_gate_match_contract() {
     ]);
     assert_eq!(no_eval.len(), 16);
     assert!(!no_eval.contains(&"browser_evaluate".to_owned()));
+}
+
+#[test]
+fn real_stdio_type_press_enter_and_select_option_round_trip() {
+    if chromium().executable_path().is_none() {
+        eprintln!("skipping input tools MCP test: Chromium executable unavailable");
+        return;
+    }
+
+    let page_server = PageServer::start();
+    let mut server = ServerProcess::spawn();
+    server.initialize();
+
+    server.send(json!({
+        "jsonrpc":"2.0","id":201,"method":"tools/call",
+        "params":{"name":"browser_navigate","arguments":{"url":page_server.input_url()}}
+    }));
+    let navigated = result_text(&server.receive()).to_owned();
+    assert!(navigated.contains("Test input"), "{navigated}");
+
+    server.send(json!({
+        "jsonrpc":"2.0","id":202,"method":"tools/call",
+        "params":{"name":"browser_snapshot","arguments":{}}
+    }));
+    let snapshot = result_text(&server.receive()).to_owned();
+    assert!(snapshot.contains(r#""Password length: 0""#), "{snapshot}");
+    // Nothing has been typed yet, and the renderer omits the value part entirely
+    // for an empty field, so the mask is absent here. Pinning that keeps the mask
+    // assertions below honest: they observe a transition rather than a constant
+    // that would hold even if masking were removed from the renderer.
+    assert!(!snapshot.contains("[value=••••••]"), "{snapshot}");
+    let password_target = role_ref(&snapshot, "textbox", "Secret input");
+    let password_sentinel = "stdio-password-sentinel-203";
+    let mut next_id = 203;
+
+    let typed_id = next_id;
+    next_id += 1;
+    server.send(json!({
+        "jsonrpc":"2.0","id":typed_id,"method":"tools/call",
+        "params":{
+            "name":"browser_type",
+            "arguments":{"target":password_target,"text":password_sentinel}
+        }
+    }));
+    let password_typed = result_text(&server.receive()).to_owned();
+    // The page reports the length it received, so the secret round-tripped
+    // intact even though every snapshot renders it masked. Every snapshot
+    // observed from here on is checked for the sentinel, so a leak at any point
+    // fails the test rather than being overwritten by a later masked snapshot.
+    let password_typed = poll_snapshot_until_never_leaking(
+        &mut server,
+        password_typed,
+        &mut next_id,
+        &format!(
+            r#""Password length: {}""#,
+            password_sentinel.chars().count()
+        ),
+        password_sentinel,
+    );
+    assert!(
+        password_typed.contains("[value=••••••]"),
+        "{password_typed}"
+    );
+
+    let input_target = role_ref(&password_typed, "textbox", "Test input");
+    let input_id = next_id;
+    next_id += 1;
+    server.send(json!({
+        "jsonrpc":"2.0","id":input_id,"method":"tools/call",
+        "params":{
+            "name":"browser_type",
+            "arguments":{"target":input_target,"text":"stdio typed"}
+        }
+    }));
+    let typed = result_text(&server.receive()).to_owned();
+    assert!(typed.contains(r#"[value="stdio typed"]"#), "{typed}");
+    assert!(typed.contains("[value=••••••]"), "{typed}");
+    assert!(!typed.contains(password_sentinel), "{typed}");
+
+    let press_id = next_id;
+    next_id += 1;
+    server.send(json!({
+        "jsonrpc":"2.0","id":press_id,"method":"tools/call",
+        "params":{"name":"browser_press_key","arguments":{"key":"Enter"}}
+    }));
+    let pressed = result_text(&server.receive()).to_owned();
+    // An untargeted press goes wherever focus already is, and the typing above
+    // left focus on the text input -- so the readout naming `name` as the target
+    // is what distinguishes a key that reached the focused element from one that
+    // fell through to the body.
+    let observed = poll_snapshot_until_never_leaking(
+        &mut server,
+        pressed,
+        &mut next_id,
+        r#""Key pressed: Enter; trusted: true; target: name""#,
+        password_sentinel,
+    );
+    assert!(
+        observed.contains(r#""Input value: stdio typed""#),
+        "{observed}"
+    );
+
+    let select_target = role_ref(&observed, "combobox", "Test choice");
+    let select_id = next_id;
+    next_id += 1;
+    server.send(json!({
+        "jsonrpc":"2.0","id":select_id,"method":"tools/call",
+        "params":{
+            "name":"browser_select_option",
+            "arguments":{"target":select_target,"values":"beta"}
+        }
+    }));
+    let selected = result_text(&server.receive()).to_owned();
+    let selected = poll_snapshot_until_never_leaking(
+        &mut server,
+        selected,
+        &mut next_id,
+        r#""Selected value: beta; changes: 1""#,
+        password_sentinel,
+    );
+    assert!(
+        selected.contains(r#""Input value: stdio typed""#),
+        "{selected}"
+    );
+    assert!(selected.contains("[value=••••••]"), "{selected}");
+    assert!(!selected.contains(password_sentinel), "{selected}");
+
+    // A targeted press focuses the ref before dispatching, so the key has to
+    // land on the password field rather than on whatever held focus (the text
+    // input, from the typing above). The length readout is caret-agnostic --
+    // an insertion anywhere still moves the count by one -- so a dropped target
+    // leaves the length unchanged and stalls this poll instead of passing.
+    let secret_target = role_ref(&selected, "textbox", "Secret input");
+    let targeted_press_id = next_id;
+    next_id += 1;
+    server.send(json!({
+        "jsonrpc":"2.0","id":targeted_press_id,"method":"tools/call",
+        "params":{
+            "name":"browser_press_key",
+            "arguments":{"target":secret_target,"key":"7"}
+        }
+    }));
+    let targeted = result_text(&server.receive()).to_owned();
+    let targeted = poll_snapshot_until_never_leaking(
+        &mut server,
+        targeted,
+        &mut next_id,
+        &format!(
+            r#""Password length: {}""#,
+            password_sentinel.chars().count() + 1
+        ),
+        password_sentinel,
+    );
+    assert!(
+        targeted.contains(r#""Key pressed: 7; trusted: true; target: secret""#),
+        "{targeted}"
+    );
+    // The key went to the targeted ref and nowhere else: the text input's readout
+    // still reads exactly what the earlier typing left it, closing quote included,
+    // so a stray "7" delivered there would fail this.
+    assert!(
+        targeted.contains(r#""Input value: stdio typed""#),
+        "{targeted}"
+    );
+    assert!(targeted.contains("[value=••••••]"), "{targeted}");
+
+    // Rejecting a key must reject it before anything touches the page. The
+    // targeted press above focused the password field to deliver its key, so
+    // focus now names `secret` -- which also proves the readout is live rather
+    // than a constant, since it started at `none`.
+    let targeted = poll_snapshot_until_never_leaking(
+        &mut server,
+        targeted,
+        &mut next_id,
+        r#""Focused: secret; focus changes: "#,
+        password_sentinel,
+    );
+    let focus_before = status_text(&targeted, r#""Focused: secret"#);
+
+    // Aim the bad key at the *text* input, not the password field that currently
+    // holds focus: validating after resolving the ref would run the text input's
+    // focus handlers and step the counter, so an unchanged readout is what
+    // distinguishes "rejected before touching the page" from "rejected after".
+    let stale_focus_target = role_ref(&targeted, "textbox", "Test input");
+    let rejected_id = next_id;
+    next_id += 1;
+    let rejected = call_tool(
+        &mut server,
+        rejected_id,
+        "browser_press_key",
+        json!({"target": stale_focus_target, "key": "NoSuchKey"}),
+    );
+    let rejected = error_result_text(&rejected).to_owned();
+    assert!(rejected.contains("NoSuchKey"), "{rejected}");
+
+    let after_reject_id = next_id;
+    next_id += 1;
+    let after_reject = call_tool(&mut server, after_reject_id, "browser_snapshot", json!({}));
+    let after_reject = result_text(&after_reject).to_owned();
+    assert_eq!(
+        status_text(&after_reject, r#""Focused: "#),
+        focus_before,
+        "a rejected key press moved focus:\n{after_reject}"
+    );
+    assert!(
+        after_reject.contains(r#""Key pressed: 7; trusted: true; target: secret""#),
+        "a rejected key press reached the page:\n{after_reject}"
+    );
+    assert!(!after_reject.contains(password_sentinel), "{after_reject}");
+
+    // Filling a combobox resolves the visible label: the options are labelled
+    // "Alpha" and "Beta" over lowercase values, so a value-only matcher finds
+    // nothing and fails the call rather than reporting a new selection. The
+    // change counter reaching 2 proves exactly one further change event fired.
+    //
+    // The refs come from the post-rejection snapshot: a rejected ref action
+    // still clears the ref table on its way out, so every ref taken before it
+    // is stale by now.
+    let choice_target = role_ref(&after_reject, "combobox", "Test choice");
+    let fill_id = next_id;
+    next_id += 1;
+    server.send(json!({
+        "jsonrpc":"2.0","id":fill_id,"method":"tools/call",
+        "params":{
+            "name":"browser_fill_form",
+            "arguments":{"fields":[
+                {"target":choice_target,"name":"choice","type":"combobox","value":"Alpha"}
+            ]}
+        }
+    }));
+    let filled = result_text(&server.receive()).to_owned();
+    let filled = poll_snapshot_until_never_leaking(
+        &mut server,
+        filled,
+        &mut next_id,
+        r#""Selected value: alpha; changes: 2""#,
+        password_sentinel,
+    );
+    assert!(filled.contains(r#""Input value: stdio typed""#), "{filled}");
+    assert!(filled.contains("[value=••••••]"), "{filled}");
+    assert!(!filled.contains(password_sentinel), "{filled}");
+
+    server.finish();
 }
 
 #[test]
@@ -2191,7 +2664,10 @@ fn real_stdio_same_document_push_state_and_hash_history_complete_with_snapshots(
     }
 
     let page_server = PageServer::start();
-    let mut server = ServerProcess::spawn_with_env(&[("RUSTWRIGHT_MCP_TOOL_TIMEOUT_MS", "3000")]);
+    // Generous tool budget and elapsed bounds at half of it: under a loaded,
+    // fully parallel suite the tight budget produced false failures while a
+    // genuine frame-wait regression still blows through the halved bound.
+    let mut server = ServerProcess::spawn_with_env(&[("RUSTWRIGHT_MCP_TOOL_TIMEOUT_MS", "10000")]);
     server.initialize();
 
     server.send(json!({
@@ -2203,9 +2679,16 @@ fn real_stdio_same_document_push_state_and_hash_history_complete_with_snapshots(
     }));
     let spa_second = server.receive();
     assert!(
-        result_text(&spa_second).contains("SPA location: /history-spa?step=two"),
+        result_text(&spa_second).contains("SPA location:"),
         "{}",
         result_text(&spa_second)
+    );
+    let mut poll_id = 2600;
+    poll_snapshot_until(
+        &mut server,
+        result_text(&spa_second).to_owned(),
+        &mut poll_id,
+        "SPA location: /history-spa?step=two",
     );
 
     let started = Instant::now();
@@ -2215,14 +2698,15 @@ fn real_stdio_same_document_push_state_and_hash_history_complete_with_snapshots(
     }));
     let spa_back = server.receive();
     assert!(
-        started.elapsed() < Duration::from_secs(2),
-        "pushState back navigation approached the tool timeout: {:?}",
+        started.elapsed() < Duration::from_secs(5),
+        "pushState back navigation ran toward the 10-second tool timeout: {:?}",
         started.elapsed()
     );
-    assert!(
-        result_text(&spa_back).contains("SPA location: /history-spa?step=one"),
-        "{}",
-        result_text(&spa_back)
+    poll_snapshot_until(
+        &mut server,
+        result_text(&spa_back).to_owned(),
+        &mut poll_id,
+        "SPA location: /history-spa?step=one",
     );
 
     server.send(json!({
@@ -2230,10 +2714,11 @@ fn real_stdio_same_document_push_state_and_hash_history_complete_with_snapshots(
         "params":{"name":"browser_navigate_forward","arguments":{}}
     }));
     let spa_forward = server.receive();
-    assert!(
-        result_text(&spa_forward).contains("SPA location: /history-spa?step=two"),
-        "{}",
-        result_text(&spa_forward)
+    poll_snapshot_until(
+        &mut server,
+        result_text(&spa_forward).to_owned(),
+        &mut poll_id,
+        "SPA location: /history-spa?step=two",
     );
 
     server.send(json!({
@@ -2257,10 +2742,11 @@ fn real_stdio_same_document_push_state_and_hash_history_complete_with_snapshots(
         }
     }));
     let hash_first = server.receive();
-    assert!(
-        result_text(&hash_first).contains("Hash location: #first"),
-        "{}",
-        result_text(&hash_first)
+    poll_snapshot_until(
+        &mut server,
+        result_text(&hash_first).to_owned(),
+        &mut poll_id,
+        "Hash location: #first",
     );
 
     server.send(json!({
@@ -2271,10 +2757,11 @@ fn real_stdio_same_document_push_state_and_hash_history_complete_with_snapshots(
         }
     }));
     let hash_second = server.receive();
-    assert!(
-        result_text(&hash_second).contains("Hash location: #second"),
-        "{}",
-        result_text(&hash_second)
+    poll_snapshot_until(
+        &mut server,
+        result_text(&hash_second).to_owned(),
+        &mut poll_id,
+        "Hash location: #second",
     );
 
     server.send(json!({
@@ -2282,10 +2769,11 @@ fn real_stdio_same_document_push_state_and_hash_history_complete_with_snapshots(
         "params":{"name":"browser_navigate_back","arguments":{}}
     }));
     let hash_back = server.receive();
-    assert!(
-        result_text(&hash_back).contains("Hash location: #first"),
-        "{}",
-        result_text(&hash_back)
+    poll_snapshot_until(
+        &mut server,
+        result_text(&hash_back).to_owned(),
+        &mut poll_id,
+        "Hash location: #first",
     );
 
     server.send(json!({
@@ -2293,10 +2781,11 @@ fn real_stdio_same_document_push_state_and_hash_history_complete_with_snapshots(
         "params":{"name":"browser_navigate_forward","arguments":{}}
     }));
     let hash_forward = server.receive();
-    assert!(
-        result_text(&hash_forward).contains("Hash location: #second"),
-        "{}",
-        result_text(&hash_forward)
+    poll_snapshot_until(
+        &mut server,
+        result_text(&hash_forward).to_owned(),
+        &mut poll_id,
+        "Hash location: #second",
     );
 
     server.finish();
@@ -2333,11 +2822,13 @@ fn real_stdio_scrolls_viewport_and_target_returns_snapshots_and_invalidates_refs
         }
     }));
     let down = server.receive();
-    let down_snapshot = result_text(&down).to_owned();
-    let down_y = scroll_y(&down_snapshot);
-    assert!(
-        down_y.abs_diff(600) <= 75,
-        "expected scroll position near 600, got {down_y}:\n{down_snapshot}"
+    let mut poll_id = 3200;
+    let down_snapshot = poll_snapshot_state(
+        &mut server,
+        result_text(&down).to_owned(),
+        &mut poll_id,
+        "scroll position near 600",
+        |snapshot| scroll_y(snapshot).abs_diff(600) <= 75,
     );
     let far_target = button_ref(&down_snapshot, "Far below fold target");
 
@@ -2349,12 +2840,14 @@ fn real_stdio_scrolls_viewport_and_target_returns_snapshots_and_invalidates_refs
         }
     }));
     let target = server.receive();
-    let target_snapshot = result_text(&target).to_owned();
-    let target_y = scroll_y(&target_snapshot);
-    assert!(
-        target_y >= 4000,
-        "expected far target to scroll beyond 4000, got {target_y}:\n{target_snapshot}"
+    let target_snapshot = poll_snapshot_state(
+        &mut server,
+        result_text(&target).to_owned(),
+        &mut poll_id,
+        "far target scrolled beyond 4000",
+        |snapshot| scroll_y(snapshot) >= 4000,
     );
+    let target_y = scroll_y(&target_snapshot);
 
     server.send(json!({
         "jsonrpc":"2.0","id":34,"method":"tools/call",
@@ -2364,11 +2857,12 @@ fn real_stdio_scrolls_viewport_and_target_returns_snapshots_and_invalidates_refs
         }
     }));
     let up = server.receive();
-    let up_snapshot = result_text(&up).to_owned();
-    let up_y = scroll_y(&up_snapshot);
-    assert!(
-        up_y < target_y,
-        "default upward scroll did not decrease {target_y}:\n{up_snapshot}"
+    let up_snapshot = poll_snapshot_state(
+        &mut server,
+        result_text(&up).to_owned(),
+        &mut poll_id,
+        "default upward scroll decreased the position",
+        |snapshot| scroll_y(snapshot) < target_y,
     );
 
     server.send(json!({

--- a/rust-native/src/lib.rs
+++ b/rust-native/src/lib.rs
@@ -887,13 +887,74 @@ impl Page {
         delay: Option<Duration>,
         cancel: Option<&CancelToken>,
     ) -> Result<()> {
+        self.type_text_with_options_and_cancel(
+            selector,
+            text,
+            delay,
+            ActionOptions::default(),
+            cancel,
+        )
+    }
+
+    /// Type with an operation timeout.
+    pub fn type_text_with_options(
+        &self,
+        selector: &str,
+        text: &str,
+        delay: Option<Duration>,
+        options: ActionOptions,
+    ) -> Result<()> {
+        self.type_text_with_options_and_cancel(selector, text, delay, options, None)
+    }
+
+    /// Type with an operation timeout and optional cancellation signal.
+    pub fn type_text_with_options_and_cancel(
+        &self,
+        selector: &str,
+        text: &str,
+        delay: Option<Duration>,
+        options: ActionOptions,
+        cancel: Option<&CancelToken>,
+    ) -> Result<()> {
         self.inner
-            .type_text_with_cancel(selector, text, delay, cancel)
+            .type_text_with_timeout_and_cancel(selector, text, delay, options.timeout, cancel)
     }
 
     /// Press a native key, optionally after focusing an element.
     pub fn press_key(&self, selector: Option<&str>, key: &str) -> Result<()> {
-        self.inner.press_key(selector, key)
+        self.press_key_with_cancel(selector, key, None)
+    }
+
+    /// Press a native key with an optional cancellation signal.
+    pub fn press_key_with_cancel(
+        &self,
+        selector: Option<&str>,
+        key: &str,
+        cancel: Option<&CancelToken>,
+    ) -> Result<()> {
+        self.press_key_with_options_and_cancel(selector, key, ActionOptions::default(), cancel)
+    }
+
+    /// Press a native key with an operation timeout.
+    pub fn press_key_with_options(
+        &self,
+        selector: Option<&str>,
+        key: &str,
+        options: ActionOptions,
+    ) -> Result<()> {
+        self.press_key_with_options_and_cancel(selector, key, options, None)
+    }
+
+    /// Press a native key with an operation timeout and optional cancellation signal.
+    pub fn press_key_with_options_and_cancel(
+        &self,
+        selector: Option<&str>,
+        key: &str,
+        options: ActionOptions,
+        cancel: Option<&CancelToken>,
+    ) -> Result<()> {
+        self.inner
+            .press_key_with_timeout_and_cancel(selector, key, options.timeout, cancel)
     }
 
     /// Select option values through the DOM and return the resulting values.
@@ -909,6 +970,10 @@ impl Page {
     }
 
     /// Select values with an optional cancellation signal.
+    ///
+    /// Matches option values only. Use
+    /// [`Self::select_options_by_value_or_label_with_cancel`] when a visible
+    /// label should also match.
     pub fn select_options_with_cancel<S: AsRef<str>>(
         &self,
         selector: &str,
@@ -921,6 +986,33 @@ impl Page {
             .collect::<Vec<_>>();
         self.inner
             .select_options_with_cancel(selector, &values, cancel)
+    }
+
+    /// Select exact values or visible labels in DOM order and return the resulting values.
+    ///
+    /// Unlike [`Self::select_options`], this treats value and label matches
+    /// alike. For a single-select, the first matching option in DOM order wins.
+    pub fn select_options_by_value_or_label<S: AsRef<str>>(
+        &self,
+        selector: &str,
+        values: &[S],
+    ) -> Result<Vec<String>> {
+        self.select_options_by_value_or_label_with_cancel(selector, values, None)
+    }
+
+    /// Select exact values or visible labels in DOM order with cancellation.
+    pub fn select_options_by_value_or_label_with_cancel<S: AsRef<str>>(
+        &self,
+        selector: &str,
+        values: &[S],
+        cancel: Option<&CancelToken>,
+    ) -> Result<Vec<String>> {
+        let values = values
+            .iter()
+            .map(|value| value.as_ref().to_string())
+            .collect::<Vec<_>>();
+        self.inner
+            .select_options_by_value_or_label_with_cancel(selector, &values, cancel)
     }
 
     /// Move Chromium's native mouse to the element center.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ impl CancelToken {
         let _ = self.try_cancel();
     }
 
-    /// Attempt to cancel before a physical pointer action commits.
+    /// Attempt to cancel before a physical input action commits.
     ///
     /// Returns `false` if cancellation already won or physical dispatch has
     /// committed, making the cancellation boundary atomic for callers that
@@ -100,7 +100,7 @@ impl CancelToken {
         self.inner.cancelled.load(Ordering::SeqCst)
     }
 
-    /// Whether any physical pointer action has crossed its cancellation boundary.
+    /// Whether any physical input action has crossed its cancellation boundary.
     ///
     /// This observation remains true for request-level result ownership. The
     /// separate per-action arbitration state is reset after each dispatch.
@@ -2506,8 +2506,135 @@ multiline-compatible = """4.5.6"""
     }
 
     #[test]
+    fn typing_cancelled_during_final_character_returns_success_without_commit() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(1)
+            .build()
+            .unwrap();
+        let (write_tx, mut write_rx) = mpsc::unbounded_channel();
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let (events, _) = broadcast::channel(4);
+        let event_log = Arc::new(Mutex::new(CdpEventLog::new()));
+        let (alive_tx, _) = watch::channel(true);
+        let client = Arc::new(CdpClient {
+            write_tx,
+            pending: Arc::clone(&pending),
+            events: events.clone(),
+            event_log: Arc::clone(&event_log),
+            next_id: AtomicU64::new(1),
+            sent_runtime_enable_count: AtomicU64::new(0),
+            sent_target_close_count: AtomicU64::new(0),
+            sent_context_dispose_count: AtomicU64::new(0),
+            alive: Arc::new(AtomicBool::new(true)),
+            alive_tx,
+        });
+        let browser = Arc::new(BrowserInner {
+            runtime: OwnedRuntime::new(runtime),
+            client: Arc::clone(&client),
+            process: Mutex::new(None),
+            profile_dir: Mutex::new(None),
+            owned: false,
+            ws_endpoint: "ws://test.invalid".to_string(),
+            stealth_user_agent_override: Mutex::new(None),
+            single_process_fallback: false,
+            lifecycle: Arc::new(CloseLifecycle::new()),
+            attached_pages: AttachedPageRegistry::default(),
+            next_native_network_index: AtomicU64::new(1),
+        });
+        let page = RustwrightPage {
+            inner: Arc::new(PageInner {
+                browser: Arc::clone(&browser),
+                target_id: "test-target".to_string(),
+                registry_generation: 0,
+                session_id: "test-session".to_string(),
+                context_id: None,
+                main_frame_id: Mutex::new(None),
+                frame_state: Mutex::new(PageFrameState::new("test-session".to_string())),
+                network_requests: Arc::new(Mutex::new(NetworkRequestStore::new(0))),
+                event_stream_start_cursor: 0,
+                background_override_active: Arc::new(AtomicBool::new(false)),
+                screenshot_lock: Arc::new(tokio::sync::Mutex::new(())),
+                mouse_dispatch_lock: Arc::new(tokio::sync::Mutex::new(())),
+                default_timeouts: Mutex::new(DefaultTimeoutRegister::default()),
+                lifecycle: Arc::new(CloseLifecycle::new()),
+                target_closed: AtomicBool::new(false),
+                crashed: AtomicBool::new(false),
+                close_target_on_drop: AtomicBool::new(false),
+                console_records: Mutex::new(ConsoleRecordStore::default()),
+                console_capture: tokio::sync::Mutex::new(ConsoleCaptureState::default()),
+                native_network_records: Mutex::new(NativeNetworkRecordStore::new(1)),
+            }),
+        };
+        let token = CancelToken::new();
+        let dispatch_token = token.clone();
+        let responder = browser.runtime.handle().spawn(async move {
+            let mut cancellation_won = None;
+            loop {
+                let command = match write_rx.recv().await.unwrap() {
+                    CdpOutgoing::Text(payload) => serde_json::from_str::<Value>(&payload).unwrap(),
+                    CdpOutgoing::Close => panic!("unexpected transport close"),
+                };
+                let method = command["method"].as_str().unwrap();
+                let result = match method {
+                    "Page.getFrameTree" => json!({}),
+                    "Runtime.evaluate" => {
+                        json!({ "result": { "type": "boolean", "value": true } })
+                    }
+                    "Input.dispatchKeyEvent" => json!({}),
+                    other => panic!("unexpected CDP command: {other}"),
+                };
+                let key_up =
+                    method == "Input.dispatchKeyEvent" && command["params"]["type"] == "keyUp";
+                if method == "Input.dispatchKeyEvent" && command["params"]["type"] == "keyDown" {
+                    cancellation_won = Some(dispatch_token.try_cancel());
+                }
+                dispatch_cdp_payload(
+                    json!({ "id": command["id"], "result": result }),
+                    Arc::clone(&pending),
+                    events.clone(),
+                    Arc::clone(&event_log),
+                );
+                if key_up {
+                    return cancellation_won;
+                }
+            }
+        });
+
+        let result = page.type_text_with_timeout_and_cancel(
+            "#target",
+            "a",
+            None,
+            Some(1_000.0),
+            Some(&token),
+        );
+        let cancellation_won = browser.block_on_raw(responder).unwrap().unwrap();
+
+        assert!(
+            cancellation_won,
+            "typing must remain request-cancellable while the final character is in flight"
+        );
+        assert!(
+            result.is_ok(),
+            "a fully dispatched type must not be reported as cancelled: {result:?}"
+        );
+        assert!(
+            !token.is_physical_action_committed(),
+            "typing must not claim request-level physical commitment"
+        );
+    }
+
+    #[test]
     fn command_timeout_without_override_is_thirty_seconds() {
         assert_eq!(BrowserInner::command_timeout(None), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn native_input_timeout_honors_budget_larger_than_thirty_seconds() {
+        assert_eq!(
+            native_input_timeout(Some(45_000.0)),
+            Duration::from_secs(45)
+        );
     }
 
     #[test]
@@ -2519,6 +2646,118 @@ multiline-compatible = """4.5.6"""
             Err(RwError::Timeout(5_000))
         )
         .is_ok());
+    }
+
+    #[test]
+    fn committed_key_press_preserves_action_result_after_cleanup_failure() {
+        assert_eq!(KEY_RELEASE_CLEANUP_TIMEOUT, Duration::from_secs(5));
+        assert!(committed_key_dispatch_result(
+            Ok(()),
+            vec![RwError::Timeout(
+                KEY_RELEASE_CLEANUP_TIMEOUT.as_millis() as u64
+            )],
+        )
+        .is_ok());
+        assert!(matches!(
+            committed_key_dispatch_result(
+                Err(RwError::InvalidInput("unsupported key".to_owned())),
+                Vec::new(),
+            ),
+            Err(RwError::InvalidInput(message)) if message == "unsupported key"
+        ));
+    }
+
+    fn chord_shape(key: &str) -> (Vec<String>, i64, String) {
+        let chord = parse_key_chord(key).unwrap_or_else(|error| panic!("{key:?}: {error}"));
+        let names = chord
+            .modifiers
+            .iter()
+            .map(|(descriptor, _)| descriptor.key.clone())
+            .collect();
+        let mask = chord
+            .modifiers
+            .iter()
+            .fold(0, |mask, (_, held)| mask | held);
+        (names, mask, chord.base.key.clone())
+    }
+
+    #[test]
+    fn key_chord_parsing_matches_the_dispatch_shape() {
+        assert_eq!(chord_shape("a"), (Vec::new(), 0, "a".to_owned()));
+        assert_eq!(
+            chord_shape("Control+a"),
+            (vec!["Control".to_owned()], 2, "a".to_owned())
+        );
+        // `+` is the chord separator, so a bare `+` has to stay addressable as a
+        // base key rather than parsing as two empty parts.
+        assert_eq!(chord_shape("+"), (Vec::new(), 0, "+".to_owned()));
+        assert_eq!(
+            chord_shape("Control+Shift+Alt+Meta+a"),
+            (
+                vec![
+                    "Control".to_owned(),
+                    "Shift".to_owned(),
+                    "Alt".to_owned(),
+                    "Meta".to_owned(),
+                ],
+                2 | 8 | 1 | 4,
+                "a".to_owned()
+            )
+        );
+    }
+
+    #[test]
+    fn key_chord_parsing_deduplicates_repeated_modifiers() {
+        // Holding a held modifier is a no-op for the page but not for us: each
+        // repeat costs another key-down dispatch and another key-up that must be
+        // cleaned up under its own budget after the press commits. Without the
+        // dedup, a caller-supplied string scales that work linearly.
+        let (names, mask, base) = chord_shape("Control+Control+Control+Shift+Shift+a");
+        assert_eq!(names, vec!["Control".to_owned(), "Shift".to_owned()]);
+        assert_eq!(base, "a");
+        // The mask a repeated modifier produces is the mask it produces once, so
+        // deduplicating cannot change what the page sees.
+        assert_eq!(mask, chord_shape("Control+Shift+a").1);
+        // `Control` and `ControlLeft` are the same physical key, so the second
+        // one is the redundant repeat the dedup is for.
+        assert_eq!(chord_shape("ControlLeft+Control+a").0.len(), 1);
+
+        // Left and right modifiers share a mask but are different keys: a page
+        // reading `event.code` can tell them apart, so both key-downs still go
+        // out. Deduplicating by mask instead of by code would silently drop one.
+        let paired = parse_key_chord("ControlLeft+ControlRight+a").expect("paired chord");
+        assert_eq!(
+            paired
+                .modifiers
+                .iter()
+                .map(|(descriptor, _)| descriptor.code.as_str())
+                .collect::<Vec<_>>(),
+            vec!["ControlLeft", "ControlRight"]
+        );
+    }
+
+    #[test]
+    fn key_chord_parsing_rejects_unusable_keys_before_any_dispatch() {
+        // Every one of these used to be discovered after the caller's target had
+        // already been focused -- and, for a bad base key behind a good modifier,
+        // after that modifier's key-down had already been dispatched.
+        for key in ["", "Control+", "+a", "a++b"] {
+            assert!(
+                matches!(
+                    parse_key_chord(key),
+                    Err(RwError::InvalidInput(message)) if message.starts_with("unsupported key:")
+                ),
+                "{key:?} should be rejected as an empty chord part"
+            );
+        }
+        assert!(matches!(
+            parse_key_chord("Hyper+a"),
+            Err(RwError::InvalidInput(message)) if message == "unsupported key modifier: Hyper"
+        ));
+        assert!(
+            parse_key_chord("Control+NoSuchKey").is_err(),
+            "an unknown base key must fail before its modifier is pressed"
+        );
     }
 
     #[test]
@@ -8392,6 +8631,10 @@ async fn evaluate_expression_for_page_async(
 struct OperationDeadline {
     at: tokio::time::Instant,
     timeout: Duration,
+}
+
+fn native_input_timeout(timeout_ms: Option<f64>) -> Duration {
+    BrowserInner::command_timeout(timeout_ms)
 }
 
 impl OperationDeadline {
@@ -17308,6 +17551,7 @@ return true;
         self.type_text_with_cancel(selector, text, delay, None)
     }
 
+    /// Type with an optional cancellation signal and the page's default timeout.
     pub fn type_text_with_cancel(
         &self,
         selector: &str,
@@ -17315,14 +17559,34 @@ return true;
         delay: Option<Duration>,
         cancel: Option<&CancelToken>,
     ) -> RwResult<()> {
+        self.type_text_with_timeout_and_cancel(selector, text, delay, None, cancel)
+    }
+
+    /// Type with an explicit timeout and optional cancellation signal.
+    pub fn type_text_with_timeout_and_cancel(
+        &self,
+        selector: &str,
+        text: &str,
+        delay: Option<Duration>,
+        timeout_ms: Option<f64>,
+        cancel: Option<&CancelToken>,
+    ) -> RwResult<()> {
         let locator_json = selector_to_locator_json(selector)?;
+        let timeout_ms = self.resolve_timeout(timeout_ms, false);
         let page = Arc::clone(&self.inner);
         let text = text.to_string();
+        let timeout = native_input_timeout(timeout_ms);
         let browser = Arc::clone(&page.browser);
-        browser.block_on_raw(cancelable(cancel.cloned(), async move {
-            let deadline = OperationDeadline::new(Duration::from_secs(30));
-            let resolution = focus_locator_for_native_input(&page, &locator_json, deadline).await?;
+        browser.block_on_raw(async move {
+            let deadline = OperationDeadline::new(timeout);
+            let resolution = cancelable(
+                cancel.cloned(),
+                focus_locator_for_native_input(&page, &locator_json, deadline),
+            )
+            .await?;
+            ensure_not_cancelled(cancel)?;
             for character in text.chars() {
+                ensure_not_cancelled(cancel)?;
                 dispatch_typed_character(
                     &page.browser.client,
                     &resolution.session_id,
@@ -17333,30 +17597,72 @@ return true;
                 .await?;
             }
             Ok(())
-        }))
+        })
     }
 
     /// Press a key through Chromium's input domain, optionally focusing a selector first.
     pub fn press_key(&self, selector: Option<&str>, key: &str) -> RwResult<()> {
+        self.press_key_with_cancel(selector, key, None)
+    }
+
+    /// Press a key with an optional cancellation signal and the page's default timeout.
+    pub fn press_key_with_cancel(
+        &self,
+        selector: Option<&str>,
+        key: &str,
+        cancel: Option<&CancelToken>,
+    ) -> RwResult<()> {
+        self.press_key_with_timeout_and_cancel(selector, key, None, cancel)
+    }
+
+    /// Press a key with an explicit timeout and optional cancellation signal.
+    pub fn press_key_with_timeout_and_cancel(
+        &self,
+        selector: Option<&str>,
+        key: &str,
+        timeout_ms: Option<f64>,
+        cancel: Option<&CancelToken>,
+    ) -> RwResult<()> {
         let locator_json = selector.map(selector_to_locator_json).transpose()?;
+        // Reject an unusable key before anything touches the page. Focusing the
+        // target runs the page's focus/blur handlers, so validating afterwards
+        // would mutate page state on a call that then returns InvalidInput. The
+        // parse is pure and cheap, and `dispatch_key_press` re-derives the same
+        // chord through the same parser, so there is one definition of valid.
+        parse_key_chord(key)?;
+        let timeout_ms = self.resolve_timeout(timeout_ms, false);
         let page = Arc::clone(&self.inner);
         let key = key.to_string();
+        let timeout = native_input_timeout(timeout_ms);
         let browser = Arc::clone(&page.browser);
         browser.block_on_raw(async move {
-            let deadline = OperationDeadline::new(Duration::from_secs(30));
-            let session_id = match locator_json {
-                Some(locator_json) => {
-                    focus_locator_for_native_input(&page, &locator_json, deadline)
-                        .await?
-                        .session_id
+            let deadline = OperationDeadline::new(timeout);
+            let session_id = cancelable(cancel.cloned(), async {
+                match locator_json {
+                    Some(locator_json) => {
+                        Ok(
+                            focus_locator_for_native_input(&page, &locator_json, deadline)
+                                .await?
+                                .session_id,
+                        )
+                    }
+                    None => Ok(page.session_id.clone()),
                 }
-                None => page.session_id.clone(),
-            };
-            dispatch_key_press(&page.browser.client, &session_id, &key, None, deadline).await
+            })
+            .await?;
+            dispatch_key_press(
+                &page.browser.client,
+                &session_id,
+                &key,
+                None,
+                deadline,
+                cancel,
+            )
+            .await
         })
     }
 
-    /// Select options by value using the page DOM and return the resulting values.
+    /// Select options by value and return the resulting values.
     pub fn select_options(&self, selector: &str, values: &[String]) -> RwResult<Vec<String>> {
         self.select_options_with_cancel(selector, values, None)
     }
@@ -17379,6 +17685,53 @@ const matched = options.filter(option => requested.includes(option.value));
 const found = new Set(matched.map(option => option.value));
 const missing = requested.filter(value => !found.has(value));
 if (missing.length) throw new Error(`Select option values not found: ${{missing.join(', ')}}`);
+for (const option of options) option.selected = false;
+if (el.multiple) {{
+  for (const option of matched) option.selected = true;
+}} else if (matched.length) {{
+  matched[0].selected = true;
+}}
+el.dispatchEvent(new Event('input', {{ bubbles: true }}));
+el.dispatchEvent(new Event('change', {{ bubbles: true }}));
+return JSON.stringify(Array.from(el.selectedOptions).map(option => option.value));
+"#
+        );
+        let json = self.evaluate_locator_json_cancelable(locator_json, 0, body, None, cancel)?;
+        let selected_json: String = serde_json::from_str(&json)?;
+        Ok(serde_json::from_str(&selected_json)?)
+    }
+
+    /// Select exact values or visible labels in DOM order and return the resulting values.
+    pub fn select_options_by_value_or_label(
+        &self,
+        selector: &str,
+        values: &[String],
+    ) -> RwResult<Vec<String>> {
+        self.select_options_by_value_or_label_with_cancel(selector, values, None)
+    }
+
+    pub fn select_options_by_value_or_label_with_cancel(
+        &self,
+        selector: &str,
+        values: &[String],
+        cancel: Option<&CancelToken>,
+    ) -> RwResult<Vec<String>> {
+        let locator_json = selector_to_locator_json(selector)?;
+        let values_json = serde_json::to_string(values)?;
+        let body = format!(
+            r#"
+if (!el) throw new Error('No element matches locator');
+if (!(el instanceof HTMLSelectElement)) throw new Error('Element is not a <select> element');
+const requested = {values_json};
+const options = Array.from(el.options);
+const optionRequested = option => requested.some(
+  value => option.value === value || option.label === value
+);
+const matched = options.filter(optionRequested);
+const missing = requested.filter(value => !options.some(
+  option => option.value === value || option.label === value
+));
+if (missing.length) throw new Error(`Select options not found by value or label: ${{missing.join(', ')}}`);
 for (const option of options) option.selected = false;
 if (el.multiple) {{
   for (const option of matched) option.selected = true;
@@ -18130,6 +18483,14 @@ async fn wait_input_delay(delay: Option<Duration>, deadline: OperationDeadline) 
     Ok(())
 }
 
+fn ensure_not_cancelled(cancel: Option<&CancelToken>) -> RwResult<()> {
+    if cancel.is_some_and(CancelToken::is_cancelled) {
+        Err(RwError::Cancelled)
+    } else {
+        Ok(())
+    }
+}
+
 async fn dispatch_typed_character(
     client: &CdpClient,
     session_id: &str,
@@ -18138,26 +18499,39 @@ async fn dispatch_typed_character(
     deadline: OperationDeadline,
 ) -> RwResult<()> {
     if !character.is_ascii() || character.is_ascii_control() {
+        let dispatch_timeout = deadline.remaining()?;
         client
             .send(
                 "Input.insertText",
                 json!({ "text": character.to_string() }),
                 Some(session_id),
-                deadline.remaining()?,
+                dispatch_timeout,
             )
             .await?;
         return wait_input_delay(delay, deadline).await;
     }
-    dispatch_key_press(client, session_id, &character.to_string(), delay, deadline).await
+    dispatch_key_press(
+        client,
+        session_id,
+        &character.to_string(),
+        delay,
+        deadline,
+        None,
+    )
+    .await
 }
 
-async fn dispatch_key_press(
-    client: &CdpClient,
-    session_id: &str,
-    key: &str,
-    delay: Option<Duration>,
-    deadline: OperationDeadline,
-) -> RwResult<()> {
+struct KeyChord {
+    modifiers: Vec<(NativeKeyDescriptor, i64)>,
+    base: NativeKeyDescriptor,
+}
+
+// Parsing a chord is pure string work with no page effect, which is what lets
+// callers validate a key BEFORE resolving or focusing a target. Doing it after
+// focus would let `press_key(target, "Nonsense")` fire the target's focus/blur
+// handlers and only then report InvalidInput, mutating the page on a call that
+// is reported as rejected.
+fn parse_key_chord(key: &str) -> RwResult<KeyChord> {
     let parts = if key == "+" {
         vec![key]
     } else {
@@ -18171,64 +18545,171 @@ async fn dispatch_key_press(
         .first()
         .copied()
         .ok_or_else(|| RwError::InvalidInput("key must not be empty".to_string()))?;
-    let mut modifiers = 0_i64;
-    let mut pressed_modifiers = Vec::new();
+    let mut modifiers: Vec<(NativeKeyDescriptor, i64)> = Vec::new();
     for modifier_name in modifier_names {
         let mask = native_modifier_mask(modifier_name).ok_or_else(|| {
             RwError::InvalidInput(format!("unsupported key modifier: {modifier_name}"))
         })?;
         let descriptor = native_key_descriptor(modifier_name)?;
-        modifiers |= mask;
-        client
-            .send(
-                "Input.dispatchKeyEvent",
-                native_key_event_params(&descriptor, "rawKeyDown", modifiers, false),
-                Some(session_id),
-                deadline.remaining()?,
-            )
-            .await?;
-        pressed_modifiers.push((descriptor, mask));
+        // Holding a modifier that is already held is a no-op, so a repeat adds
+        // nothing but another key-down to dispatch and another key-up to clean
+        // up. Without this, "Control+Control+...+a" scales both the dispatch
+        // work and the post-commit cleanup wait linearly with a caller-supplied
+        // string.
+        //
+        // Deduplicate on the physical key code, not the modifier mask:
+        // ControlLeft and ControlRight share a mask but are distinct keys a page
+        // can tell apart through `event.code`, so collapsing them by mask would
+        // drop a key-down the caller asked for. There are only eight modifier
+        // codes, so the chord stays bounded either way.
+        if modifiers
+            .iter()
+            .any(|(held, _)| held.code == descriptor.code)
+        {
+            continue;
+        }
+        modifiers.push((descriptor, mask));
     }
     let base = native_key_descriptor(base_name)?;
-    let include_text = base.text.is_some() && modifiers & (1 | 2 | 4) == 0;
-    client
-        .send(
-            "Input.dispatchKeyEvent",
-            native_key_event_params(
-                &base,
-                if include_text {
-                    "keyDown"
-                } else {
-                    "rawKeyDown"
-                },
-                modifiers,
-                include_text,
-            ),
-            Some(session_id),
-            deadline.remaining()?,
-        )
-        .await?;
-    wait_input_delay(delay, deadline).await?;
-    client
-        .send(
-            "Input.dispatchKeyEvent",
-            native_key_event_params(&base, "keyUp", modifiers, false),
-            Some(session_id),
-            deadline.remaining()?,
-        )
-        .await?;
-    for (descriptor, mask) in pressed_modifiers.into_iter().rev() {
-        modifiers &= !mask;
-        client
-            .send(
-                "Input.dispatchKeyEvent",
-                native_key_event_params(&descriptor, "keyUp", modifiers, false),
-                Some(session_id),
-                deadline.remaining()?,
-            )
-            .await?;
+    Ok(KeyChord { modifiers, base })
+}
+
+async fn dispatch_key_press(
+    client: &CdpClient,
+    session_id: &str,
+    key: &str,
+    delay: Option<Duration>,
+    deadline: OperationDeadline,
+    cancel: Option<&CancelToken>,
+) -> RwResult<()> {
+    let KeyChord {
+        modifiers: resolved_modifiers,
+        base,
+    } = parse_key_chord(key)?;
+    let first_dispatch_timeout = deadline.remaining()?;
+
+    // All validation and timeout checks that can fail without input happen
+    // before this boundary. From the first key-down attempt onward, Chromium
+    // may have accepted an irreversible event, so cancellation loses and every
+    // attempted key-down receives an independent-budget key-up cleanup.
+    dispatch_committed_physical_action(cancel, async {
+        let mut modifiers = 0_i64;
+        let mut attempted_modifiers = Vec::new();
+        let mut base_attempted = false;
+        let mut action_result = Ok(());
+
+        for (index, (descriptor, mask)) in resolved_modifiers.iter().enumerate() {
+            let dispatch_timeout = if index == 0 {
+                first_dispatch_timeout
+            } else {
+                match deadline.remaining() {
+                    Ok(remaining) => remaining,
+                    Err(error) => {
+                        action_result = Err(error);
+                        break;
+                    }
+                }
+            };
+            modifiers |= mask;
+            attempted_modifiers.push((descriptor, *mask));
+            if let Err(error) = client
+                .send(
+                    "Input.dispatchKeyEvent",
+                    native_key_event_params(descriptor, "rawKeyDown", modifiers, false),
+                    Some(session_id),
+                    dispatch_timeout,
+                )
+                .await
+            {
+                action_result = Err(error);
+                break;
+            }
+        }
+
+        if action_result.is_ok() {
+            let include_text = base.text.is_some() && modifiers & (1 | 2 | 4) == 0;
+            let dispatch_timeout = if resolved_modifiers.is_empty() {
+                Ok(first_dispatch_timeout)
+            } else {
+                deadline.remaining()
+            };
+            match dispatch_timeout {
+                Ok(dispatch_timeout) => {
+                    base_attempted = true;
+                    if let Err(error) = client
+                        .send(
+                            "Input.dispatchKeyEvent",
+                            native_key_event_params(
+                                &base,
+                                if include_text {
+                                    "keyDown"
+                                } else {
+                                    "rawKeyDown"
+                                },
+                                modifiers,
+                                include_text,
+                            ),
+                            Some(session_id),
+                            dispatch_timeout,
+                        )
+                        .await
+                    {
+                        action_result = Err(error);
+                    }
+                }
+                Err(error) => action_result = Err(error),
+            }
+        }
+
+        if action_result.is_ok() {
+            action_result = wait_input_delay(delay, deadline).await;
+        }
+
+        let mut cleanup_errors = Vec::new();
+        if base_attempted {
+            if let Err(error) = client
+                .send(
+                    "Input.dispatchKeyEvent",
+                    native_key_event_params(&base, "keyUp", modifiers, false),
+                    Some(session_id),
+                    KEY_RELEASE_CLEANUP_TIMEOUT,
+                )
+                .await
+            {
+                cleanup_errors.push(error);
+            }
+        }
+        for (descriptor, mask) in attempted_modifiers.into_iter().rev() {
+            modifiers &= !mask;
+            if let Err(error) = client
+                .send(
+                    "Input.dispatchKeyEvent",
+                    native_key_event_params(descriptor, "keyUp", modifiers, false),
+                    Some(session_id),
+                    KEY_RELEASE_CLEANUP_TIMEOUT,
+                )
+                .await
+            {
+                cleanup_errors.push(error);
+            }
+        }
+        committed_key_dispatch_result(action_result, cleanup_errors)
+    })
+    .await
+}
+
+const KEY_RELEASE_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
+
+fn committed_key_dispatch_result(
+    action_result: RwResult<()>,
+    cleanup_errors: Vec<RwError>,
+) -> RwResult<()> {
+    for error in cleanup_errors {
+        eprintln!(
+            "rustwright: key-up cleanup received no confirmation after committed key press: {error}"
+        );
     }
-    Ok(())
+    action_result
 }
 
 fn is_page_not_attached_error(error: &RwError) -> bool {


### PR DESCRIPTION
https://github.com/Skyvern-AI/rustwright-cloud/pull/155