### PR TITLE
release: cut a stable 0.2.0 and unblock the tagged publish workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable user-facing changes to Rustwright are documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-29
+
 ### Added
 
 - Added a persistent `rustwright` CLI for browser sessions, accessibility snapshots, and element-reference actions.
@@ -78,6 +80,7 @@ All notable user-facing changes to Rustwright are documented in this file.
 - Added an experimental Node.js binding for launching Chromium and performing core page navigation, interaction, evaluation, screenshot, and lifecycle operations.
 
 [Unreleased]: https://github.com/Skyvern-AI/rustwright/commits/main
+[0.2.0]: https://github.com/Skyvern-AI/rustwright/releases/tag/v0.2.0
 [0.1.1]: https://github.com/Skyvern-AI/rustwright/releases/tag/v0.1.1
 [0.1.0]: https://github.com/Skyvern-AI/rustwright/releases/tag/v0.1.0
 [0.1.0-alpha.4]: https://github.com/Skyvern-AI/rustwright/releases/tag/v0.1.0-alpha.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,7 +1018,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustwright"
-version = "0.1.0-alpha.4"
+version = "0.2.0"
 dependencies = [
  "rustwright-core",
  "serde",
@@ -1027,7 +1027,7 @@ dependencies = [
 
 [[package]]
 name = "rustwright-capi"
-version = "0.1.0-alpha.4"
+version = "0.2.0"
 dependencies = [
  "libc",
  "rustwright-core",
@@ -1037,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "rustwright-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "bytes",
@@ -1069,7 +1069,7 @@ dependencies = [
 
 [[package]]
 name = "rustwright-node"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "napi",
  "napi-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-core"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.85"
 description = "Rust CDP core for a Python Playwright-compatible automation API"

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-capi"
-version = "0.1.0-alpha.4"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1018,7 +1018,7 @@ dependencies = [
 
 [[package]]
 name = "rustwright-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "bytes",

--- a/csharp/Rustwright/Rustwright.csproj
+++ b/csharp/Rustwright/Rustwright.csproj
@@ -6,7 +6,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <PackageId>Rustwright</PackageId>
-    <Version>0.1.1</Version>
+    <Version>0.2.0</Version>
     <Authors>Skyvern</Authors>
     <Description>A synchronous .NET binding for Rustwright's Rust-powered Chromium CDP engine.</Description>
     <PackageTags>browser;automation;cdp;chromium;playwright</PackageTags>

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -26,81 +26,147 @@ commit, tag it, and publish to both PyPI and npm. The skill is defined in
 - [ ] Confirm the npm account behind `NPM_TOKEN` may create the unscoped public package `rustwright`. Unscoped packages are owned by npm user accounts, not organizations.
 - [ ] `examples/quickstart.py` is the public smoke test used by the registry-verification step below; confirm it still runs cleanly before tagging.
 
-No crates.io settings or token are currently required. Do not publish `rustwright-core` yet: it is tightly coupled to PyO3, has only a small Rust-facing API, and would commit the team to Rust API compatibility, documentation, security advisories, and an additional release channel. Reconsider after the core is cleanly separated and there are committed Rust users; then add a dedicated crates.io workflow and a narrowly scoped `CARGO_REGISTRY_TOKEN`.
+`rustwright-core` and `rustwright` are already published on crates.io, but no workflow publishes them: there is no crates.io job and no `CARGO_REGISTRY_TOKEN`, so a `v*` tag leaves both crates untouched and they are updated by hand. Publishing the core commits the team to Rust API compatibility, documentation, security advisories, and an additional release channel, so decide deliberately whether to keep that channel current, add a dedicated crates.io workflow, or yank it — but do not let it drift silently behind the tagged releases.
 
 ## Prepare a release
 
-- [ ] Choose one version in prerelease SemVer form, for example `0.2.0-alpha.1`. The npm workflow deliberately publishes under the `next` dist-tag and rejects a stable version.
-- [ ] Set that exact string in these source-of-truth fields:
+- [ ] Choose one version in SemVer form, for example `0.2.0`. A single `v*` tag drives the PyPI, npm, NuGet, RubyGems, and Maven Central workflows, and each one compares its own packages against that tag, so every version field in the tree has to hold that exact string.
+- [ ] Set that exact string in every source-of-truth field. All five tagged
+      workflows validate their own packages, so a field missed here fails the
+      release at tag time, after the tag is already pushed:
   - `pyproject.toml` → `[project].version`
   - `Cargo.toml` → `[package].version` for `rustwright-core`
+  - `capi/Cargo.toml` → `[package].version` for `rustwright-capi`
+  - `rust-native/Cargo.toml` → `[package].version` for `rustwright`
   - `node/Cargo.toml` → `[package].version` for `rustwright-node`
   - `node/package.json` → `version`
+  - `csharp/Rustwright/Rustwright.csproj` → `<Version>`
+  - `ruby/lib/rustwright.rb` → `VERSION` (`ruby/rustwright.gemspec` reads it, so
+    the gemspec itself needs no edit)
+  - `java/build.gradle.kts` → **two** sites: the top-level `version =` and the
+    literal inside the `coordinates(...)` call. The Maven validator only checks
+    the first, so a missed `coordinates(...)` bump publishes under the wrong
+    version instead of failing.
 - [ ] Set the same string in the shipped runtime metadata:
   - `python/rustwright/sync_api.py` → Rustwright creator `version` in `_write_har`
   - `python/rustwright/sync_api.py` → `playwrightVersion` in `_write_trace_zip`
   - `python/rustwright/cli.py` → source-checkout fallback in `_version`
   - `python/rustwright/_backend.py` → source-checkout fallback in `_version` (before `+local`)
-- [ ] Regenerate the lockfiles; do not edit generated entries by hand:
+  - `python/rustwright/_agent/cli.py` → source-checkout fallback
+- [ ] Update the docs that quote the version: `java/README.md` quotes the Maven
+      coordinates in more than one place.
+- [ ] Add a `## [<version>] - <date>` section to `CHANGELOG.md` by renaming the
+      current `## [Unreleased]` section and opening a fresh empty one above it,
+      add the matching link reference at the bottom, and add the version to
+      `REQUIRED_VERSIONS` in `tests/test_changelog.py`.
+- [ ] Regenerate the lockfiles; do not edit generated entries by hand. There are
+      three Cargo lockfiles, because `cli/` and `mcp/` are separate workspaces
+      that depend on `rustwright-core` by path — the root `cargo` command does
+      not touch them:
 
   ```bash
-  cargo check
+  cargo metadata --format-version 1 > /dev/null
+  cargo metadata --manifest-path cli/Cargo.toml --format-version 1 > /dev/null
+  cargo metadata --manifest-path mcp/Cargo.toml --format-version 1 > /dev/null
   (cd node && npm install --package-lock-only --ignore-scripts)
   ```
 
-- [ ] Confirm `Cargo.lock` now has the same version for `rustwright-core` and `rustwright-node`, and `node/package-lock.json` has it in both top-level version fields.
-- [ ] Confirm all nine files are staged: `pyproject.toml`, `Cargo.toml`, `node/Cargo.toml`, `node/package.json`, `python/rustwright/sync_api.py`, `python/rustwright/cli.py`, `python/rustwright/_backend.py`, `Cargo.lock`, and `node/package-lock.json`.
+  `cargo metadata` resolves and rewrites a lockfile without compiling, which
+  keeps the diff to the version lines instead of churning third-party pins.
+
+- [ ] Confirm every `rustwright*` entry across `Cargo.lock`, `cli/Cargo.lock`,
+      and `mcp/Cargo.lock` holds the release version, except `rustwright-cli`
+      and `rustwright-mcp`, which version independently. Confirm
+      `node/package-lock.json` has it in both top-level version fields.
+- [ ] Confirm nothing was missed:
+
+  ```bash
+  git grep -n "$PREVIOUS_VERSION" -- . ':!CHANGELOG.md' ':!docs/'
+  ```
+
 - [ ] Run local release checks:
 
   ```bash
   cargo check --locked
   cargo test --locked
+  cargo metadata --manifest-path cli/Cargo.toml --locked --format-version 1 > /dev/null
+  cargo metadata --manifest-path mcp/Cargo.toml --locked --format-version 1 > /dev/null
   (cd node && npm ci --ignore-scripts && npm run build && npm run smoke)
   ```
 
-Before tagging, the four source manifests, shipped runtime metadata, and both lockfiles must have one matching version. The source `node/package.json` intentionally remains `"private": true`; the npm workflow removes that field only in its temporary assembled package.
+Before tagging, every source manifest, the shipped runtime metadata, and all
+four lockfiles must have one matching version. The source `node/package.json`
+intentionally remains `"private": true`; the npm workflow removes that field
+only in its temporary assembled package.
 
 ## Dry run
 
 - [ ] Merge the version bump and release setup before tagging.
-- [ ] In **Actions → Release Python package → Run workflow**, select the release commit, leave `dry_run` checked, and run it.
-- [ ] In **Actions → Release Node.js package → Run workflow**, select the same commit, leave `dry_run` checked, and run it.
-- [ ] Download and inspect `pypi-wheel-*`, `pypi-sdist`, and `npm-package`. A dispatch with `dry_run: true` never reaches either publish job.
+- [ ] Dry-run **all five** workflows against the release commit, not just PyPI and
+      npm. One tag starts all of them, so a workflow you did not dry-run is a
+      workflow that first runs for real. For each of **Release Python package**,
+      **Release Node.js package**, **Release .NET package**, **Release Ruby
+      gem**, and **Release Maven package**, open **Actions → *workflow* → Run
+      workflow**, select the release commit, leave `dry_run` checked, and run it.
+- [ ] Confirm each run's `validate release metadata` job passed. That job is what
+      compares the tree against the tag, so a green metadata job is the signal
+      that the version fields are consistent.
+- [ ] Download and inspect the build artifacts: `pypi-wheel-*`, `pypi-sdist`,
+      `npm-package`, the NuGet `.nupkg`, the platform gems, and the Maven bundle.
+      A dispatch with `dry_run: true` never reaches any publish job.
 
 ## Publish
 
 - [ ] From an up-to-date, clean checkout of the release commit, use the same version as every manifest:
 
   ```bash
-  VERSION=0.2.0-alpha.1
+  VERSION=0.2.0
   git tag -a "v${VERSION}" -m "Rustwright ${VERSION}"
   git push origin "v${VERSION}"
   ```
 
-- [ ] Approve the `pypi` and `npm` GitHub environment deployments. The tag starts both workflows; publishing is also guarded to `Skyvern-AI/rustwright`.
+- [ ] Approve all five GitHub environment deployments: `pypi`, `npm`, `nuget`,
+      `rubygems`, and `maven-central`. The one tag starts every workflow;
+      publishing is also guarded to `Skyvern-AI/rustwright`.
+- [ ] Maven Central publishes are **permanent** — a released coordinate cannot be
+      deleted, only superseded. PyPI, npm, NuGet, RubyGems, and crates.io allow
+      yanking, which hides a version from resolution without removing it. Treat
+      the `maven-central` approval as the point of no return.
 - [ ] If a publish job alone must be retried, dispatch that workflow from the existing tag and clear `dry_run`. A branch dispatch cannot publish.
-- [ ] Never move or reuse a published version tag. Fix forward with a new prerelease version.
+- [ ] Never move or reuse a published version tag. Fix forward with a new version.
 
 ## Verify the registries
 
 - [ ] In a clean Python environment, install the exact release and Chromium, then run the quickstart:
 
   ```bash
-  VERSION=0.2.0-alpha.1
+  VERSION=0.2.0
   python -m venv /tmp/rustwright-pypi-verify
   /tmp/rustwright-pypi-verify/bin/python -m pip install --upgrade pip
-  /tmp/rustwright-pypi-verify/bin/python -m pip install --pre "rustwright==${VERSION}"
+  /tmp/rustwright-pypi-verify/bin/python -m pip install "rustwright==${VERSION}"
   /tmp/rustwright-pypi-verify/bin/python -m rustwright install chromium
   /tmp/rustwright-pypi-verify/bin/python examples/quickstart.py
   ```
 
-- [ ] In a clean Node.js project, install from the experimental dist-tag and load the addon:
+- [ ] In a clean Node.js project, install the exact release and load the addon:
 
   ```bash
   test_dir="$(mktemp -d)"
-  (cd "$test_dir" && npm init --yes && npm install rustwright@next && node -e "require('rustwright')")
+  (cd "$test_dir" && npm init --yes && npm install "rustwright@${VERSION}" && node -e "require('rustwright')")
   ```
 
 - [ ] Confirm PyPI shows five `cp38-abi3` wheels plus the sdist: macOS arm64/x86_64, manylinux x86_64/aarch64, and Windows x86_64.
-- [ ] Confirm npm shows version `${VERSION}` under the `next` dist-tag and displays provenance.
+- [ ] Confirm npm shows version `${VERSION}` under the `latest` dist-tag and displays provenance. `release-npm.yml` publishes without an explicit `--tag`, so npm applies `latest`.
+- [ ] Confirm the remaining three registries list `${VERSION}`: NuGet
+      (`Rustwright`), RubyGems (`rustwright`, including one platform gem per
+      supported target), and Maven Central
+      (`io.github.skyvern-ai:rustwright`). Maven Central can take several hours
+      to surface a new coordinate in search after the deployment succeeds.
+- [ ] Update the prose that describes a binding as unpublished now that it is
+      published — `java/README.md` still frames the Maven coordinates as planned
+      and the artifact as unavailable.
+- [ ] `rustwright-core` and `rustwright` on crates.io are **not** published by
+      any workflow. If this release is meant to reach crates.io, publish both by
+      hand from the tagged commit, core first, and confirm the versions match
+      the tag. If it is not, record that decision so the gap is deliberate.
 - [ ] Record both registry URLs and workflow run URLs on the release tracking issue.

--- a/java/README.md
+++ b/java/README.md
@@ -4,11 +4,11 @@ This dependency-free Java 23 package uses the finalized `java.lang.foreign` API.
 
 ## Install (not yet published)
 
-The planned Maven Central coordinates are `io.github.skyvern-ai:rustwright:0.1.1`. The artifact is not yet published. Once it is available, add it with Gradle:
+The planned Maven Central coordinates are `io.github.skyvern-ai:rustwright:0.2.0`. The artifact is not yet published. Once it is available, add it with Gradle:
 
 ```kotlin
 dependencies {
-    implementation("io.github.skyvern-ai:rustwright:0.1.1")
+    implementation("io.github.skyvern-ai:rustwright:0.2.0")
 }
 ```
 
@@ -18,7 +18,7 @@ Or with Maven:
 <dependency>
   <groupId>io.github.skyvern-ai</groupId>
   <artifactId>rustwright</artifactId>
-  <version>0.1.1</version>
+  <version>0.2.0</version>
 </dependency>
 ```
 

--- a/java/build.gradle.kts
+++ b/java/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 }
 
 group = "io.github.skyvern-ai"
-version = "0.1.1"
+version = "0.2.0"
 
 tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
@@ -51,7 +51,7 @@ mavenPublishing {
         javadocJar = JavadocJar.Javadoc(),
         sourcesJar = SourcesJar.Sources(),
     ))
-    coordinates("io.github.skyvern-ai", "rustwright", "0.1.1")
+    coordinates("io.github.skyvern-ai", "rustwright", "0.2.0")
     publishToMavenCentral(automaticRelease = true)
 
     // Maven-local builds intentionally stay unsigned. The guarded release job

--- a/mcp/Cargo.lock
+++ b/mcp/Cargo.lock
@@ -1053,7 +1053,7 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rustwright"
-version = "0.1.0-alpha.4"
+version = "0.2.0"
 dependencies = [
  "rustwright-core",
  "serde",
@@ -1062,7 +1062,7 @@ dependencies = [
 
 [[package]]
 name = "rustwright-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "bytes",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright-node"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rustwright",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rustwright",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@napi-rs/cli": "^3.7.4"

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rustwright",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "description": "Node.js bindings for Rustwright's Rust CDP core",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustwright"
-version = "0.1.1"
+version = "0.2.0"
 description = "A Rust-backed, CDP-first Python automation library with a Playwright-compatible sync API"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/python/rustwright/_agent/cli.py
+++ b/python/rustwright/_agent/cli.py
@@ -67,7 +67,7 @@ def _version() -> str:
     try:
         return metadata.version("rustwright")
     except metadata.PackageNotFoundError:
-        return "0.1.1"
+        return "0.2.0"
 
 
 class ParserExit(Exception):

--- a/python/rustwright/_backend.py
+++ b/python/rustwright/_backend.py
@@ -28,7 +28,7 @@ def _version() -> str:
     try:
         return metadata.version("rustwright")
     except metadata.PackageNotFoundError:
-        return "0.1.1+local"
+        return "0.2.0+local"
 
 
 def backend_marker(api_module: str | None = None) -> BackendMarker:

--- a/python/rustwright/cli.py
+++ b/python/rustwright/cli.py
@@ -128,7 +128,7 @@ def _version() -> str:
     try:
         return metadata.version("rustwright")
     except metadata.PackageNotFoundError:
-        return "0.1.1"
+        return "0.2.0"
 
 
 def _normal_browser_name(name: str) -> str:

--- a/python/rustwright/sync_api.py
+++ b/python/rustwright/sync_api.py
@@ -5727,7 +5727,7 @@ def _write_har(
             )
     log: dict[str, Any] = {
         "version": "1.2",
-        "creator": {"name": "Rustwright", "version": "0.1.1"},
+        "creator": {"name": "Rustwright", "version": "0.2.0"},
         "entries": entries,
     }
     if resolved_har_mode != "minimal":
@@ -11878,7 +11878,7 @@ class Tracing(_EventEmitter):
                 "type": "context-options",
                 "origin": "library",
                 "browserName": "chromium",
-                "playwrightVersion": "rustwright-0.1.1",
+                "playwrightVersion": "rustwright-0.2.0",
                 "options": _trace_option_payload(self._context),
                 "platform": sys.platform,
                 "wallTime": self._start_wall_time_ms,

--- a/ruby/lib/rustwright.rb
+++ b/ruby/lib/rustwright.rb
@@ -5,7 +5,7 @@ require 'monitor'
 require 'rbconfig'
 
 module Rustwright
-  VERSION = '0.1.1'
+  VERSION = '0.2.0'
   UNSET = Object.new.freeze
 
   class Error < StandardError; end

--- a/rust-native/Cargo.toml
+++ b/rust-native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustwright"
-version = "0.1.0-alpha.4"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -10,6 +10,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 CHANGELOG = ROOT / "CHANGELOG.md"
 REQUIRED_VERSIONS = (
+    "0.2.0",
     "0.1.1",
     "0.1.0",
     "0.1.0-alpha.4",


### PR DESCRIPTION
https://github.com/Skyvern-AI/rustwright-cloud/pull/163