### PR TITLE
ci: reconcile release workflows with the development repository

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -42,18 +42,31 @@ jobs:
           gemspec = Gem::Specification.load('ruby/rustwright.gemspec')
           abort 'Unable to load ruby/rustwright.gemspec' unless gemspec
 
+          # RubyGems rewrites a SemVer prerelease when it parses it, so a
+          # Cargo.toml version of "0.3.0-beta.1" reaches the gemspec as
+          # "0.3.0.pre.beta.1". Those raw strings can never match, so compare
+          # parsed Gem::Version values here.
           versions = {
-            'Cargo.toml' => cargo_version,
-            'ruby/rustwright.gemspec' => gemspec.version.to_s
+            'Cargo.toml' => Gem::Version.new(cargo_version),
+            'ruby/rustwright.gemspec' => gemspec.version
           }
           expected = versions.values.first
-          abort "Package versions do not match: #{versions}" unless versions.values.all? { |value| value == expected }
+          unless versions.values.all? { |value| value == expected }
+            abort "Package versions do not match: #{versions.transform_values(&:to_s)}"
+          end
 
+          # The tag is compared literally, not as a Gem::Version. Parsed
+          # equality also accepts "0.2" for "0.2.0" and "0.3.0-rc1" for
+          # "0.3.0-rc.1", and the other four workflows compare tag strings
+          # exactly. A looser check here would let one tag publish the gem
+          # while every other registry rejected it.
           if ENV['GITHUB_REF_TYPE'] == 'tag'
             tag_version = ENV.fetch('GITHUB_REF_NAME').sub(/^v/, '')
-            abort "Tag version #{tag_version.inspect} does not match package version #{expected.inspect}" unless tag_version == expected
+            unless tag_version == cargo_version
+              abort "Tag version #{tag_version.inspect} does not match package version #{cargo_version.inspect}"
+            end
           end
-          puts "Validated package version #{expected}"
+          puts "Validated package version #{cargo_version}"
           RUBY
 
   native:
@@ -227,7 +240,6 @@ jobs:
         with:
           name: gem-package
           path: gem-dist
-
 
       - name: Publish experimental platform gems
         shell: bash

--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -182,7 +182,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
           java-version: "23"
@@ -235,7 +235,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up JDK
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
           java-version: "23"

--- a/.github/workflows/release-nuget.yml
+++ b/.github/workflows/release-nuget.yml
@@ -256,7 +256,6 @@ jobs:
           name: nuget-package
           path: nuget-dist
 
-
       - name: NuGet login (Trusted Publishing)
         id: nuget_login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0


### PR DESCRIPTION
The release workflows here and in the development repository are maintained by hand and had drifted in both directions. Releases are cut from tags on this repository, so these are the copies that actually run.

This applies the union of both sides' fixes to the three files that differed:

- **release-gem.yml** — compare versions as parsed `Gem::Version` values. RubyGems rewrites a SemVer prerelease (`0.3.0-beta.1` becomes `0.3.0.pre.beta.1`), so the current raw-string comparison would abort the next prerelease gem release with a false "versions do not match".
- **release-maven.yml** — newer pinned `actions/setup-java` (v5.6.0).
- **release-nuget.yml** — spacing normalization only.

The matching change on the development side has already merged, leaving the shared workflow files byte-identical in both repositories. `release-npm.yml` and `release-pypi.yml` already matched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)