### PR TITLE
security: bump js-yaml to 4.3.1 (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1715,9 +1715,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Problem

Dependabot alert #1 (high, GHSA-5p4m-2wfm-xmqj) reports `js-yaml` 4.3.0 in `node/package-lock.json`. The vulnerable range is `>= 4.0.0, < 4.3.1`.

## Solution

Bump `js-yaml` to 4.3.1 in the lockfile.

`js-yaml` is not a direct dependency — it arrives transitively through `@napi-rs/cli`, which is a `devDependency` used for building the Node bindings. The consuming range already permits 4.3.1, so this is a lockfile-only change: no manifest edit and no override needed.

Blast radius is limited to the build toolchain; nothing in the published `rustwright` package depends on `js-yaml` at runtime (`files` ships only the prebuilt `.node`/`.cjs`/`.mjs` artifacts).

## How Has This Been Tested?

- `npm update js-yaml --package-lock-only` produced a 3-line lockfile change (version, resolved, integrity) with no tree restructuring.
- Verified the resolved version moved 4.3.0 → 4.3.1 and that no other package entry changed.
- CI on this PR is the enforcement point for the build itself.

Closes the repo's only open Dependabot alert.
