### PR TITLE
ci(release): unblock stable publishing for gem, maven, nuget, and npm

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -112,8 +112,21 @@ jobs:
           set -euo pipefail
           linker="$RUNNER_TEMP/zig-cc"
           cat > "$linker" <<'SH'
-          #!/bin/sh
-          exec zig cc -target "${ZIG_TARGET}" "$@"
+          #!/usr/bin/env bash
+          # cc-rs appends clang-style --target=<rust-triple>; zig cc only
+          # understands zig-style triples, so drop incoming target flags in
+          # favor of the pinned ZIG_TARGET.
+          args=()
+          skip=0
+          for arg in "$@"; do
+            if (( skip )); then skip=0; continue; fi
+            case "$arg" in
+              --target=*) continue ;;
+              -target) skip=1; continue ;;
+              *) args+=("$arg") ;;
+            esac
+          done
+          exec zig cc -target "${ZIG_TARGET}" "${args[@]}"
           SH
           chmod +x "$linker"
           target_env="$(printf '%s' "$CARGO_BUILD_TARGET" | tr '[:lower:]-' '[:upper:]_')"
@@ -215,18 +228,6 @@ jobs:
           name: gem-package
           path: gem-dist
 
-      - name: Require a prerelease version
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
-          case "$version" in
-            *-*) ;;
-            *)
-              echo "The experimental Ruby gem requires a prerelease version such as 0.2.0-alpha.1" >&2
-              exit 1
-              ;;
-          esac
 
       - name: Publish experimental platform gems
         shell: bash

--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -68,10 +68,6 @@ jobs:
           expected = next(iter(versions.values()))
           if any(version != expected for version in versions.values()):
               raise SystemExit(f"Package versions do not match: {versions}")
-          if "-" not in expected:
-              raise SystemExit(
-                  f"The experimental Maven package requires a prerelease version, got {expected!r}"
-              )
 
           if os.environ["GITHUB_REF_TYPE"] == "tag":
               tag_version = os.environ["GITHUB_REF_NAME"].removeprefix("v")
@@ -143,8 +139,21 @@ jobs:
           set -euo pipefail
           linker="$RUNNER_TEMP/zig-cc"
           cat > "$linker" <<'SH'
-          #!/bin/sh
-          exec zig cc -target "${ZIG_TARGET}" "$@"
+          #!/usr/bin/env bash
+          # cc-rs appends clang-style --target=<rust-triple>; zig cc only
+          # understands zig-style triples, so drop incoming target flags in
+          # favor of the pinned ZIG_TARGET.
+          args=()
+          skip=0
+          for arg in "$@"; do
+            if (( skip )); then skip=0; continue; fi
+            case "$arg" in
+              --target=*) continue ;;
+              -target) skip=1; continue ;;
+              *) args+=("$arg") ;;
+            esac
+          done
+          exec zig cc -target "${ZIG_TARGET}" "${args[@]}"
           SH
           chmod +x "$linker"
           target_env="$(printf '%s' "$CARGO_BUILD_TARGET" | tr '[:lower:]-' '[:upper:]_')"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -94,11 +94,11 @@ jobs:
           - runner: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             zig: true
-            extra_args: --zig --zig-abi-suffix 2.17
+            extra_args: --use-napi-cross
           - runner: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             zig: true
-            extra_args: --zig --zig-abi-suffix 2.17
+            extra_args: --use-napi-cross
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             zig: false

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -139,8 +139,21 @@ jobs:
           set -euo pipefail
           linker="$RUNNER_TEMP/zig-cc"
           cat > "$linker" <<'SH'
-          #!/bin/sh
-          exec zig cc -target "${ZIG_TARGET}" "$@"
+          #!/usr/bin/env bash
+          # cc-rs appends clang-style --target=<rust-triple>; zig cc only
+          # understands zig-style triples, so drop incoming target flags in
+          # favor of the pinned ZIG_TARGET.
+          args=()
+          skip=0
+          for arg in "$@"; do
+            if (( skip )); then skip=0; continue; fi
+            case "$arg" in
+              --target=*) continue ;;
+              -target) skip=1; continue ;;
+              *) args+=("$arg") ;;
+            esac
+          done
+          exec zig cc -target "${ZIG_TARGET}" "${args[@]}"
           SH
           chmod +x "$linker"
           target_env="$(printf '%s' "$CARGO_BUILD_TARGET" | tr '[:lower:]-' '[:upper:]_')"
@@ -243,18 +256,6 @@ jobs:
           name: nuget-package
           path: nuget-dist
 
-      - name: Require a prerelease version
-        shell: bash
-        run: |
-          set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
-          case "$version" in
-            *-*) ;;
-            *)
-              echo "The experimental NuGet package requires a prerelease version such as 0.2.0-alpha.1" >&2
-              exit 1
-              ;;
-          esac
 
       - name: NuGet login (Trusted Publishing)
         id: nuget_login


### PR DESCRIPTION
The v0.2.0 tag ran the four registry workflows for the first time; all four failed before publishing anything (publish jobs skipped, so no partial registry state). Three root causes, each fixed surgically:

1. **Obsolete prerelease guards** — maven (version-validation job), gem, and nuget (publish jobs) still enforced "experimental requires a prerelease version", predating the stable-0.2.0 decision. Removed.
2. **zig-cc shim vs cc-rs** — the Linux linker shim forwarded cc-rs's clang-style `--target=x86_64-unknown-linux-gnu` to `zig cc`, which parses only zig-style triples and fails with `UnknownOperatingSystem`. The shim now drops incoming `--target=*`/`-target` flags in favor of its pinned `ZIG_TARGET` (zig stays pinned at 0.14.1).
3. **napi v3 removed `--zig`** — the npm Linux legs now use `--use-napi-cross`, keeping the same glibc 2.17 portability goal.

PyPI needed none of this: its wheels build via maturin's own zig support and 0.2.0 published from the tag run.

Validation: actionlint on all five release workflows — no findings beyond the three pre-existing SC2129 style notes. Next step after merge: `workflow_dispatch` each fixed workflow with `dry_run: true` to prove the build legs, then publish for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)